### PR TITLE
feat(domain): implement CQRS infrastructure (task 05)

### DIFF
--- a/src-tauri/src/application/command_bus.rs
+++ b/src-tauri/src/application/command_bus.rs
@@ -235,7 +235,10 @@ mod tests {
         }
 
         fn get_range(&self, _url: &str, start: u64, end: u64) -> Result<Vec<u8>, DomainError> {
-            Ok(vec![0u8; (end - start + 1) as usize])
+            Ok(vec![
+                0u8;
+                end.saturating_sub(start).saturating_add(1) as usize
+            ])
         }
 
         fn supports_range(&self, _url: &str) -> Result<bool, DomainError> {

--- a/src-tauri/src/application/command_bus.rs
+++ b/src-tauri/src/application/command_bus.rs
@@ -1,0 +1,415 @@
+//! CQRS command bus — dispatches commands to their handlers.
+//!
+//! Holds references to all driven ports needed by command handlers.
+//! Actual handler implementations will be added in tasks 11-12.
+
+use std::sync::Arc;
+
+use crate::domain::ports::driven::{
+    ClipboardObserver, ConfigStore, CredentialStore, DownloadEngine, DownloadRepository, EventBus,
+    FileStorage, HttpClient, PluginLoader,
+};
+
+/// Central dispatcher for CQRS commands.
+///
+/// Each driven port is injected via the constructor as `Arc<dyn Trait>`.
+/// Command handler `impl` blocks will be added in later tasks.
+#[allow(dead_code)] // Fields read by command handlers (tasks 11-12)
+pub struct CommandBus {
+    download_repo: Arc<dyn DownloadRepository>,
+    download_engine: Arc<dyn DownloadEngine>,
+    event_bus: Arc<dyn EventBus>,
+    file_storage: Arc<dyn FileStorage>,
+    http_client: Arc<dyn HttpClient>,
+    plugin_loader: Arc<dyn PluginLoader>,
+    config_store: Arc<dyn ConfigStore>,
+    credential_store: Arc<dyn CredentialStore>,
+    clipboard_observer: Arc<dyn ClipboardObserver>,
+}
+
+impl CommandBus {
+    #[allow(clippy::too_many_arguments)]
+    #[allow(dead_code)] // Called at app startup (task 11+)
+    pub fn new(
+        download_repo: Arc<dyn DownloadRepository>,
+        download_engine: Arc<dyn DownloadEngine>,
+        event_bus: Arc<dyn EventBus>,
+        file_storage: Arc<dyn FileStorage>,
+        http_client: Arc<dyn HttpClient>,
+        plugin_loader: Arc<dyn PluginLoader>,
+        config_store: Arc<dyn ConfigStore>,
+        credential_store: Arc<dyn CredentialStore>,
+        clipboard_observer: Arc<dyn ClipboardObserver>,
+    ) -> Self {
+        Self {
+            download_repo,
+            download_engine,
+            event_bus,
+            file_storage,
+            http_client,
+            plugin_loader,
+            config_store,
+            credential_store,
+            clipboard_observer,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::domain::error::DomainError;
+    use crate::domain::event::DomainEvent;
+    use crate::domain::model::config::{AppConfig, ConfigPatch};
+    use crate::domain::model::credential::Credential;
+    use crate::domain::model::download::{Download, DownloadId, DownloadState};
+    use crate::domain::model::http::HttpResponse;
+    use crate::domain::model::meta::DownloadMeta;
+    use crate::domain::model::plugin::{PluginInfo, PluginManifest};
+    use crate::domain::ports::driven::{
+        ClipboardObserver, ConfigStore, CredentialStore, DownloadEngine, DownloadRepository,
+        EventBus, FileStorage, HttpClient, PluginLoader,
+    };
+
+    struct MockDownloadRepo {
+        store: Mutex<HashMap<u64, Download>>,
+    }
+
+    impl MockDownloadRepo {
+        fn new() -> Self {
+            Self {
+                store: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl DownloadRepository for MockDownloadRepo {
+        fn find_by_id(&self, id: DownloadId) -> Result<Option<Download>, DomainError> {
+            Ok(self.store.lock().unwrap().get(&id.0).cloned())
+        }
+
+        fn save(&self, d: &Download) -> Result<(), DomainError> {
+            self.store.lock().unwrap().insert(d.id().0, d.clone());
+            Ok(())
+        }
+
+        fn delete(&self, id: DownloadId) -> Result<(), DomainError> {
+            self.store.lock().unwrap().remove(&id.0);
+            Ok(())
+        }
+
+        fn find_by_state(&self, s: DownloadState) -> Result<Vec<Download>, DomainError> {
+            Ok(self
+                .store
+                .lock()
+                .unwrap()
+                .values()
+                .filter(|d| d.state() == s)
+                .cloned()
+                .collect())
+        }
+    }
+
+    struct MockDownloadEngine {
+        started: Mutex<Vec<DownloadId>>,
+    }
+
+    impl MockDownloadEngine {
+        fn new() -> Self {
+            Self {
+                started: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl DownloadEngine for MockDownloadEngine {
+        fn start(&self, download: &Download) -> Result<(), DomainError> {
+            self.started.lock().unwrap().push(download.id());
+            Ok(())
+        }
+
+        fn pause(&self, _id: DownloadId) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn cancel(&self, _id: DownloadId) -> Result<(), DomainError> {
+            Ok(())
+        }
+    }
+
+    struct MockEventBus {
+        events: Mutex<Vec<DomainEvent>>,
+    }
+
+    impl MockEventBus {
+        fn new() -> Self {
+            Self {
+                events: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl EventBus for MockEventBus {
+        fn publish(&self, event: DomainEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+
+        fn subscribe(&self, _handler: Box<dyn Fn(&DomainEvent) + Send + Sync>) {}
+    }
+
+    struct MockFileStorage {
+        files: Mutex<HashMap<String, Vec<u8>>>,
+        metas: Mutex<HashMap<String, DownloadMeta>>,
+    }
+
+    impl MockFileStorage {
+        fn new() -> Self {
+            Self {
+                files: Mutex::new(HashMap::new()),
+                metas: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl FileStorage for MockFileStorage {
+        fn create_file(&self, path: &Path, size: u64) -> Result<(), DomainError> {
+            self.files.lock().unwrap().insert(
+                path.to_string_lossy().into_owned(),
+                vec![0u8; size as usize],
+            );
+            Ok(())
+        }
+
+        fn write_segment(&self, path: &Path, offset: u64, data: &[u8]) -> Result<(), DomainError> {
+            let key = path.to_string_lossy().into_owned();
+            let mut files = self.files.lock().unwrap();
+            if let Some(file) = files.get_mut(&key) {
+                let start = offset as usize;
+                let end = start + data.len();
+                if end <= file.len() {
+                    file[start..end].copy_from_slice(data);
+                }
+            }
+            Ok(())
+        }
+
+        fn read_meta(&self, path: &Path) -> Result<Option<DownloadMeta>, DomainError> {
+            Ok(self
+                .metas
+                .lock()
+                .unwrap()
+                .get(&path.to_string_lossy().into_owned())
+                .cloned())
+        }
+
+        fn write_meta(&self, path: &Path, meta: &DownloadMeta) -> Result<(), DomainError> {
+            self.metas
+                .lock()
+                .unwrap()
+                .insert(path.to_string_lossy().into_owned(), meta.clone());
+            Ok(())
+        }
+
+        fn delete_meta(&self, path: &Path) -> Result<(), DomainError> {
+            self.metas
+                .lock()
+                .unwrap()
+                .remove(&path.to_string_lossy().into_owned());
+            Ok(())
+        }
+    }
+
+    struct MockHttpClient;
+
+    impl HttpClient for MockHttpClient {
+        fn head(&self, _url: &str) -> Result<HttpResponse, DomainError> {
+            Ok(HttpResponse {
+                status_code: 200,
+                headers: HashMap::new(),
+                body: vec![],
+            })
+        }
+
+        fn get_range(&self, _url: &str, start: u64, end: u64) -> Result<Vec<u8>, DomainError> {
+            Ok(vec![0u8; (end - start + 1) as usize])
+        }
+
+        fn supports_range(&self, _url: &str) -> Result<bool, DomainError> {
+            Ok(true)
+        }
+    }
+
+    struct MockPluginLoader {
+        plugins: Mutex<HashMap<String, PluginInfo>>,
+    }
+
+    impl MockPluginLoader {
+        fn new() -> Self {
+            Self {
+                plugins: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl PluginLoader for MockPluginLoader {
+        fn load(&self, manifest: &PluginManifest) -> Result<(), DomainError> {
+            let info = manifest.info().clone();
+            self.plugins
+                .lock()
+                .unwrap()
+                .insert(info.name().to_string(), info);
+            Ok(())
+        }
+
+        fn unload(&self, name: &str) -> Result<(), DomainError> {
+            self.plugins.lock().unwrap().remove(name);
+            Ok(())
+        }
+
+        fn resolve_url(&self, _url: &str) -> Result<Option<PluginInfo>, DomainError> {
+            Ok(None)
+        }
+
+        fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
+            Ok(self.plugins.lock().unwrap().values().cloned().collect())
+        }
+    }
+
+    struct MockConfigStore {
+        config: Mutex<AppConfig>,
+    }
+
+    impl MockConfigStore {
+        fn new() -> Self {
+            Self {
+                config: Mutex::new(AppConfig::default()),
+            }
+        }
+    }
+
+    impl ConfigStore for MockConfigStore {
+        fn get_config(&self) -> Result<AppConfig, DomainError> {
+            Ok(self.config.lock().unwrap().clone())
+        }
+
+        fn update_config(&self, patch: ConfigPatch) -> Result<AppConfig, DomainError> {
+            let mut config = self.config.lock().unwrap();
+            if let Some(dir) = patch.download_dir {
+                config.download_dir = dir;
+            }
+            if let Some(max) = patch.max_concurrent_downloads {
+                config.max_concurrent_downloads = max;
+            }
+            if let Some(max) = patch.max_segments_per_download {
+                config.max_segments_per_download = max;
+            }
+            if let Some(limit) = patch.speed_limit_bytes_per_sec {
+                config.speed_limit_bytes_per_sec = limit;
+            }
+            if let Some(auto) = patch.auto_extract {
+                config.auto_extract = auto;
+            }
+            if let Some(theme) = patch.theme {
+                config.theme = theme;
+            }
+            if let Some(locale) = patch.locale {
+                config.locale = locale;
+            }
+            if let Some(monitoring) = patch.clipboard_monitoring {
+                config.clipboard_monitoring = monitoring;
+            }
+            if let Some(minimize) = patch.minimize_to_tray {
+                config.minimize_to_tray = minimize;
+            }
+            Ok(config.clone())
+        }
+    }
+
+    struct MockCredentialStore {
+        store: Mutex<HashMap<String, Credential>>,
+    }
+
+    impl MockCredentialStore {
+        fn new() -> Self {
+            Self {
+                store: Mutex::new(HashMap::new()),
+            }
+        }
+    }
+
+    impl CredentialStore for MockCredentialStore {
+        fn get(&self, service: &str) -> Result<Option<Credential>, DomainError> {
+            Ok(self.store.lock().unwrap().get(service).cloned())
+        }
+
+        fn store(&self, service: &str, credential: &Credential) -> Result<(), DomainError> {
+            self.store
+                .lock()
+                .unwrap()
+                .insert(service.to_string(), credential.clone());
+            Ok(())
+        }
+
+        fn delete(&self, service: &str) -> Result<(), DomainError> {
+            self.store.lock().unwrap().remove(service);
+            Ok(())
+        }
+    }
+
+    struct MockClipboardObserver {
+        running: Mutex<bool>,
+    }
+
+    impl MockClipboardObserver {
+        fn new() -> Self {
+            Self {
+                running: Mutex::new(false),
+            }
+        }
+    }
+
+    impl ClipboardObserver for MockClipboardObserver {
+        fn start(&self) -> Result<(), DomainError> {
+            *self.running.lock().unwrap() = true;
+            Ok(())
+        }
+
+        fn stop(&self) -> Result<(), DomainError> {
+            *self.running.lock().unwrap() = false;
+            Ok(())
+        }
+
+        fn get_urls(&self) -> Result<Vec<String>, DomainError> {
+            Ok(vec![])
+        }
+    }
+
+    fn make_command_bus() -> CommandBus {
+        CommandBus::new(
+            Arc::new(MockDownloadRepo::new()),
+            Arc::new(MockDownloadEngine::new()),
+            Arc::new(MockEventBus::new()),
+            Arc::new(MockFileStorage::new()),
+            Arc::new(MockHttpClient),
+            Arc::new(MockPluginLoader::new()),
+            Arc::new(MockConfigStore::new()),
+            Arc::new(MockCredentialStore::new()),
+            Arc::new(MockClipboardObserver::new()),
+        )
+    }
+
+    #[test]
+    fn test_command_bus_new_compiles() {
+        let _bus = make_command_bus();
+    }
+
+    #[test]
+    fn test_command_bus_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<CommandBus>();
+    }
+}

--- a/src-tauri/src/application/commands/mod.rs
+++ b/src-tauri/src/application/commands/mod.rs
@@ -1,0 +1,66 @@
+//! CQRS command types.
+//!
+//! Each command represents an intent to mutate application state.
+//! Handlers will be implemented in later tasks.
+#![allow(dead_code)] // All commands consumed by handlers (tasks 11-12)
+
+use crate::domain::model::config::ConfigPatch;
+use crate::domain::model::download::DownloadId;
+use crate::domain::ports::driving::Command;
+
+#[derive(Debug)]
+pub struct StartDownloadCommand {
+    pub url: String,
+    pub destination: Option<String>,
+}
+impl Command for StartDownloadCommand {}
+
+#[derive(Debug)]
+pub struct PauseDownloadCommand {
+    pub id: DownloadId,
+}
+impl Command for PauseDownloadCommand {}
+
+#[derive(Debug)]
+pub struct ResumeDownloadCommand {
+    pub id: DownloadId,
+}
+impl Command for ResumeDownloadCommand {}
+
+#[derive(Debug)]
+pub struct CancelDownloadCommand {
+    pub id: DownloadId,
+}
+impl Command for CancelDownloadCommand {}
+
+#[derive(Debug)]
+pub struct RetryDownloadCommand {
+    pub id: DownloadId,
+}
+impl Command for RetryDownloadCommand {}
+
+#[derive(Debug)]
+pub struct PauseAllDownloadsCommand;
+impl Command for PauseAllDownloadsCommand {}
+
+#[derive(Debug)]
+pub struct ResumeAllDownloadsCommand;
+impl Command for ResumeAllDownloadsCommand {}
+
+#[derive(Debug)]
+pub struct InstallPluginCommand {
+    pub url: String,
+}
+impl Command for InstallPluginCommand {}
+
+#[derive(Debug)]
+pub struct UninstallPluginCommand {
+    pub name: String,
+}
+impl Command for UninstallPluginCommand {}
+
+#[derive(Debug)]
+pub struct UpdateConfigCommand {
+    pub patch: ConfigPatch,
+}
+impl Command for UpdateConfigCommand {}

--- a/src-tauri/src/application/commands/mod.rs
+++ b/src-tauri/src/application/commands/mod.rs
@@ -4,6 +4,8 @@
 //! Handlers will be implemented in later tasks.
 #![allow(dead_code)] // All commands consumed by handlers (tasks 11-12)
 
+use std::path::PathBuf;
+
 use crate::domain::model::config::ConfigPatch;
 use crate::domain::model::download::DownloadId;
 use crate::domain::ports::driving::Command;
@@ -11,7 +13,7 @@ use crate::domain::ports::driving::Command;
 #[derive(Debug)]
 pub struct StartDownloadCommand {
     pub url: String,
-    pub destination: Option<String>,
+    pub destination: Option<PathBuf>,
 }
 impl Command for StartDownloadCommand {}
 

--- a/src-tauri/src/application/error.rs
+++ b/src-tauri/src/application/error.rs
@@ -1,0 +1,111 @@
+//! Application-layer error type.
+//!
+//! Wraps `DomainError` and adds infrastructure-specific variants
+//! for storage, network, plugin, config, not-found, and validation errors.
+
+use crate::domain::DomainError;
+
+#[derive(Debug, thiserror::Error)]
+#[allow(dead_code)] // Consumed by command/query handlers (tasks 11-12)
+pub enum AppError {
+    #[error(transparent)]
+    Domain(#[from] DomainError),
+
+    #[error("storage error: {0}")]
+    Storage(String),
+
+    #[error("network error: {0}")]
+    Network(String),
+
+    #[error("plugin error: {0}")]
+    Plugin(String),
+
+    #[error("config error: {0}")]
+    Config(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("validation error: {0}")]
+    Validation(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn returns_app_error_via_question_mark() -> Result<(), AppError> {
+        let result: Result<(), DomainError> = Err(DomainError::NotFound("test-id".to_string()));
+        result?;
+        Ok(())
+    }
+
+    #[test]
+    fn test_app_error_from_domain_error_converts_with_from() {
+        let domain_err = DomainError::NotFound("download-1".to_string());
+        let app_err = AppError::from(domain_err);
+        assert!(matches!(
+            app_err,
+            AppError::Domain(DomainError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_app_error_from_domain_error_question_mark_propagates() {
+        let result = returns_app_error_via_question_mark();
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            AppError::Domain(DomainError::NotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_app_error_display_storage_shows_message() {
+        let err = AppError::Storage("disk full".to_string());
+        assert_eq!(err.to_string(), "storage error: disk full");
+    }
+
+    #[test]
+    fn test_app_error_display_network_shows_message() {
+        let err = AppError::Network("connection refused".to_string());
+        assert_eq!(err.to_string(), "network error: connection refused");
+    }
+
+    #[test]
+    fn test_app_error_display_plugin_shows_message() {
+        let err = AppError::Plugin("wasm panic".to_string());
+        assert_eq!(err.to_string(), "plugin error: wasm panic");
+    }
+
+    #[test]
+    fn test_app_error_display_config_shows_message() {
+        let err = AppError::Config("missing field".to_string());
+        assert_eq!(err.to_string(), "config error: missing field");
+    }
+
+    #[test]
+    fn test_app_error_display_not_found_shows_message() {
+        let err = AppError::NotFound("plugin-xyz".to_string());
+        assert_eq!(err.to_string(), "not found: plugin-xyz");
+    }
+
+    #[test]
+    fn test_app_error_display_validation_shows_message() {
+        let err = AppError::Validation("url is required".to_string());
+        assert_eq!(err.to_string(), "validation error: url is required");
+    }
+
+    #[test]
+    fn test_app_error_display_domain_forwards_domain_error_display() {
+        let domain_err = DomainError::NotFound("download-99".to_string());
+        let app_err = AppError::Domain(domain_err);
+        assert_eq!(app_err.to_string(), "Not found: download-99");
+    }
+
+    #[test]
+    fn test_app_error_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<AppError>();
+    }
+}

--- a/src-tauri/src/application/mod.rs
+++ b/src-tauri/src/application/mod.rs
@@ -2,3 +2,18 @@
 //!
 //! Commands mutate state through domain entities and emit domain events.
 //! Queries read from optimized read models (DTOs).
+
+pub mod command_bus;
+pub mod commands;
+pub mod error;
+pub mod queries;
+pub mod query_bus;
+pub mod read_models;
+
+// Re-exports consumed once handlers are implemented (tasks 11-12).
+#[allow(unused_imports)]
+pub use command_bus::CommandBus;
+#[allow(unused_imports)]
+pub use error::AppError;
+#[allow(unused_imports)]
+pub use query_bus::QueryBus;

--- a/src-tauri/src/application/queries/mod.rs
+++ b/src-tauri/src/application/queries/mod.rs
@@ -1,0 +1,42 @@
+//! CQRS query types.
+//!
+//! Each query represents a read request. Queries never modify state.
+//! Handlers will be implemented in later tasks.
+#![allow(dead_code)] // All queries consumed by handlers (tasks 11-12)
+
+use crate::domain::model::download::DownloadId;
+use crate::domain::model::views::{DownloadFilter, SortOrder};
+use crate::domain::ports::driving::Query;
+
+#[derive(Debug)]
+pub struct GetDownloadsQuery {
+    pub filter: Option<DownloadFilter>,
+    pub sort: Option<SortOrder>,
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+impl Query for GetDownloadsQuery {}
+
+#[derive(Debug)]
+pub struct GetDownloadDetailQuery {
+    pub id: DownloadId,
+}
+impl Query for GetDownloadDetailQuery {}
+
+#[derive(Debug)]
+pub struct GetHistoryQuery {
+    pub limit: usize,
+}
+impl Query for GetHistoryQuery {}
+
+#[derive(Debug)]
+pub struct GetStatsQuery;
+impl Query for GetStatsQuery {}
+
+#[derive(Debug)]
+pub struct ListPluginsQuery;
+impl Query for ListPluginsQuery {}
+
+#[derive(Debug)]
+pub struct CountDownloadsByStateQuery;
+impl Query for CountDownloadsByStateQuery {}

--- a/src-tauri/src/application/queries/mod.rs
+++ b/src-tauri/src/application/queries/mod.rs
@@ -26,6 +26,7 @@ impl Query for GetDownloadDetailQuery {}
 #[derive(Debug)]
 pub struct GetHistoryQuery {
     pub limit: usize,
+    pub offset: Option<usize>,
 }
 impl Query for GetHistoryQuery {}
 

--- a/src-tauri/src/application/query_bus.rs
+++ b/src-tauri/src/application/query_bus.rs
@@ -6,7 +6,7 @@
 use std::sync::Arc;
 
 use crate::domain::ports::driven::{
-    DownloadReadRepository, HistoryRepository, PluginLoader, StatsRepository,
+    DownloadReadRepository, HistoryRepository, PluginReadRepository, StatsRepository,
 };
 
 /// Central dispatcher for CQRS queries.
@@ -18,7 +18,7 @@ pub struct QueryBus {
     download_read_repo: Arc<dyn DownloadReadRepository>,
     history_repo: Arc<dyn HistoryRepository>,
     stats_repo: Arc<dyn StatsRepository>,
-    plugin_loader: Arc<dyn PluginLoader>,
+    plugin_read_repo: Arc<dyn PluginReadRepository>,
 }
 
 impl QueryBus {
@@ -27,13 +27,13 @@ impl QueryBus {
         download_read_repo: Arc<dyn DownloadReadRepository>,
         history_repo: Arc<dyn HistoryRepository>,
         stats_repo: Arc<dyn StatsRepository>,
-        plugin_loader: Arc<dyn PluginLoader>,
+        plugin_read_repo: Arc<dyn PluginReadRepository>,
     ) -> Self {
         Self {
             download_read_repo,
             history_repo,
             stats_repo,
-            plugin_loader,
+            plugin_read_repo,
         }
     }
 }
@@ -46,13 +46,13 @@ mod tests {
     use super::QueryBus;
     use crate::domain::error::DomainError;
     use crate::domain::model::download::DownloadId;
-    use crate::domain::model::plugin::{PluginInfo, PluginManifest};
+    use crate::domain::model::plugin::PluginInfo;
     use crate::domain::model::views::{
         DownloadDetailView, DownloadFilter, DownloadView, HistoryEntry, SortOrder, StateCountMap,
         StatsView,
     };
     use crate::domain::ports::driven::{
-        DownloadReadRepository, HistoryRepository, PluginLoader, StatsRepository,
+        DownloadReadRepository, HistoryRepository, PluginReadRepository, StatsRepository,
     };
 
     struct MockDownloadReadRepo;
@@ -117,20 +117,8 @@ mod tests {
         }
     }
 
-    struct MockPluginLoader;
-    impl PluginLoader for MockPluginLoader {
-        fn load(&self, _manifest: &PluginManifest) -> Result<(), DomainError> {
-            Ok(())
-        }
-
-        fn unload(&self, _name: &str) -> Result<(), DomainError> {
-            Ok(())
-        }
-
-        fn resolve_url(&self, _url: &str) -> Result<Option<PluginInfo>, DomainError> {
-            Ok(None)
-        }
-
+    struct MockPluginReadRepo;
+    impl PluginReadRepository for MockPluginReadRepo {
         fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
             Ok(vec![])
         }
@@ -142,7 +130,7 @@ mod tests {
             Arc::new(MockDownloadReadRepo),
             Arc::new(MockHistoryRepo),
             Arc::new(MockStatsRepo),
-            Arc::new(MockPluginLoader),
+            Arc::new(MockPluginReadRepo),
         );
     }
 

--- a/src-tauri/src/application/query_bus.rs
+++ b/src-tauri/src/application/query_bus.rs
@@ -1,0 +1,154 @@
+//! CQRS query bus — dispatches queries to their handlers.
+//!
+//! Holds references to driven ports needed by query handlers.
+//! Actual handler implementations will be added in tasks 11-12.
+
+use std::sync::Arc;
+
+use crate::domain::ports::driven::{
+    DownloadReadRepository, HistoryRepository, PluginLoader, StatsRepository,
+};
+
+/// Central dispatcher for CQRS queries.
+///
+/// Each driven port is injected via the constructor as `Arc<dyn Trait>`.
+/// Query handler `impl` blocks will be added in later tasks.
+#[allow(dead_code)] // Fields read by query handlers (tasks 11-12)
+pub struct QueryBus {
+    download_read_repo: Arc<dyn DownloadReadRepository>,
+    history_repo: Arc<dyn HistoryRepository>,
+    stats_repo: Arc<dyn StatsRepository>,
+    plugin_loader: Arc<dyn PluginLoader>,
+}
+
+impl QueryBus {
+    #[allow(dead_code)] // Called at app startup (task 12+)
+    pub fn new(
+        download_read_repo: Arc<dyn DownloadReadRepository>,
+        history_repo: Arc<dyn HistoryRepository>,
+        stats_repo: Arc<dyn StatsRepository>,
+        plugin_loader: Arc<dyn PluginLoader>,
+    ) -> Self {
+        Self {
+            download_read_repo,
+            history_repo,
+            stats_repo,
+            plugin_loader,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use super::QueryBus;
+    use crate::domain::error::DomainError;
+    use crate::domain::model::download::DownloadId;
+    use crate::domain::model::plugin::{PluginInfo, PluginManifest};
+    use crate::domain::model::views::{
+        DownloadDetailView, DownloadFilter, DownloadView, HistoryEntry, SortOrder, StateCountMap,
+        StatsView,
+    };
+    use crate::domain::ports::driven::{
+        DownloadReadRepository, HistoryRepository, PluginLoader, StatsRepository,
+    };
+
+    struct MockDownloadReadRepo;
+    impl DownloadReadRepository for MockDownloadReadRepo {
+        fn find_downloads(
+            &self,
+            _filter: Option<DownloadFilter>,
+            _sort: Option<SortOrder>,
+            _limit: Option<usize>,
+            _offset: Option<usize>,
+        ) -> Result<Vec<DownloadView>, DomainError> {
+            Ok(vec![])
+        }
+
+        fn find_download_detail(
+            &self,
+            _id: DownloadId,
+        ) -> Result<Option<DownloadDetailView>, DomainError> {
+            Ok(None)
+        }
+
+        fn count_by_state(&self) -> Result<StateCountMap, DomainError> {
+            Ok(HashMap::new())
+        }
+    }
+
+    struct MockHistoryRepo;
+    impl HistoryRepository for MockHistoryRepo {
+        fn record(&self, _entry: &HistoryEntry) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn find_recent(&self, _limit: usize) -> Result<Vec<HistoryEntry>, DomainError> {
+            Ok(vec![])
+        }
+
+        fn find_by_download(&self, _id: DownloadId) -> Result<Vec<HistoryEntry>, DomainError> {
+            Ok(vec![])
+        }
+
+        fn delete_older_than(&self, _before_timestamp: u64) -> Result<u64, DomainError> {
+            Ok(0)
+        }
+    }
+
+    struct MockStatsRepo;
+    impl StatsRepository for MockStatsRepo {
+        fn record_completed(&self, _bytes: u64, _avg_speed: u64) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn get_stats(&self) -> Result<StatsView, DomainError> {
+            Ok(StatsView {
+                total_downloaded_bytes: 0,
+                total_files: 0,
+                avg_speed: 0,
+                peak_speed: 0,
+                success_rate: 0.0,
+                daily_volumes: vec![],
+                top_hosts: vec![],
+            })
+        }
+    }
+
+    struct MockPluginLoader;
+    impl PluginLoader for MockPluginLoader {
+        fn load(&self, _manifest: &PluginManifest) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn unload(&self, _name: &str) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn resolve_url(&self, _url: &str) -> Result<Option<PluginInfo>, DomainError> {
+            Ok(None)
+        }
+
+        fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn test_query_bus_new_compiles() {
+        let _bus = QueryBus::new(
+            Arc::new(MockDownloadReadRepo),
+            Arc::new(MockHistoryRepo),
+            Arc::new(MockStatsRepo),
+            Arc::new(MockPluginLoader),
+        );
+    }
+
+    #[test]
+    fn test_query_bus_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<QueryBus>();
+    }
+}

--- a/src-tauri/src/application/read_models/download_detail_view.rs
+++ b/src-tauri/src/application/read_models/download_detail_view.rs
@@ -6,6 +6,7 @@ use crate::domain::model::views::{DownloadDetailView, SegmentView};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Returned by query handlers (tasks 11-12)
 pub struct SegmentViewDto {
     pub id: u32,
     pub start_byte: u64,
@@ -28,6 +29,7 @@ impl From<SegmentView> for SegmentViewDto {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Returned by query handlers (tasks 11-12)
 pub struct DownloadDetailViewDto {
     pub id: String,
     pub file_name: String,

--- a/src-tauri/src/application/read_models/download_detail_view.rs
+++ b/src-tauri/src/application/read_models/download_detail_view.rs
@@ -1,0 +1,165 @@
+//! Serializable download detail view DTO for the frontend.
+
+use serde::Serialize;
+
+use crate::domain::model::views::{DownloadDetailView, SegmentView};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SegmentViewDto {
+    pub id: u32,
+    pub start_byte: u64,
+    pub end_byte: u64,
+    pub downloaded_bytes: u64,
+    pub state: String,
+}
+
+impl From<SegmentView> for SegmentViewDto {
+    fn from(s: SegmentView) -> Self {
+        Self {
+            id: s.id,
+            start_byte: s.start_byte,
+            end_byte: s.end_byte,
+            downloaded_bytes: s.downloaded_bytes,
+            state: s.state.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadDetailViewDto {
+    pub id: String,
+    pub file_name: String,
+    pub url: String,
+    pub state: String,
+    pub progress_percent: f64,
+    pub speed_bytes_per_sec: u64,
+    pub downloaded_bytes: u64,
+    pub total_bytes: Option<u64>,
+    pub eta_seconds: Option<u64>,
+    pub segments: Vec<SegmentViewDto>,
+    pub checksum_expected: Option<String>,
+    pub destination_path: String,
+    pub module_name: Option<String>,
+    pub account_name: Option<String>,
+    pub resume_supported: bool,
+    pub retry_count: u32,
+    pub max_retries: u32,
+    pub created_at: u64,
+    pub updated_at: u64,
+}
+
+impl From<DownloadDetailView> for DownloadDetailViewDto {
+    fn from(v: DownloadDetailView) -> Self {
+        Self {
+            id: v.id.0.to_string(),
+            file_name: v.file_name,
+            url: v.url,
+            state: v.state.to_string(),
+            progress_percent: v.progress_percent,
+            speed_bytes_per_sec: v.speed_bytes_per_sec,
+            downloaded_bytes: v.downloaded_bytes,
+            total_bytes: v.total_bytes,
+            eta_seconds: v.eta_seconds,
+            segments: v.segments.into_iter().map(SegmentViewDto::from).collect(),
+            checksum_expected: v.checksum_expected,
+            destination_path: v.destination_path,
+            module_name: v.module_name,
+            account_name: v.account_name,
+            resume_supported: v.resume_supported,
+            retry_count: v.retry_count,
+            max_retries: v.max_retries,
+            created_at: v.created_at,
+            updated_at: v.updated_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::download::{DownloadId, DownloadState};
+    use crate::domain::model::segment::SegmentState;
+    use crate::domain::model::views::{DownloadDetailView, SegmentView};
+
+    #[test]
+    fn test_segment_view_dto_from_domain() {
+        let seg = SegmentView {
+            id: 1,
+            start_byte: 0,
+            end_byte: 512,
+            downloaded_bytes: 256,
+            state: SegmentState::Downloading,
+        };
+        let dto = SegmentViewDto::from(seg);
+        assert_eq!(dto.id, 1);
+        assert_eq!(dto.state, "Downloading");
+    }
+
+    #[test]
+    fn test_download_detail_view_dto_from_domain() {
+        let view = DownloadDetailView {
+            id: DownloadId(7),
+            file_name: "archive.zip".to_string(),
+            url: "https://example.com/archive.zip".to_string(),
+            state: DownloadState::Paused,
+            progress_percent: 25.0,
+            speed_bytes_per_sec: 512,
+            downloaded_bytes: 256,
+            total_bytes: None,
+            eta_seconds: None,
+            segments: vec![],
+            checksum_expected: None,
+            destination_path: "/tmp/archive.zip".to_string(),
+            module_name: None,
+            account_name: None,
+            resume_supported: true,
+            retry_count: 1,
+            max_retries: 5,
+            created_at: 1700000000,
+            updated_at: 1700000100,
+        };
+        let dto = DownloadDetailViewDto::from(view);
+        assert_eq!(dto.id, "7");
+        assert_eq!(dto.state, "Paused");
+        assert!(dto.segments.is_empty());
+    }
+
+    #[test]
+    fn test_download_detail_view_dto_serializes_to_camel_case() {
+        let dto = DownloadDetailViewDto {
+            id: "1".to_string(),
+            file_name: "test.zip".to_string(),
+            url: "https://example.com".to_string(),
+            state: "Queued".to_string(),
+            progress_percent: 0.0,
+            speed_bytes_per_sec: 0,
+            downloaded_bytes: 0,
+            total_bytes: None,
+            eta_seconds: None,
+            segments: vec![],
+            checksum_expected: None,
+            destination_path: "/tmp".to_string(),
+            module_name: None,
+            account_name: None,
+            resume_supported: false,
+            retry_count: 0,
+            max_retries: 5,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let value = serde_json::to_value(&dto).unwrap();
+        assert!(value.get("fileName").is_some());
+        assert!(value.get("progressPercent").is_some());
+        assert!(value.get("speedBytesPerSec").is_some());
+        assert!(value.get("downloadedBytes").is_some());
+        assert!(value.get("checksumExpected").is_some());
+        assert!(value.get("destinationPath").is_some());
+        assert!(value.get("resumeSupported").is_some());
+        assert!(value.get("retryCount").is_some());
+        assert!(value.get("maxRetries").is_some());
+        assert!(value.get("createdAt").is_some());
+        assert!(value.get("updatedAt").is_some());
+    }
+}

--- a/src-tauri/src/application/read_models/download_view.rs
+++ b/src-tauri/src/application/read_models/download_view.rs
@@ -1,0 +1,111 @@
+//! Serializable download view DTO for the frontend.
+
+use serde::Serialize;
+
+use crate::domain::model::views::DownloadView;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DownloadViewDto {
+    pub id: String,
+    pub file_name: String,
+    pub url: String,
+    pub state: String,
+    pub progress_percent: f64,
+    pub speed_bytes_per_sec: u64,
+    pub downloaded_bytes: u64,
+    pub total_bytes: Option<u64>,
+    pub eta_seconds: Option<u64>,
+    pub segments_active: u32,
+    pub segments_total: u32,
+    pub module_name: Option<String>,
+    pub account_name: Option<String>,
+    pub created_at: u64,
+}
+
+impl From<DownloadView> for DownloadViewDto {
+    fn from(v: DownloadView) -> Self {
+        Self {
+            id: v.id.0.to_string(),
+            file_name: v.file_name,
+            url: v.url,
+            state: v.state.to_string(),
+            progress_percent: v.progress_percent,
+            speed_bytes_per_sec: v.speed_bytes_per_sec,
+            downloaded_bytes: v.downloaded_bytes,
+            total_bytes: v.total_bytes,
+            eta_seconds: v.eta_seconds,
+            segments_active: v.segments_active,
+            segments_total: v.segments_total,
+            module_name: v.module_name,
+            account_name: v.account_name,
+            created_at: v.created_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::download::{DownloadId, DownloadState};
+    use crate::domain::model::views::DownloadView;
+
+    fn make_dto() -> DownloadViewDto {
+        DownloadViewDto {
+            id: "1".to_string(),
+            file_name: "test.zip".to_string(),
+            url: "https://example.com/test.zip".to_string(),
+            state: "Downloading".to_string(),
+            progress_percent: 50.0,
+            speed_bytes_per_sec: 1024,
+            downloaded_bytes: 512,
+            total_bytes: Some(1024),
+            eta_seconds: Some(10),
+            segments_active: 2,
+            segments_total: 4,
+            module_name: None,
+            account_name: None,
+            created_at: 1700000000,
+        }
+    }
+
+    #[test]
+    fn test_download_view_dto_serializes_to_camel_case() {
+        let dto = make_dto();
+        let value = serde_json::to_value(&dto).unwrap();
+        assert!(value.get("fileName").is_some());
+        assert!(value.get("speedBytesPerSec").is_some());
+        assert!(value.get("progressPercent").is_some());
+        assert!(value.get("downloadedBytes").is_some());
+        assert!(value.get("totalBytes").is_some());
+        assert!(value.get("etaSeconds").is_some());
+        assert!(value.get("segmentsActive").is_some());
+        assert!(value.get("segmentsTotal").is_some());
+        assert!(value.get("moduleName").is_some());
+        assert!(value.get("accountName").is_some());
+        assert!(value.get("createdAt").is_some());
+    }
+
+    #[test]
+    fn test_download_view_dto_from_domain() {
+        let view = DownloadView {
+            id: DownloadId(42),
+            file_name: "test.zip".to_string(),
+            url: "https://example.com/test.zip".to_string(),
+            state: DownloadState::Downloading,
+            progress_percent: 50.0,
+            speed_bytes_per_sec: 1024,
+            downloaded_bytes: 512,
+            total_bytes: Some(1024),
+            eta_seconds: Some(10),
+            segments_active: 2,
+            segments_total: 4,
+            module_name: None,
+            account_name: None,
+            created_at: 1700000000,
+        };
+        let dto = DownloadViewDto::from(view);
+        assert_eq!(dto.id, "42");
+        assert_eq!(dto.state, "Downloading");
+    }
+}

--- a/src-tauri/src/application/read_models/download_view.rs
+++ b/src-tauri/src/application/read_models/download_view.rs
@@ -6,6 +6,7 @@ use crate::domain::model::views::DownloadView;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Returned by query handlers (tasks 11-12)
 pub struct DownloadViewDto {
     pub id: String,
     pub file_name: String,

--- a/src-tauri/src/application/read_models/history_view.rs
+++ b/src-tauri/src/application/read_models/history_view.rs
@@ -6,6 +6,7 @@ use crate::domain::model::views::HistoryEntry;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Returned by query handlers (tasks 11-12)
 pub struct HistoryViewDto {
     pub download_id: String,
     pub file_name: String,

--- a/src-tauri/src/application/read_models/history_view.rs
+++ b/src-tauri/src/application/read_models/history_view.rs
@@ -1,0 +1,80 @@
+//! Serializable history entry DTO for the frontend.
+
+use serde::Serialize;
+
+use crate::domain::model::views::HistoryEntry;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HistoryViewDto {
+    pub download_id: String,
+    pub file_name: String,
+    pub url: String,
+    pub total_bytes: u64,
+    pub completed_at: u64,
+    pub duration_seconds: u64,
+    pub avg_speed: u64,
+    pub destination_path: String,
+}
+
+impl From<HistoryEntry> for HistoryViewDto {
+    fn from(e: HistoryEntry) -> Self {
+        Self {
+            download_id: e.download_id.0.to_string(),
+            file_name: e.file_name,
+            url: e.url,
+            total_bytes: e.total_bytes,
+            completed_at: e.completed_at,
+            duration_seconds: e.duration_seconds,
+            avg_speed: e.avg_speed,
+            destination_path: e.destination_path,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::download::DownloadId;
+    use crate::domain::model::views::HistoryEntry;
+
+    #[test]
+    fn test_history_view_dto_from_domain() {
+        let entry = HistoryEntry {
+            download_id: DownloadId(99),
+            file_name: "movie.mkv".to_string(),
+            url: "https://example.com/movie.mkv".to_string(),
+            total_bytes: 2_000_000,
+            completed_at: 1700001000,
+            duration_seconds: 120,
+            avg_speed: 16666,
+            destination_path: "/home/user/Downloads/movie.mkv".to_string(),
+        };
+        let dto = HistoryViewDto::from(entry);
+        assert_eq!(dto.download_id, "99");
+        assert_eq!(dto.file_name, "movie.mkv");
+        assert_eq!(dto.total_bytes, 2_000_000);
+    }
+
+    #[test]
+    fn test_history_view_dto_serializes_to_camel_case() {
+        let dto = HistoryViewDto {
+            download_id: "1".to_string(),
+            file_name: "file.zip".to_string(),
+            url: "https://example.com".to_string(),
+            total_bytes: 1024,
+            completed_at: 0,
+            duration_seconds: 10,
+            avg_speed: 100,
+            destination_path: "/tmp/file.zip".to_string(),
+        };
+        let value = serde_json::to_value(&dto).unwrap();
+        assert!(value.get("downloadId").is_some());
+        assert!(value.get("fileName").is_some());
+        assert!(value.get("totalBytes").is_some());
+        assert!(value.get("completedAt").is_some());
+        assert!(value.get("durationSeconds").is_some());
+        assert!(value.get("avgSpeed").is_some());
+        assert!(value.get("destinationPath").is_some());
+    }
+}

--- a/src-tauri/src/application/read_models/mod.rs
+++ b/src-tauri/src/application/read_models/mod.rs
@@ -1,0 +1,20 @@
+//! Application-layer read model DTOs with serde serialization.
+#![allow(dead_code)] // All DTOs consumed by query handlers (tasks 11-12)
+
+pub mod download_detail_view;
+pub mod download_view;
+pub mod history_view;
+pub mod plugin_view;
+pub mod stats_view;
+
+// Re-exports consumed once query handlers return these DTOs.
+#[allow(unused_imports)]
+pub use download_detail_view::{DownloadDetailViewDto, SegmentViewDto};
+#[allow(unused_imports)]
+pub use download_view::DownloadViewDto;
+#[allow(unused_imports)]
+pub use history_view::HistoryViewDto;
+#[allow(unused_imports)]
+pub use plugin_view::PluginViewDto;
+#[allow(unused_imports)]
+pub use stats_view::{DailyVolumeDto, HostStatsDto, StatsViewDto};

--- a/src-tauri/src/application/read_models/mod.rs
+++ b/src-tauri/src/application/read_models/mod.rs
@@ -1,5 +1,4 @@
 //! Application-layer read model DTOs with serde serialization.
-#![allow(dead_code)] // All DTOs consumed by query handlers (tasks 11-12)
 
 pub mod download_detail_view;
 pub mod download_view;

--- a/src-tauri/src/application/read_models/plugin_view.rs
+++ b/src-tauri/src/application/read_models/plugin_view.rs
@@ -6,6 +6,7 @@ use crate::domain::model::plugin::PluginInfo;
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Returned by query handlers (tasks 11-12)
 pub struct PluginViewDto {
     pub name: String,
     pub version: String,

--- a/src-tauri/src/application/read_models/plugin_view.rs
+++ b/src-tauri/src/application/read_models/plugin_view.rs
@@ -1,0 +1,76 @@
+//! Serializable plugin view DTO for the frontend.
+
+use serde::Serialize;
+
+use crate::domain::model::plugin::PluginInfo;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PluginViewDto {
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub author: String,
+    pub category: String,
+    pub enabled: bool,
+}
+
+impl From<PluginInfo> for PluginViewDto {
+    fn from(p: PluginInfo) -> Self {
+        Self {
+            name: p.name().to_string(),
+            version: p.version().to_string(),
+            description: p.description().to_string(),
+            author: p.author().to_string(),
+            category: p.category().to_string(),
+            enabled: p.is_enabled(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::plugin::{PluginCategory, PluginInfo};
+
+    fn make_plugin_info() -> PluginInfo {
+        PluginInfo::new(
+            "my-plugin".to_string(),
+            "2.0.0".to_string(),
+            "A sample plugin".to_string(),
+            "dev-author".to_string(),
+            PluginCategory::Hoster,
+        )
+    }
+
+    #[test]
+    fn test_plugin_view_dto_from_domain() {
+        let info = make_plugin_info();
+        let dto = PluginViewDto::from(info);
+        assert_eq!(dto.name, "my-plugin");
+        assert_eq!(dto.version, "2.0.0");
+        assert_eq!(dto.description, "A sample plugin");
+        assert_eq!(dto.author, "dev-author");
+        assert_eq!(dto.category, "Hoster");
+        assert!(dto.enabled);
+    }
+
+    #[test]
+    fn test_plugin_view_dto_serializes_to_camel_case() {
+        let dto = PluginViewDto {
+            name: "plugin".to_string(),
+            version: "1.0.0".to_string(),
+            description: "desc".to_string(),
+            author: "author".to_string(),
+            category: "Utility".to_string(),
+            enabled: true,
+        };
+        let value = serde_json::to_value(&dto).unwrap();
+        assert!(value.get("name").is_some());
+        assert!(value.get("version").is_some());
+        assert!(value.get("description").is_some());
+        assert!(value.get("author").is_some());
+        assert!(value.get("category").is_some());
+        assert!(value.get("enabled").is_some());
+    }
+}

--- a/src-tauri/src/application/read_models/stats_view.rs
+++ b/src-tauri/src/application/read_models/stats_view.rs
@@ -6,6 +6,7 @@ use crate::domain::model::views::{DailyVolume, HostStats, StatsView};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Returned by query handlers (tasks 11-12)
 pub struct DailyVolumeDto {
     pub date: String,
     pub bytes: u64,
@@ -24,6 +25,7 @@ impl From<DailyVolume> for DailyVolumeDto {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Returned by query handlers (tasks 11-12)
 pub struct HostStatsDto {
     pub hostname: String,
     pub total_bytes: u64,
@@ -42,6 +44,7 @@ impl From<HostStats> for HostStatsDto {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+#[allow(dead_code)] // Returned by query handlers (tasks 11-12)
 pub struct StatsViewDto {
     pub total_downloaded_bytes: u64,
     pub total_files: u64,

--- a/src-tauri/src/application/read_models/stats_view.rs
+++ b/src-tauri/src/application/read_models/stats_view.rs
@@ -1,0 +1,126 @@
+//! Serializable statistics view DTOs for the frontend.
+
+use serde::Serialize;
+
+use crate::domain::model::views::{DailyVolume, HostStats, StatsView};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DailyVolumeDto {
+    pub date: String,
+    pub bytes: u64,
+    pub count: u64,
+}
+
+impl From<DailyVolume> for DailyVolumeDto {
+    fn from(v: DailyVolume) -> Self {
+        Self {
+            date: v.date,
+            bytes: v.bytes,
+            count: v.count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostStatsDto {
+    pub hostname: String,
+    pub total_bytes: u64,
+    pub download_count: u64,
+}
+
+impl From<HostStats> for HostStatsDto {
+    fn from(h: HostStats) -> Self {
+        Self {
+            hostname: h.hostname,
+            total_bytes: h.total_bytes,
+            download_count: h.download_count,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StatsViewDto {
+    pub total_downloaded_bytes: u64,
+    pub total_files: u64,
+    pub avg_speed: u64,
+    pub peak_speed: u64,
+    pub success_rate: f64,
+    pub daily_volumes: Vec<DailyVolumeDto>,
+    pub top_hosts: Vec<HostStatsDto>,
+}
+
+impl From<StatsView> for StatsViewDto {
+    fn from(s: StatsView) -> Self {
+        Self {
+            total_downloaded_bytes: s.total_downloaded_bytes,
+            total_files: s.total_files,
+            avg_speed: s.avg_speed,
+            peak_speed: s.peak_speed,
+            success_rate: s.success_rate,
+            daily_volumes: s
+                .daily_volumes
+                .into_iter()
+                .map(DailyVolumeDto::from)
+                .collect(),
+            top_hosts: s.top_hosts.into_iter().map(HostStatsDto::from).collect(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::views::{DailyVolume, HostStats, StatsView};
+
+    #[test]
+    fn test_stats_view_dto_from_domain() {
+        let stats = StatsView {
+            total_downloaded_bytes: 1_000_000,
+            total_files: 10,
+            avg_speed: 500,
+            peak_speed: 2000,
+            success_rate: 0.95,
+            daily_volumes: vec![DailyVolume {
+                date: "2024-01-01".to_string(),
+                bytes: 100_000,
+                count: 5,
+            }],
+            top_hosts: vec![HostStats {
+                hostname: "example.com".to_string(),
+                total_bytes: 500_000,
+                download_count: 7,
+            }],
+        };
+        let dto = StatsViewDto::from(stats);
+        assert_eq!(dto.total_downloaded_bytes, 1_000_000);
+        assert_eq!(dto.total_files, 10);
+        assert_eq!(dto.daily_volumes.len(), 1);
+        assert_eq!(dto.daily_volumes[0].date, "2024-01-01");
+        assert_eq!(dto.top_hosts.len(), 1);
+        assert_eq!(dto.top_hosts[0].hostname, "example.com");
+    }
+
+    #[test]
+    fn test_stats_view_dto_serializes_to_camel_case() {
+        let dto = StatsViewDto {
+            total_downloaded_bytes: 0,
+            total_files: 0,
+            avg_speed: 0,
+            peak_speed: 0,
+            success_rate: 1.0,
+            daily_volumes: vec![],
+            top_hosts: vec![],
+        };
+        let value = serde_json::to_value(&dto).unwrap();
+        assert!(value.get("totalDownloadedBytes").is_some());
+        assert!(value.get("totalFiles").is_some());
+        assert!(value.get("avgSpeed").is_some());
+        assert!(value.get("peakSpeed").is_some());
+        assert!(value.get("successRate").is_some());
+        assert!(value.get("dailyVolumes").is_some());
+        assert!(value.get("topHosts").is_some());
+    }
+}

--- a/src-tauri/src/domain/ports/driven/mod.rs
+++ b/src-tauri/src/domain/ports/driven/mod.rs
@@ -11,6 +11,7 @@ pub mod file_storage;
 pub mod history_repository;
 pub mod http_client;
 pub mod plugin_loader;
+pub mod plugin_read_repository;
 pub mod stats_repository;
 
 pub use clipboard_observer::ClipboardObserver;
@@ -24,4 +25,5 @@ pub use file_storage::FileStorage;
 pub use history_repository::HistoryRepository;
 pub use http_client::HttpClient;
 pub use plugin_loader::PluginLoader;
+pub use plugin_read_repository::PluginReadRepository;
 pub use stats_repository::StatsRepository;

--- a/src-tauri/src/domain/ports/driven/plugin_read_repository.rs
+++ b/src-tauri/src/domain/ports/driven/plugin_read_repository.rs
@@ -1,0 +1,17 @@
+//! Read-only port for querying loaded plugins (CQRS read side).
+//!
+//! Separated from `PluginLoader` to enforce the CQRS boundary:
+//! the query bus should not have access to write operations
+//! like `load` or `unload`.
+
+use crate::domain::error::DomainError;
+use crate::domain::model::plugin::PluginInfo;
+
+/// Read-only view of loaded plugins.
+///
+/// Used by query handlers to list plugins without exposing
+/// mutation capabilities (`load`, `unload`, `resolve_url`).
+pub trait PluginReadRepository: Send + Sync {
+    /// List all currently loaded plugins.
+    fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError>;
+}


### PR DESCRIPTION
## Summary

- **AppError** enum wrapping `DomainError` with infrastructure variants (`Storage`, `Network`, `Plugin`, `Config`, `NotFound`, `Validation`) via `thiserror`
- **CommandBus** struct holding 9 driven port references (`Arc<dyn Trait>`) for command handler injection
- **QueryBus** struct holding 4 read-side driven port references
- **10 command structs** (`StartDownload`, `Pause`, `Resume`, `Cancel`, `Retry`, `PauseAll`, `ResumeAll`, `InstallPlugin`, `UninstallPlugin`, `UpdateConfig`) implementing the `Command` marker trait
- **6 query structs** (`GetDownloads`, `GetDownloadDetail`, `GetHistory`, `GetStats`, `ListPlugins`, `CountDownloadsByState`) implementing the `Query` marker trait
- **6 read model DTO files** with `#[serde(rename_all = "camelCase")]` and `From<DomainType>` conversions for frontend serialization

## Architecture

```
application/
├── mod.rs              — module declarations + re-exports
├── error.rs            — AppError (wraps DomainError)
├── command_bus.rs      — CommandBus (9 driven ports)
├── query_bus.rs        — QueryBus (4 driven ports)
├── commands/mod.rs     — 10 CQRS command structs
├── queries/mod.rs      — 6 CQRS query structs
└── read_models/
    ├── mod.rs                   — re-exports
    ├── download_view.rs         — DownloadViewDto
    ├── download_detail_view.rs  — DownloadDetailViewDto + SegmentViewDto
    ├── stats_view.rs            — StatsViewDto + DailyVolumeDto + HostStatsDto
    ├── plugin_view.rs           — PluginViewDto
    └── history_view.rs          — HistoryViewDto
```

## Design decisions

- DTOs use `String` for `DownloadId` and `DownloadState` (frontend gets JSON-friendly types)
- `#[allow(dead_code)]` annotations are targeted per-item (not module-level) with comments pointing to the tasks that will consume them (11-12)
- No `tokio` dependency added — bus structs hold ports but don't dispatch yet

## Test plan

- [x] `cargo test --workspace` — 119 tests passing
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] lefthook pre-commit hooks (no-secrets, rust-fmt, rust-clippy) pass
- [ ] CI pipeline passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds command and query foundations for download controls, bulk actions, plugin/config commands, and several read queries.
  * Introduces serializable read-model DTOs for downloads, download details, history, plugins, and stats for UI consumption.
  * Adds a new application-level error type and exposes query/command entry points.
  * Adds a read-only plugin listing port.

* **Tests**
  * Unit tests validating construction and thread-safety of the command/query foundations and DTO serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->