### PR TITLE
feat(core): implement event system (task 07)

### DIFF
--- a/src-tauri/src/adapters/driven/event/mod.rs
+++ b/src-tauri/src/adapters/driven/event/mod.rs
@@ -1,0 +1,5 @@
+pub mod tauri_bridge;
+pub mod tokio_event_bus;
+
+pub use tauri_bridge::spawn_tauri_event_bridge;
+pub use tokio_event_bus::TokioEventBus;

--- a/src-tauri/src/adapters/driven/event/tauri_bridge.rs
+++ b/src-tauri/src/adapters/driven/event/tauri_bridge.rs
@@ -1,0 +1,237 @@
+use serde_json::json;
+use tauri::{AppHandle, Emitter};
+
+use crate::domain::event::DomainEvent;
+use crate::domain::ports::driven::EventBus;
+
+/// Subscribes to the EventBus and emits each event to the Tauri webview.
+pub fn spawn_tauri_event_bridge(app_handle: AppHandle, event_bus: &dyn EventBus) {
+    let handle = app_handle.clone();
+    event_bus.subscribe(Box::new(move |event: &DomainEvent| {
+        let (name, payload) = to_tauri_event(event);
+        handle.emit(name, payload).ok(); // Best-effort, don't crash on emit failure
+    }));
+}
+
+fn event_name(event: &DomainEvent) -> &'static str {
+    match event {
+        DomainEvent::DownloadCreated { .. } => "download-created",
+        DomainEvent::DownloadStarted { .. } => "download-started",
+        DomainEvent::DownloadPaused { .. } => "download-paused",
+        DomainEvent::DownloadResumed { .. } => "download-resumed",
+        DomainEvent::DownloadResumedFromWait { .. } => "download-resumed-from-wait",
+        DomainEvent::DownloadCompleted { .. } => "download-completed",
+        DomainEvent::DownloadFailed { .. } => "download-failed",
+        DomainEvent::DownloadRetrying { .. } => "download-retrying",
+        DomainEvent::DownloadWaiting { .. } => "download-waiting",
+        DomainEvent::DownloadChecking { .. } => "download-checking",
+        DomainEvent::DownloadExtracting { .. } => "download-extracting",
+        DomainEvent::DownloadProgress { .. } => "download-progress",
+        DomainEvent::SegmentStarted { .. } => "segment-started",
+        DomainEvent::SegmentCompleted { .. } => "segment-completed",
+        DomainEvent::SegmentFailed { .. } => "segment-failed",
+        DomainEvent::PluginLoaded { .. } => "plugin-loaded",
+        DomainEvent::PluginUnloaded { .. } => "plugin-unloaded",
+        DomainEvent::PackageCreated { .. } => "package-created",
+    }
+}
+
+fn event_payload(event: &DomainEvent) -> serde_json::Value {
+    match event {
+        DomainEvent::DownloadCreated { id }
+        | DomainEvent::DownloadStarted { id }
+        | DomainEvent::DownloadPaused { id }
+        | DomainEvent::DownloadResumed { id }
+        | DomainEvent::DownloadResumedFromWait { id }
+        | DomainEvent::DownloadCompleted { id }
+        | DomainEvent::DownloadWaiting { id }
+        | DomainEvent::DownloadChecking { id }
+        | DomainEvent::DownloadExtracting { id } => json!({ "id": id.0 }),
+
+        DomainEvent::DownloadFailed { id, error } => json!({ "id": id.0, "error": error }),
+        DomainEvent::DownloadRetrying { id, attempt } => {
+            json!({ "id": id.0, "attempt": attempt })
+        }
+        DomainEvent::DownloadProgress {
+            id,
+            downloaded_bytes,
+            total_bytes,
+        } => {
+            json!({ "id": id.0, "downloadedBytes": downloaded_bytes, "totalBytes": total_bytes })
+        }
+
+        DomainEvent::SegmentStarted {
+            download_id,
+            segment_id,
+        }
+        | DomainEvent::SegmentCompleted {
+            download_id,
+            segment_id,
+        } => {
+            json!({ "downloadId": download_id.0, "segmentId": segment_id })
+        }
+        DomainEvent::SegmentFailed {
+            download_id,
+            segment_id,
+            error,
+        } => {
+            json!({ "downloadId": download_id.0, "segmentId": segment_id, "error": error })
+        }
+
+        DomainEvent::PluginLoaded { name, version } => {
+            json!({ "name": name, "version": version })
+        }
+        DomainEvent::PluginUnloaded { name } => json!({ "name": name }),
+        DomainEvent::PackageCreated { id, name } => json!({ "id": id, "name": name }),
+    }
+}
+
+fn to_tauri_event(event: &DomainEvent) -> (&'static str, serde_json::Value) {
+    (event_name(event), event_payload(event))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::download::DownloadId;
+
+    #[test]
+    fn test_event_name_download_variants() {
+        assert_eq!(
+            event_name(&DomainEvent::DownloadCreated { id: DownloadId(1) }),
+            "download-created"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadStarted { id: DownloadId(1) }),
+            "download-started"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadPaused { id: DownloadId(1) }),
+            "download-paused"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadResumed { id: DownloadId(1) }),
+            "download-resumed"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadResumedFromWait { id: DownloadId(1) }),
+            "download-resumed-from-wait"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadCompleted { id: DownloadId(1) }),
+            "download-completed"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadFailed {
+                id: DownloadId(1),
+                error: "err".into()
+            }),
+            "download-failed"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadRetrying {
+                id: DownloadId(1),
+                attempt: 1
+            }),
+            "download-retrying"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadWaiting { id: DownloadId(1) }),
+            "download-waiting"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadChecking { id: DownloadId(1) }),
+            "download-checking"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadExtracting { id: DownloadId(1) }),
+            "download-extracting"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadProgress {
+                id: DownloadId(1),
+                downloaded_bytes: 0,
+                total_bytes: 100
+            }),
+            "download-progress"
+        );
+    }
+
+    #[test]
+    fn test_event_name_segment_variants() {
+        assert_eq!(
+            event_name(&DomainEvent::SegmentStarted {
+                download_id: DownloadId(1),
+                segment_id: 0
+            }),
+            "segment-started"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::SegmentCompleted {
+                download_id: DownloadId(1),
+                segment_id: 0
+            }),
+            "segment-completed"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::SegmentFailed {
+                download_id: DownloadId(1),
+                segment_id: 0,
+                error: "err".into()
+            }),
+            "segment-failed"
+        );
+    }
+
+    #[test]
+    fn test_event_name_plugin_variants() {
+        assert_eq!(
+            event_name(&DomainEvent::PluginLoaded {
+                name: "p".into(),
+                version: "1.0".into()
+            }),
+            "plugin-loaded"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::PluginUnloaded { name: "p".into() }),
+            "plugin-unloaded"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::PackageCreated {
+                id: 1,
+                name: "pkg".into()
+            }),
+            "package-created"
+        );
+    }
+
+    #[test]
+    fn test_event_payload_download_progress_camel_case() {
+        let event = DomainEvent::DownloadProgress {
+            id: DownloadId(7),
+            downloaded_bytes: 512,
+            total_bytes: 1024,
+        };
+        let (_, payload) = to_tauri_event(&event);
+        assert_eq!(payload["id"], 7);
+        assert_eq!(payload["downloadedBytes"], 512);
+        assert_eq!(payload["totalBytes"], 1024);
+        // Verify snake_case keys are not present
+        assert!(payload.get("downloaded_bytes").is_none());
+        assert!(payload.get("total_bytes").is_none());
+    }
+
+    #[test]
+    fn test_event_payload_segment_camel_case() {
+        let event = DomainEvent::SegmentCompleted {
+            download_id: DownloadId(3),
+            segment_id: 2,
+        };
+        let (_, payload) = to_tauri_event(&event);
+        assert_eq!(payload["downloadId"], 3);
+        assert_eq!(payload["segmentId"], 2);
+        // Verify snake_case keys are not present
+        assert!(payload.get("download_id").is_none());
+        assert!(payload.get("segment_id").is_none());
+    }
+}

--- a/src-tauri/src/adapters/driven/event/tauri_bridge.rs
+++ b/src-tauri/src/adapters/driven/event/tauri_bridge.rs
@@ -6,10 +6,9 @@ use crate::domain::ports::driven::EventBus;
 
 /// Subscribes to the EventBus and emits each event to the Tauri webview.
 pub fn spawn_tauri_event_bridge(app_handle: AppHandle, event_bus: &dyn EventBus) {
-    let handle = app_handle.clone();
     event_bus.subscribe(Box::new(move |event: &DomainEvent| {
         let (name, payload) = to_tauri_event(event);
-        handle.emit(name, payload).ok(); // Best-effort, don't crash on emit failure
+        app_handle.emit(name, payload).ok();
     }));
 }
 
@@ -82,7 +81,7 @@ fn event_payload(event: &DomainEvent) -> serde_json::Value {
             json!({ "name": name, "version": version })
         }
         DomainEvent::PluginUnloaded { name } => json!({ "name": name }),
-        DomainEvent::PackageCreated { id, name } => json!({ "id": id, "name": name }),
+        DomainEvent::PackageCreated { id, name } => json!({ "id": id.to_string(), "name": name }),
     }
 }
 

--- a/src-tauri/src/adapters/driven/event/tokio_event_bus.rs
+++ b/src-tauri/src/adapters/driven/event/tokio_event_bus.rs
@@ -1,0 +1,119 @@
+use tokio::sync::broadcast;
+
+use crate::domain::event::DomainEvent;
+use crate::domain::ports::driven::EventBus;
+
+pub struct TokioEventBus {
+    sender: broadcast::Sender<DomainEvent>,
+}
+
+impl TokioEventBus {
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        let (sender, _) = broadcast::channel(capacity);
+        Self { sender }
+    }
+}
+
+impl EventBus for TokioEventBus {
+    fn publish(&self, event: DomainEvent) {
+        let _ = self.sender.send(event);
+    }
+
+    fn subscribe(&self, handler: Box<dyn Fn(&DomainEvent) + Send + Sync + 'static>) {
+        let mut rx = self.sender.subscribe();
+        tokio::spawn(async move {
+            loop {
+                match rx.recv().await {
+                    Ok(event) => handler(&event),
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        tracing::warn!(skipped = n, "event bus subscriber lagged, events dropped");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::download::DownloadId;
+    use std::sync::{Arc, Mutex};
+    use tokio::sync::Notify;
+
+    #[tokio::test]
+    async fn test_publish_and_receive_event() {
+        let bus = TokioEventBus::new(16);
+        let received: Arc<Mutex<Vec<DomainEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let notify = Arc::new(Notify::new());
+        let received_clone = received.clone();
+        let notify_clone = notify.clone();
+
+        bus.subscribe(Box::new(move |event: &DomainEvent| {
+            received_clone.lock().unwrap().push(event.clone());
+            notify_clone.notify_one();
+        }));
+
+        bus.publish(DomainEvent::DownloadStarted { id: DownloadId(1) });
+        notify.notified().await;
+
+        let events = received.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0],
+            DomainEvent::DownloadStarted { id: DownloadId(1) }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multiple_subscribers_receive_same_event() {
+        let bus = TokioEventBus::new(16);
+        let received1: Arc<Mutex<Vec<DomainEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let received2: Arc<Mutex<Vec<DomainEvent>>> = Arc::new(Mutex::new(Vec::new()));
+        let notify1 = Arc::new(Notify::new());
+        let notify2 = Arc::new(Notify::new());
+        let clone1 = received1.clone();
+        let clone2 = received2.clone();
+        let n1 = notify1.clone();
+        let n2 = notify2.clone();
+
+        bus.subscribe(Box::new(move |event: &DomainEvent| {
+            clone1.lock().unwrap().push(event.clone());
+            n1.notify_one();
+        }));
+        bus.subscribe(Box::new(move |event: &DomainEvent| {
+            clone2.lock().unwrap().push(event.clone());
+            n2.notify_one();
+        }));
+
+        bus.publish(DomainEvent::DownloadCompleted { id: DownloadId(42) });
+        notify1.notified().await;
+        notify2.notified().await;
+
+        assert_eq!(received1.lock().unwrap().len(), 1);
+        assert_eq!(received2.lock().unwrap().len(), 1);
+        assert_eq!(
+            received1.lock().unwrap()[0],
+            DomainEvent::DownloadCompleted { id: DownloadId(42) }
+        );
+        assert_eq!(
+            received2.lock().unwrap()[0],
+            DomainEvent::DownloadCompleted { id: DownloadId(42) }
+        );
+    }
+
+    #[test]
+    fn test_publish_no_subscriber_doesnt_block() {
+        let bus = TokioEventBus::new(16);
+        bus.publish(DomainEvent::DownloadStarted { id: DownloadId(99) });
+        bus.publish(DomainEvent::DownloadCompleted { id: DownloadId(99) });
+    }
+
+    #[test]
+    fn test_new_with_zero_capacity_uses_minimum() {
+        let bus = TokioEventBus::new(0);
+        bus.publish(DomainEvent::DownloadStarted { id: DownloadId(1) });
+    }
+}

--- a/src-tauri/src/adapters/driven/mod.rs
+++ b/src-tauri/src/adapters/driven/mod.rs
@@ -1,3 +1,4 @@
 //! Driven adapters — implementations of domain port traits.
 
+pub mod event;
 pub mod sqlite;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ mod application;
 pub mod domain;
 
 // Public API — concrete types for app wiring (main.rs, Tauri setup, integration tests)
+pub use adapters::driven::event::TokioEventBus;
+pub use adapters::driven::event::spawn_tauri_event_bridge;
 pub use adapters::driven::sqlite::connection;
 pub use adapters::driven::sqlite::download_read_repo::SqliteDownloadReadRepo;
 pub use adapters::driven::sqlite::download_repo::SqliteDownloadRepo;

--- a/src/hooks/useTauriEvent.test.ts
+++ b/src/hooks/useTauriEvent.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useTauriEvent } from './useTauriEvent';
+
+// Mock @tauri-apps/api/event
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(),
+}));
+
+import { listen } from '@tauri-apps/api/event';
+
+describe('useTauriEvent', () => {
+  let mockUnlisten: ReturnType<typeof vi.fn>;
+  let capturedCallback: ((event: { payload: unknown }) => void) | null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUnlisten = vi.fn();
+    capturedCallback = null;
+    vi.mocked(listen).mockImplementation((_event, callback) => {
+      capturedCallback = callback as (event: { payload: unknown }) => void;
+      return Promise.resolve(mockUnlisten);
+    });
+  });
+
+  it('should subscribe to the specified event on mount', () => {
+    const callback = vi.fn();
+    renderHook(() => useTauriEvent('download-progress', callback));
+    expect(listen).toHaveBeenCalledWith('download-progress', expect.any(Function));
+  });
+
+  it('should call callback with payload when event fires', () => {
+    const callback = vi.fn();
+    renderHook(() => useTauriEvent('download-started', callback));
+    capturedCallback?.({ payload: { id: 42 } });
+    expect(callback).toHaveBeenCalledWith({ id: 42 });
+  });
+
+  it('should cleanup listener on unmount', async () => {
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useTauriEvent('download-progress', callback));
+    unmount();
+    await vi.waitFor(() => {
+      expect(mockUnlisten).toHaveBeenCalled();
+    });
+  });
+
+  it('should re-subscribe when eventName changes and cleanup old listener', async () => {
+    const callback = vi.fn();
+    const { rerender } = renderHook(
+      ({ eventName }) => useTauriEvent(eventName, callback),
+      { initialProps: { eventName: 'download-started' } }
+    );
+    expect(listen).toHaveBeenCalledTimes(1);
+    rerender({ eventName: 'download-completed' });
+    expect(listen).toHaveBeenCalledTimes(2);
+    expect(listen).toHaveBeenLastCalledWith('download-completed', expect.any(Function));
+    await vi.waitFor(() => {
+      expect(mockUnlisten).toHaveBeenCalled();
+    });
+  });
+
+  it('should not call callback after cleanup (cancelled flag)', async () => {
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useTauriEvent('test-event', callback));
+    unmount();
+    // Simulate event arriving after unmount
+    capturedCallback?.({ payload: 'late-data' });
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should handle listen rejection without unhandled promise', async () => {
+    vi.mocked(listen).mockRejectedValueOnce(new Error('backend unavailable'));
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useTauriEvent('test-event', callback));
+    // Should not throw unhandled rejection
+    unmount();
+    await vi.waitFor(() => {
+      expect(listen).toHaveBeenCalled();
+    });
+  });
+
+  it('should use latest callback without re-subscribing', () => {
+    const callback1 = vi.fn();
+    const callback2 = vi.fn();
+    const { rerender } = renderHook(
+      ({ cb }) => useTauriEvent('test-event', cb),
+      { initialProps: { cb: callback1 } }
+    );
+    rerender({ cb: callback2 });
+    expect(listen).toHaveBeenCalledTimes(1);
+    capturedCallback?.({ payload: 'data' });
+    expect(callback2).toHaveBeenCalledWith('data');
+    expect(callback1).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useTauriEvent.test.ts
+++ b/src/hooks/useTauriEvent.test.ts
@@ -10,12 +10,12 @@ vi.mock('@tauri-apps/api/event', () => ({
 import { listen } from '@tauri-apps/api/event';
 
 describe('useTauriEvent', () => {
-  let mockUnlisten: ReturnType<typeof vi.fn>;
+  let mockUnlisten: ReturnType<typeof vi.fn<() => void>>;
   let capturedCallback: ((event: { payload: unknown }) => void) | null;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUnlisten = vi.fn();
+    mockUnlisten = vi.fn<() => void>();
     capturedCallback = null;
     vi.mocked(listen).mockImplementation((_event, callback) => {
       capturedCallback = callback as (event: { payload: unknown }) => void;

--- a/src/hooks/useTauriEvent.ts
+++ b/src/hooks/useTauriEvent.ts
@@ -1,0 +1,20 @@
+import { useEffect, useRef } from 'react';
+import { listen } from '@tauri-apps/api/event';
+
+export function useTauriEvent<T>(eventName: string, callback: (payload: T) => void): void {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    let cancelled = false;
+    const unlistenPromise = listen<T>(eventName, (event) => {
+      if (!cancelled) {
+        callbackRef.current(event.payload);
+      }
+    });
+    return () => {
+      cancelled = true;
+      unlistenPromise.then((fn) => fn()).catch(() => {});
+    };
+  }, [eventName]);
+}

--- a/src/hooks/useTauriEvent.ts
+++ b/src/hooks/useTauriEvent.ts
@@ -7,14 +7,22 @@ export function useTauriEvent<T>(eventName: string, callback: (payload: T) => vo
 
   useEffect(() => {
     let cancelled = false;
-    const unlistenPromise = listen<T>(eventName, (event) => {
+    let unlistenFn: (() => void) | undefined;
+
+    listen<T>(eventName, (event) => {
       if (!cancelled) {
         callbackRef.current(event.payload);
       }
-    });
+    })
+      .then((fn) => {
+        if (cancelled) fn();
+        else unlistenFn = fn;
+      })
+      .catch(() => {});
+
     return () => {
       cancelled = true;
-      unlistenPromise.then((fn) => fn()).catch(() => {});
+      unlistenFn?.();
     };
   }, [eventName]);
 }


### PR DESCRIPTION
## Summary

- Implement `TokioEventBus` adapter using `tokio::sync::broadcast` channel, with lag detection via `tracing::warn` for slow subscribers
- Add Tauri event bridge that subscribes to the `EventBus` and forwards all 18 `DomainEvent` variants to the frontend as kebab-case events with camelCase JSON payloads
- Add `useTauriEvent<T>` React hook with `useRef` callback pattern, race-safe async cleanup (`cancelled` flag), and `.catch()` on `unlisten` promise

## Architecture

```
Domain (DomainEvent) → EventBus port (trait) → TokioEventBus (broadcast)
                                              → Tauri bridge (subscribe + emit)
                                              → Frontend (useTauriEvent hook)
```

- No `serde` in domain — serialization handled in adapter layer (`tauri_bridge.rs`)
- Exhaustive pattern matching on all 18 `DomainEvent` variants
- Bounded channel prevents backpressure from blocking publishers

## Test plan

- [x] `test_publish_and_receive_event` — subscriber receives published event (Notify sync)
- [x] `test_multiple_subscribers_receive_same_event` — broadcast to 2 subscribers
- [x] `test_publish_no_subscriber_doesnt_block` — no panic without subscribers
- [x] `test_new_with_zero_capacity_uses_minimum` — capacity clamped to 1
- [x] `test_event_name_*` — all 18 variants map to correct kebab-case names
- [x] `test_event_payload_*_camel_case` — payloads use camelCase keys
- [x] TS: subscribe, callback, cleanup, re-subscribe, ref pattern, cancelled flag, rejection handling

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a real-time event system from backend to frontend using Tauri, with a `TokioEventBus`, a Tauri bridge, and a `useTauriEvent` React hook. Also adds safety fixes for promise handling and JS number precision.

- New Features
  - `TokioEventBus` using `tokio::sync::broadcast` with bounded channel and lag warnings; exposed as `TokioEventBus` and `spawn_tauri_event_bridge`.
  - Tauri bridge emits all 18 `DomainEvent` variants as kebab-case events with camelCase JSON payloads.
  - `useTauriEvent<T>` built on `@tauri-apps/api/event` `listen`, with ref-based callback updates and race-safe cleanup.

- Bug Fixes
  - Attach `.catch()` to `listen()` to prevent unhandled promise rejections.
  - Remove redundant `AppHandle` clone in the bridge.
  - Serialize `PackageCreated.id` as a string for JS precision safety.

<sup>Written for commit 061e71ea484584f76892a6f11e19c6e2aeebaafa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time event pipeline: non-blocking in-process event bus and a background bridge that emits structured events to the UI.
  * Exported hook for React components to subscribe to app events (downloads, segments, plugins, packages) with camelCase payload fields.

* **Tests**
  * Added unit and integration tests covering event delivery, payload shape, subscription lifecycle, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->