### PR TITLE
feat(core): implement segmented download engine (task 08)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `SqliteDownloadReadRepo` (read: filtered/sorted list, detail with segments, count by state)
   - `SqliteHistoryRepo` (record, find_recent, find_by_download, delete_older_than)
   - Initial migration creating 6 tables with indexes and foreign keys
+- Event system: TokioEventBus (broadcast), Tauri bridge, useTauriEvent React hook
+- Segmented download engine: parallel HTTP Range downloads with pause/cancel
+  - `ReqwestHttpClient` adapter implementing HttpClient port (HEAD, GET range, range detection)
+  - `SegmentedDownloadEngine` adapter implementing DownloadEngine port (start, pause, cancel)
+  - Segment worker with streaming HTTP chunks, progress throttling (500ms), and CancellationToken
+  - Configurable segment count with 64KB minimum segment size
+  - Single-segment fallback when server doesn't support Range requests

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -127,6 +127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +212,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -463,6 +495,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -558,6 +592,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +649,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -627,7 +680,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "064badf302c3194842cf2c5d61f56cc88e54a759313879cdf03abdd27d0c3b97"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types 0.5.0",
  "libc",
@@ -640,7 +693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "libc",
 ]
 
@@ -828,6 +881,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -1051,6 +1122,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1301,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1330,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1323,6 +1410,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1469,8 +1557,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1480,9 +1570,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1647,6 +1739,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.13.1",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +1803,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1788,6 +1905,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1797,14 +1920,32 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1825,9 +1966,11 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2118,6 +2261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2284,6 +2437,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2567,6 +2726,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -3312,6 +3481,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3364,6 +3589,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3384,6 +3619,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3399,6 +3644,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3520,21 +3774,30 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
+ "mime",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3544,6 +3807,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3638,6 +3915,81 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "aws-lc-rs",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -3905,7 +4257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.0",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4672,6 +5024,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "system-deps"
 version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4692,7 +5065,7 @@ checksum = "9103edf55f2da3c82aea4c7fab7c4241032bfeea0e71fa557d98e00e7ce7cc20"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-graphics",
  "crossbeam-channel",
  "dispatch2",
@@ -5127,6 +5500,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5146,6 +5529,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]
@@ -5483,6 +5867,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5565,6 +5955,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vortex"
 version = "0.0.0"
 dependencies = [
+ "bytes",
+ "futures-util",
+ "reqwest",
  "sea-orm",
  "sea-orm-migration",
  "serde",
@@ -5573,8 +5966,10 @@ dependencies = [
  "tauri-build",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "wiremock",
 ]
 
 [[package]]
@@ -5766,6 +6161,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5819,6 +6224,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6017,6 +6431,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6068,6 +6493,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6390,6 +6824,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,3 +23,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sea-orm = { version = "1.1.20", features = ["sqlx-sqlite", "runtime-tokio-native-tls", "macros"] }
 sea-orm-migration = { version = "1.1.20", features = ["sqlx-sqlite", "runtime-tokio-native-tls"] }
 tokio = { version = "1.51.0", features = ["full"] }
+reqwest = { version = "0.13.2", features = ["stream"] }
+tokio-util = { version = "0.7.18", features = ["rt"] }
+futures-util = "0.3.32"
+bytes = "1.11.1"
+
+[dev-dependencies]
+wiremock = "0.6.5"

--- a/src-tauri/src/adapters/driven/mod.rs
+++ b/src-tauri/src/adapters/driven/mod.rs
@@ -1,4 +1,5 @@
 //! Driven adapters — implementations of domain port traits.
 
 pub mod event;
+pub mod network;
 pub mod sqlite;

--- a/src-tauri/src/adapters/driven/network/download_engine.rs
+++ b/src-tauri/src/adapters/driven/network/download_engine.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
 
 use tokio::sync::watch;
@@ -11,7 +12,7 @@ use crate::domain::event::DomainEvent;
 use crate::domain::model::download::{Download, DownloadId};
 use crate::domain::ports::driven::{DownloadEngine, EventBus, FileStorage};
 
-use super::segment_worker::{SegmentParams, download_segment};
+use super::segment_worker::{SegmentError, SegmentParams, download_segment};
 
 struct ActiveDownload {
     cancel_token: CancellationToken,
@@ -58,7 +59,16 @@ impl DownloadEngine for SegmentedDownloadEngine {
         let (pause_tx, pause_rx) = watch::channel(false);
 
         {
-            let mut map = self.active_downloads.lock().unwrap();
+            let mut map = self
+                .active_downloads
+                .lock()
+                .expect("active_downloads lock poisoned");
+            if map.contains_key(&download_id) {
+                return Err(DomainError::AlreadyExists(format!(
+                    "download {}",
+                    download_id.0
+                )));
+            }
             map.insert(
                 download_id,
                 ActiveDownload {
@@ -103,7 +113,10 @@ impl DownloadEngine for SegmentedDownloadEngine {
                         id: download_id,
                         error: format!("HEAD request failed: {e}"),
                     });
-                    active_downloads.lock().unwrap().remove(&download_id);
+                    active_downloads
+                        .lock()
+                        .expect("active_downloads lock poisoned")
+                        .remove(&download_id);
                     return;
                 }
             };
@@ -125,7 +138,10 @@ impl DownloadEngine for SegmentedDownloadEngine {
                             id: download_id,
                             error: format!("file pre-allocation failed: {e}"),
                         });
-                        active_downloads.lock().unwrap().remove(&download_id);
+                        active_downloads
+                            .lock()
+                            .expect("active_downloads lock poisoned")
+                            .remove(&download_id);
                         return;
                     }
                     Ok(Err(e)) => {
@@ -133,7 +149,10 @@ impl DownloadEngine for SegmentedDownloadEngine {
                             id: download_id,
                             error: format!("file pre-allocation failed: {e}"),
                         });
-                        active_downloads.lock().unwrap().remove(&download_id);
+                        active_downloads
+                            .lock()
+                            .expect("active_downloads lock poisoned")
+                            .remove(&download_id);
                         return;
                     }
                     Ok(Ok(())) => {}
@@ -171,6 +190,7 @@ impl DownloadEngine for SegmentedDownloadEngine {
 
             event_bus.publish(DomainEvent::DownloadStarted { id: download_id });
 
+            let shared_downloaded = Arc::new(AtomicU64::new(0));
             let mut join_set = JoinSet::new();
             for (index, (start, end)) in segments.iter().enumerate() {
                 join_set.spawn(download_segment(SegmentParams {
@@ -187,6 +207,7 @@ impl DownloadEngine for SegmentedDownloadEngine {
                     dest_path: dest_path.clone(),
                     pause_rx: pause_rx.clone(),
                     cancel_token: cancel_token.clone(),
+                    shared_downloaded: shared_downloaded.clone(),
                 }));
             }
 
@@ -196,8 +217,11 @@ impl DownloadEngine for SegmentedDownloadEngine {
             while let Some(result) = join_set.join_next().await {
                 match result {
                     Ok(Ok(_bytes)) => {}
-                    Ok(Err(e)) => {
-                        if e != "cancelled" {
+                    Ok(Err(e)) => match e {
+                        SegmentError::Cancelled => {
+                            cancel_token.cancel();
+                        }
+                        _ => {
                             if failed {
                                 tracing::warn!(
                                     download_id = download_id.0,
@@ -205,11 +229,11 @@ impl DownloadEngine for SegmentedDownloadEngine {
                                     "additional segment failure (overwriting previous error)"
                                 );
                             }
-                            error_msg = e;
+                            error_msg = format!("{e:?}");
                             failed = true;
+                            cancel_token.cancel();
                         }
-                        cancel_token.cancel();
-                    }
+                    },
                     Err(e) => {
                         error_msg = format!("segment task panicked: {e}");
                         failed = true;
@@ -227,14 +251,20 @@ impl DownloadEngine for SegmentedDownloadEngine {
                 event_bus.publish(DomainEvent::DownloadCompleted { id: download_id });
             }
 
-            active_downloads.lock().unwrap().remove(&download_id);
+            active_downloads
+                .lock()
+                .expect("active_downloads lock poisoned")
+                .remove(&download_id);
         });
 
         Ok(())
     }
 
     fn pause(&self, id: DownloadId) -> Result<(), DomainError> {
-        let map = self.active_downloads.lock().unwrap();
+        let map = self
+            .active_downloads
+            .lock()
+            .expect("active_downloads lock poisoned");
         let active = map
             .get(&id)
             .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?;
@@ -245,9 +275,27 @@ impl DownloadEngine for SegmentedDownloadEngine {
         Ok(())
     }
 
+    fn resume(&self, id: DownloadId) -> Result<(), DomainError> {
+        let map = self
+            .active_downloads
+            .lock()
+            .expect("active_downloads lock poisoned");
+        let active = map
+            .get(&id)
+            .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?;
+
+        let _ = active.pause_sender.send(false);
+
+        self.event_bus.publish(DomainEvent::DownloadResumed { id });
+        Ok(())
+    }
+
     fn cancel(&self, id: DownloadId) -> Result<(), DomainError> {
         let active = {
-            let mut map = self.active_downloads.lock().unwrap();
+            let mut map = self
+                .active_downloads
+                .lock()
+                .expect("active_downloads lock poisoned");
             map.remove(&id)
                 .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?
         };
@@ -274,8 +322,10 @@ mod tests {
 
     // --- Mock types ---
 
+    type WriteRecord = (PathBuf, u64, Vec<u8>);
+
     struct MockFileStorage {
-        writes: Arc<Mutex<Vec<(PathBuf, u64, Vec<u8>)>>>,
+        writes: Arc<Mutex<Vec<WriteRecord>>>,
     }
 
     impl MockFileStorage {
@@ -333,7 +383,7 @@ mod tests {
         {
             let deadline = tokio::time::Instant::now() + timeout;
             loop {
-                if self.collected().iter().any(|e| predicate(e)) {
+                if self.collected().iter().any(&predicate) {
                     return true;
                 }
                 if tokio::time::Instant::now() >= deadline {

--- a/src-tauri/src/adapters/driven/network/download_engine.rs
+++ b/src-tauri/src/adapters/driven/network/download_engine.rs
@@ -1,0 +1,610 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use tokio::sync::watch;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
+
+use crate::domain::error::DomainError;
+use crate::domain::event::DomainEvent;
+use crate::domain::model::download::{Download, DownloadId};
+use crate::domain::ports::driven::{DownloadEngine, EventBus, FileStorage};
+
+use super::segment_worker::{SegmentParams, download_segment};
+
+struct ActiveDownload {
+    cancel_token: CancellationToken,
+    pause_sender: watch::Sender<bool>,
+}
+
+pub struct SegmentedDownloadEngine {
+    client: reqwest::Client,
+    file_storage: Arc<dyn FileStorage>,
+    event_bus: Arc<dyn EventBus>,
+    default_segments: u32,
+    active_downloads: Arc<Mutex<HashMap<DownloadId, ActiveDownload>>>,
+}
+
+impl SegmentedDownloadEngine {
+    pub fn new(
+        client: reqwest::Client,
+        file_storage: Arc<dyn FileStorage>,
+        event_bus: Arc<dyn EventBus>,
+        default_segments: u32,
+    ) -> Self {
+        Self {
+            client,
+            file_storage,
+            event_bus,
+            default_segments: default_segments.max(1),
+            active_downloads: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+}
+
+impl DownloadEngine for SegmentedDownloadEngine {
+    fn start(&self, download: &Download) -> Result<(), DomainError> {
+        let download_id = download.id();
+        let url = download.url().as_str().to_string();
+        let dest_path = PathBuf::from(download.destination_path()).join(download.file_name());
+        let segments_count = if download.segments_count() == 0 {
+            self.default_segments
+        } else {
+            download.segments_count()
+        };
+
+        let cancel_token = CancellationToken::new();
+        let (pause_tx, pause_rx) = watch::channel(false);
+
+        {
+            let mut map = self.active_downloads.lock().unwrap();
+            map.insert(
+                download_id,
+                ActiveDownload {
+                    cancel_token: cancel_token.clone(),
+                    pause_sender: pause_tx,
+                },
+            );
+        }
+
+        let client = self.client.clone();
+        let file_storage = self.file_storage.clone();
+        let event_bus = self.event_bus.clone();
+        let active_downloads = self.active_downloads.clone();
+
+        tokio::spawn(async move {
+            // Perform HEAD request to determine size and range support
+            let head_result = client.head(&url).send().await;
+
+            let (total_size, supports_range) = match head_result {
+                Ok(resp) => {
+                    let content_length = resp
+                        .headers()
+                        .get("content-length")
+                        .and_then(|v| v.to_str().ok())
+                        .and_then(|s| s.parse::<u64>().ok())
+                        .unwrap_or(0);
+                    let accepts_ranges = resp
+                        .headers()
+                        .get("accept-ranges")
+                        .and_then(|v| v.to_str().ok())
+                        .map(|v| v.eq_ignore_ascii_case("bytes"))
+                        .unwrap_or(false);
+                    (content_length, accepts_ranges)
+                }
+                Err(e) => {
+                    tracing::error!(
+                        download_id = download_id.0,
+                        error = %e,
+                        "HEAD request failed"
+                    );
+                    event_bus.publish(DomainEvent::DownloadFailed {
+                        id: download_id,
+                        error: format!("HEAD request failed: {e}"),
+                    });
+                    active_downloads.lock().unwrap().remove(&download_id);
+                    return;
+                }
+            };
+
+            // Pre-allocate file if size is known
+            if total_size > 0 {
+                let storage = file_storage.clone();
+                let path = dest_path.clone();
+                match tokio::task::spawn_blocking(move || storage.create_file(&path, total_size))
+                    .await
+                {
+                    Err(e) => {
+                        tracing::error!(
+                            download_id = download_id.0,
+                            error = %e,
+                            "spawn_blocking for create_file panicked"
+                        );
+                        event_bus.publish(DomainEvent::DownloadFailed {
+                            id: download_id,
+                            error: format!("file pre-allocation failed: {e}"),
+                        });
+                        active_downloads.lock().unwrap().remove(&download_id);
+                        return;
+                    }
+                    Ok(Err(e)) => {
+                        event_bus.publish(DomainEvent::DownloadFailed {
+                            id: download_id,
+                            error: format!("file pre-allocation failed: {e}"),
+                        });
+                        active_downloads.lock().unwrap().remove(&download_id);
+                        return;
+                    }
+                    Ok(Ok(())) => {}
+                }
+            }
+
+            // Determine number of segments
+            let num_segments = if supports_range && total_size > 0 {
+                // At least 64KB per segment
+                segments_count
+                    .min((total_size / (64 * 1024)).max(1) as u32)
+                    .max(1)
+            } else {
+                1
+            };
+
+            // Calculate segment byte ranges
+            let segments: Vec<(u64, u64)> = if total_size > 0 {
+                let segment_size = total_size / num_segments as u64;
+                (0..num_segments)
+                    .map(|i| {
+                        let start = i as u64 * segment_size;
+                        let end = if i == num_segments - 1 {
+                            total_size
+                        } else {
+                            (i as u64 + 1) * segment_size
+                        };
+                        (start, end)
+                    })
+                    .collect()
+            } else {
+                // Unknown size: single segment from 0 to u64::MAX (worker will handle stream end)
+                vec![(0, u64::MAX)]
+            };
+
+            event_bus.publish(DomainEvent::DownloadStarted { id: download_id });
+
+            let mut join_set = JoinSet::new();
+            for (index, (start, end)) in segments.iter().enumerate() {
+                join_set.spawn(download_segment(SegmentParams {
+                    client: client.clone(),
+                    file_storage: file_storage.clone(),
+                    event_bus: event_bus.clone(),
+                    download_id,
+                    segment_index: index as u32,
+                    url: url.clone(),
+                    start_byte: *start,
+                    end_byte: *end,
+                    already_downloaded: 0,
+                    total_file_size: total_size,
+                    dest_path: dest_path.clone(),
+                    pause_rx: pause_rx.clone(),
+                    cancel_token: cancel_token.clone(),
+                }));
+            }
+
+            let mut failed = false;
+            let mut error_msg = String::new();
+
+            while let Some(result) = join_set.join_next().await {
+                match result {
+                    Ok(Ok(_bytes)) => {}
+                    Ok(Err(e)) => {
+                        if e != "cancelled" {
+                            if failed {
+                                tracing::warn!(
+                                    download_id = download_id.0,
+                                    previous_error = %error_msg,
+                                    "additional segment failure (overwriting previous error)"
+                                );
+                            }
+                            error_msg = e;
+                            failed = true;
+                        }
+                        cancel_token.cancel();
+                    }
+                    Err(e) => {
+                        error_msg = format!("segment task panicked: {e}");
+                        failed = true;
+                        cancel_token.cancel();
+                    }
+                }
+            }
+
+            if failed {
+                event_bus.publish(DomainEvent::DownloadFailed {
+                    id: download_id,
+                    error: error_msg,
+                });
+            } else if !cancel_token.is_cancelled() {
+                event_bus.publish(DomainEvent::DownloadCompleted { id: download_id });
+            }
+
+            active_downloads.lock().unwrap().remove(&download_id);
+        });
+
+        Ok(())
+    }
+
+    fn pause(&self, id: DownloadId) -> Result<(), DomainError> {
+        let map = self.active_downloads.lock().unwrap();
+        let active = map
+            .get(&id)
+            .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?;
+
+        let _ = active.pause_sender.send(true);
+
+        self.event_bus.publish(DomainEvent::DownloadPaused { id });
+        Ok(())
+    }
+
+    fn cancel(&self, id: DownloadId) -> Result<(), DomainError> {
+        let active = {
+            let mut map = self.active_downloads.lock().unwrap();
+            map.remove(&id)
+                .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?
+        };
+
+        active.cancel_token.cancel();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::Path;
+    use std::sync::Mutex;
+    use std::time::Duration;
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::domain::model::download::{Download, DownloadId, Url};
+    use crate::domain::model::meta::DownloadMeta;
+    use crate::domain::ports::driven::{EventBus, FileStorage};
+
+    // --- Mock types ---
+
+    struct MockFileStorage {
+        writes: Arc<Mutex<Vec<(PathBuf, u64, Vec<u8>)>>>,
+    }
+
+    impl MockFileStorage {
+        fn new() -> Self {
+            Self {
+                writes: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl FileStorage for MockFileStorage {
+        fn create_file(&self, _path: &Path, _size: u64) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn write_segment(&self, path: &Path, offset: u64, data: &[u8]) -> Result<(), DomainError> {
+            self.writes
+                .lock()
+                .unwrap()
+                .push((path.to_path_buf(), offset, data.to_vec()));
+            Ok(())
+        }
+
+        fn read_meta(&self, _path: &Path) -> Result<Option<DownloadMeta>, DomainError> {
+            Ok(None)
+        }
+
+        fn write_meta(&self, _path: &Path, _meta: &DownloadMeta) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn delete_meta(&self, _path: &Path) -> Result<(), DomainError> {
+            Ok(())
+        }
+    }
+
+    struct CollectingEventBus {
+        events: Arc<Mutex<Vec<DomainEvent>>>,
+    }
+
+    impl CollectingEventBus {
+        fn new() -> Self {
+            Self {
+                events: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn collected(&self) -> Vec<DomainEvent> {
+            self.events.lock().unwrap().clone()
+        }
+
+        async fn wait_for_event_async<F>(&self, predicate: F, timeout: Duration) -> bool
+        where
+            F: Fn(&DomainEvent) -> bool,
+        {
+            let deadline = tokio::time::Instant::now() + timeout;
+            loop {
+                if self.collected().iter().any(|e| predicate(e)) {
+                    return true;
+                }
+                if tokio::time::Instant::now() >= deadline {
+                    return false;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+    }
+
+    impl EventBus for CollectingEventBus {
+        fn publish(&self, event: DomainEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+
+        fn subscribe(&self, _handler: Box<dyn Fn(&DomainEvent) + Send + Sync + 'static>) {}
+    }
+
+    fn make_download(id: u64, url: &str) -> Download {
+        let download_id = DownloadId(id);
+        let parsed_url = Url::new(url).unwrap();
+        Download::new(
+            download_id,
+            parsed_url,
+            "test_file.bin".to_string(),
+            "/tmp".to_string(),
+        )
+    }
+
+    fn make_engine(
+        storage: Arc<dyn FileStorage>,
+        bus: Arc<dyn EventBus>,
+    ) -> SegmentedDownloadEngine {
+        SegmentedDownloadEngine::new(reqwest::Client::new(), storage, bus, 4)
+    }
+
+    // --- Tests ---
+
+    #[tokio::test]
+    async fn test_start_spawns_download_and_completes() {
+        let server = MockServer::start().await;
+        let body = vec![b'a'; 1024];
+
+        Mock::given(method("HEAD"))
+            .and(path("/file"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-length", "1024")
+                    .insert_header("accept-ranges", "bytes"),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/file"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let engine = make_engine(storage, bus.clone());
+
+        let url = format!("{}/file", server.uri());
+        let download = make_download(1, &url);
+
+        engine.start(&download).unwrap();
+
+        let found = bus
+            .wait_for_event_async(
+                |e| matches!(e, DomainEvent::DownloadCompleted { id } if id.0 == 1),
+                Duration::from_secs(5),
+            )
+            .await;
+
+        assert!(found, "DownloadCompleted not received");
+
+        let events = bus.collected();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, DomainEvent::DownloadStarted { id } if id.0 == 1)),
+            "DownloadStarted not published"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_start_fallback_single_segment_no_range() {
+        let server = MockServer::start().await;
+        let body = vec![b'b'; 512];
+
+        Mock::given(method("HEAD"))
+            .and(path("/norange"))
+            .respond_with(
+                ResponseTemplate::new(200).insert_header("content-length", "512"),
+                // No accept-ranges header → single segment fallback
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/norange"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let engine = make_engine(storage, bus.clone());
+
+        let url = format!("{}/norange", server.uri());
+        let download = make_download(2, &url);
+
+        engine.start(&download).unwrap();
+
+        let found = bus
+            .wait_for_event_async(
+                |e| {
+                    matches!(
+                        e,
+                        DomainEvent::DownloadCompleted { id } | DomainEvent::DownloadFailed { id, .. }
+                        if id.0 == 2
+                    )
+                },
+                Duration::from_secs(5),
+            )
+            .await;
+
+        assert!(found, "download did not finish");
+
+        let events = bus.collected();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, DomainEvent::DownloadCompleted { id } if id.0 == 2)),
+            "expected DownloadCompleted, events: {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pause_sends_signal() {
+        let server = MockServer::start().await;
+        // Slow server to keep download active
+        let body = vec![b'p'; 64 * 1024];
+
+        Mock::given(method("HEAD"))
+            .and(path("/slow"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-length", &(64 * 1024u64).to_string())
+                    .insert_header("accept-ranges", "bytes"),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/slow"))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .set_body_bytes(body)
+                    .set_delay(Duration::from_secs(10)),
+            )
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let engine = make_engine(storage, bus.clone());
+
+        let url = format!("{}/slow", server.uri());
+        let download = make_download(3, &url);
+
+        engine.start(&download).unwrap();
+
+        // Wait for DownloadStarted before pausing
+        bus.wait_for_event_async(
+            |e| matches!(e, DomainEvent::DownloadStarted { id } if id.0 == 3),
+            Duration::from_secs(3),
+        )
+        .await;
+
+        let pause_result = engine.pause(DownloadId(3));
+        assert!(pause_result.is_ok(), "pause should succeed");
+
+        let events = bus.collected();
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, DomainEvent::DownloadPaused { id } if id.0 == 3)),
+            "DownloadPaused not published"
+        );
+
+        // Clean up
+        let _ = engine.cancel(DownloadId(3));
+    }
+
+    #[tokio::test]
+    async fn test_cancel_stops_download() {
+        let server = MockServer::start().await;
+        let body = vec![b'c'; 64 * 1024];
+
+        Mock::given(method("HEAD"))
+            .and(path("/cancel"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-length", &(64 * 1024u64).to_string())
+                    .insert_header("accept-ranges", "bytes"),
+            )
+            .mount(&server)
+            .await;
+
+        Mock::given(method("GET"))
+            .and(path("/cancel"))
+            .respond_with(
+                ResponseTemplate::new(206)
+                    .set_body_bytes(body)
+                    .set_delay(Duration::from_secs(10)),
+            )
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let engine = make_engine(storage, bus.clone());
+
+        let url = format!("{}/cancel", server.uri());
+        let download = make_download(4, &url);
+
+        engine.start(&download).unwrap();
+
+        // Wait for DownloadStarted
+        bus.wait_for_event_async(
+            |e| matches!(e, DomainEvent::DownloadStarted { id } if id.0 == 4),
+            Duration::from_secs(3),
+        )
+        .await;
+
+        let cancel_result = engine.cancel(DownloadId(4));
+        assert!(cancel_result.is_ok(), "cancel should succeed");
+
+        // After cancel the ID should be removed from active_downloads
+        let cancel_again = engine.cancel(DownloadId(4));
+        assert!(
+            matches!(cancel_again, Err(DomainError::NotFound(_))),
+            "second cancel should return NotFound"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_pause_unknown_id_returns_not_found() {
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let engine = make_engine(storage, bus);
+
+        let result = engine.pause(DownloadId(999));
+        assert!(
+            matches!(result, Err(DomainError::NotFound(_))),
+            "expected NotFound, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cancel_unknown_id_returns_not_found() {
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let engine = make_engine(storage, bus);
+
+        let result = engine.cancel(DownloadId(888));
+        assert!(
+            matches!(result, Err(DomainError::NotFound(_))),
+            "expected NotFound, got {result:?}"
+        );
+    }
+}

--- a/src-tauri/src/adapters/driven/network/download_engine.rs
+++ b/src-tauri/src/adapters/driven/network/download_engine.rs
@@ -121,6 +121,15 @@ impl DownloadEngine for SegmentedDownloadEngine {
                 }
             };
 
+            // Check if cancelled during HEAD request
+            if cancel_token.is_cancelled() {
+                active_downloads
+                    .lock()
+                    .expect("active_downloads lock poisoned")
+                    .remove(&download_id);
+                return;
+            }
+
             // Pre-allocate file if size is known
             if total_size > 0 {
                 let storage = file_storage.clone();
@@ -170,7 +179,9 @@ impl DownloadEngine for SegmentedDownloadEngine {
             };
 
             // Calculate segment byte ranges
-            let segments: Vec<(u64, u64)> = if total_size > 0 {
+            // end_byte == u64::MAX signals the worker to omit the Range header
+            let segments: Vec<(u64, u64)> = if supports_range && total_size > 0 && num_segments > 1
+            {
                 let segment_size = total_size / num_segments as u64;
                 (0..num_segments)
                     .map(|i| {
@@ -183,10 +194,22 @@ impl DownloadEngine for SegmentedDownloadEngine {
                         (start, end)
                     })
                     .collect()
+            } else if supports_range && total_size > 0 {
+                // Single segment with range support: use exact range
+                vec![(0, total_size)]
             } else {
-                // Unknown size: single segment from 0 to u64::MAX (worker will handle stream end)
+                // No range support or unknown size: download without Range header
                 vec![(0, u64::MAX)]
             };
+
+            // Check if cancelled during setup
+            if cancel_token.is_cancelled() {
+                active_downloads
+                    .lock()
+                    .expect("active_downloads lock poisoned")
+                    .remove(&download_id);
+                return;
+            }
 
             event_bus.publish(DomainEvent::DownloadStarted { id: download_id });
 

--- a/src-tauri/src/adapters/driven/network/download_engine.rs
+++ b/src-tauri/src/adapters/driven/network/download_engine.rs
@@ -24,6 +24,7 @@ pub struct SegmentedDownloadEngine {
     file_storage: Arc<dyn FileStorage>,
     event_bus: Arc<dyn EventBus>,
     default_segments: u32,
+    min_segment_bytes: u64,
     active_downloads: Arc<Mutex<HashMap<DownloadId, ActiveDownload>>>,
 }
 
@@ -39,8 +40,14 @@ impl SegmentedDownloadEngine {
             file_storage,
             event_bus,
             default_segments: default_segments.max(1),
+            min_segment_bytes: 64 * 1024,
             active_downloads: Arc::new(Mutex::new(HashMap::new())),
         }
+    }
+
+    pub fn with_min_segment_bytes(mut self, min_bytes: u64) -> Self {
+        self.min_segment_bytes = min_bytes.max(1);
+        self
     }
 }
 
@@ -82,6 +89,7 @@ impl DownloadEngine for SegmentedDownloadEngine {
         let file_storage = self.file_storage.clone();
         let event_bus = self.event_bus.clone();
         let active_downloads = self.active_downloads.clone();
+        let min_segment_bytes = self.min_segment_bytes;
 
         tokio::spawn(async move {
             // Perform HEAD request to determine size and range support
@@ -170,9 +178,8 @@ impl DownloadEngine for SegmentedDownloadEngine {
 
             // Determine number of segments
             let num_segments = if supports_range && total_size > 0 {
-                // At least 64KB per segment
                 segments_count
-                    .min((total_size / (64 * 1024)).max(1) as u32)
+                    .min((total_size / min_segment_bytes).max(1) as u32)
                     .max(1)
             } else {
                 1
@@ -284,21 +291,41 @@ impl DownloadEngine for SegmentedDownloadEngine {
     }
 
     fn pause(&self, id: DownloadId) -> Result<(), DomainError> {
-        let map = self
-            .active_downloads
-            .lock()
-            .expect("active_downloads lock poisoned");
-        let active = map
-            .get(&id)
-            .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?;
-
-        let _ = active.pause_sender.send(true);
-
+        {
+            let map = self
+                .active_downloads
+                .lock()
+                .expect("active_downloads lock poisoned");
+            let active = map
+                .get(&id)
+                .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?;
+            let _ = active.pause_sender.send(true);
+        }
+        // Guard dropped — safe to publish without deadlock risk
         self.event_bus.publish(DomainEvent::DownloadPaused { id });
         Ok(())
     }
 
     fn resume(&self, id: DownloadId) -> Result<(), DomainError> {
+        {
+            let map = self
+                .active_downloads
+                .lock()
+                .expect("active_downloads lock poisoned");
+            let active = map
+                .get(&id)
+                .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?;
+            let _ = active.pause_sender.send(false);
+        }
+        // Guard dropped — safe to publish without deadlock risk
+        self.event_bus.publish(DomainEvent::DownloadResumed { id });
+        Ok(())
+    }
+
+    fn cancel(&self, id: DownloadId) -> Result<(), DomainError> {
+        // Don't remove from map — the spawned task removes itself on exit.
+        // This prevents a new start() for the same ID from racing with
+        // the old task that is still shutting down.
         let map = self
             .active_downloads
             .lock()
@@ -306,23 +333,6 @@ impl DownloadEngine for SegmentedDownloadEngine {
         let active = map
             .get(&id)
             .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?;
-
-        let _ = active.pause_sender.send(false);
-
-        self.event_bus.publish(DomainEvent::DownloadResumed { id });
-        Ok(())
-    }
-
-    fn cancel(&self, id: DownloadId) -> Result<(), DomainError> {
-        let active = {
-            let mut map = self
-                .active_downloads
-                .lock()
-                .expect("active_downloads lock poisoned");
-            map.remove(&id)
-                .ok_or_else(|| DomainError::NotFound(format!("download {}", id.0)))?
-        };
-
         active.cancel_token.cancel();
         Ok(())
     }
@@ -647,11 +657,11 @@ mod tests {
         let cancel_result = engine.cancel(DownloadId(4));
         assert!(cancel_result.is_ok(), "cancel should succeed");
 
-        // After cancel the ID should be removed from active_downloads
+        // Cancel is idempotent — second call succeeds (task removes itself on exit)
         let cancel_again = engine.cancel(DownloadId(4));
         assert!(
-            matches!(cancel_again, Err(DomainError::NotFound(_))),
-            "second cancel should return NotFound"
+            cancel_again.is_ok(),
+            "second cancel should succeed (idempotent)"
         );
     }
 

--- a/src-tauri/src/adapters/driven/network/mod.rs
+++ b/src-tauri/src/adapters/driven/network/mod.rs
@@ -1,0 +1,6 @@
+mod download_engine;
+mod reqwest_client;
+mod segment_worker;
+
+pub use download_engine::SegmentedDownloadEngine;
+pub use reqwest_client::ReqwestHttpClient;

--- a/src-tauri/src/adapters/driven/network/reqwest_client.rs
+++ b/src-tauri/src/adapters/driven/network/reqwest_client.rs
@@ -1,0 +1,255 @@
+//! HTTP client adapter using reqwest.
+//!
+//! Implements the `HttpClient` domain port. Bridges async reqwest calls
+//! to the sync port contract using a dedicated OS thread + `Handle::block_on`.
+//!
+//! # Thread safety constraint
+//!
+//! The `block_on` helper spawns a new OS thread that blocks on the tokio
+//! runtime handle. This is safe from sync call sites (e.g. Tauri command
+//! handlers) but must NOT be called from within an async task on the same
+//! runtime thread, as that would deadlock.
+
+use std::collections::HashMap;
+
+use tokio::runtime::Handle;
+use tracing::debug;
+
+use crate::domain::error::DomainError;
+use crate::domain::model::http::HttpResponse;
+use crate::domain::ports::driven::http_client::HttpClient;
+
+pub struct ReqwestHttpClient {
+    client: reqwest::Client,
+}
+
+impl ReqwestHttpClient {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .user_agent("Vortex/0.1")
+            .connect_timeout(std::time::Duration::from_secs(30))
+            .timeout(std::time::Duration::from_secs(3600))
+            .build()
+            .expect("failed to create HTTP client");
+        Self { client }
+    }
+
+    pub fn with_client(client: reqwest::Client) -> Self {
+        Self { client }
+    }
+}
+
+impl Default for ReqwestHttpClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn map_reqwest_error(err: reqwest::Error) -> DomainError {
+    DomainError::StorageError(format!("HTTP request failed: {err}"))
+}
+
+/// Run an async future on the current tokio runtime from a sync context.
+///
+/// Spawns a new OS thread that blocks on the runtime handle. This avoids
+/// the deadlock risk of calling `block_in_place` on a `current_thread` runtime.
+fn block_on<F>(future: F) -> Result<F::Output, DomainError>
+where
+    F: std::future::Future + Send,
+    F::Output: Send,
+{
+    let handle = Handle::current();
+    std::thread::scope(|s| {
+        s.spawn(|| handle.block_on(future))
+            .join()
+            .map_err(|_| DomainError::StorageError("HTTP thread panicked".into()))
+    })
+}
+
+fn parse_headers(headers: &reqwest::header::HeaderMap) -> HashMap<String, Vec<String>> {
+    let mut map: HashMap<String, Vec<String>> = HashMap::new();
+    for (name, value) in headers {
+        let key = name.as_str().to_string();
+        if let Ok(v) = value.to_str() {
+            map.entry(key).or_default().push(v.to_string());
+        }
+    }
+    map
+}
+
+impl HttpClient for ReqwestHttpClient {
+    fn head(&self, url: &str) -> Result<HttpResponse, DomainError> {
+        debug!(url, "HEAD request");
+        let response = block_on(async {
+            self.client
+                .head(url)
+                .send()
+                .await
+                .map_err(map_reqwest_error)
+        })??;
+
+        let status_code = response.status().as_u16();
+        let headers = parse_headers(response.headers());
+
+        Ok(HttpResponse {
+            status_code,
+            headers,
+            body: Vec::new(),
+        })
+    }
+
+    fn get_range(&self, url: &str, start: u64, end: u64) -> Result<Vec<u8>, DomainError> {
+        debug!(url, start, end, "GET range request");
+        let range_header = format!("bytes={start}-{end}");
+
+        let bytes = block_on(async {
+            let response = self
+                .client
+                .get(url)
+                .header(reqwest::header::RANGE, &range_header)
+                .send()
+                .await
+                .map_err(map_reqwest_error)?;
+
+            if !response.status().is_success() {
+                return Err(DomainError::StorageError(format!(
+                    "HTTP {} for range request on {url}",
+                    response.status()
+                )));
+            }
+
+            response.bytes().await.map_err(map_reqwest_error)
+        })??;
+
+        Ok(bytes.to_vec())
+    }
+
+    fn supports_range(&self, url: &str) -> Result<bool, DomainError> {
+        let response = self.head(url)?;
+        let supported = response
+            .header("accept-ranges")
+            .map(|v| v.eq_ignore_ascii_case("bytes"))
+            .unwrap_or(false);
+        Ok(supported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_head_returns_status_and_headers() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("HEAD"))
+            .and(path("/file.zip"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .append_header("content-length", "1024")
+                    .append_header("accept-ranges", "bytes"),
+            )
+            .mount(&mock_server)
+            .await;
+
+        let client = ReqwestHttpClient::new();
+        let url = format!("{}/file.zip", mock_server.uri());
+        let response = client.head(&url).expect("head should succeed");
+
+        assert_eq!(response.status_code, 200);
+        assert_eq!(response.content_length(), Some(1024));
+        assert_eq!(response.header("accept-ranges"), Some("bytes"));
+        assert!(response.body.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_range_returns_partial_content() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/file.zip"))
+            .and(header("range", "bytes=0-4"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(b"hello".as_slice()))
+            .mount(&mock_server)
+            .await;
+
+        let client = ReqwestHttpClient::new();
+        let url = format!("{}/file.zip", mock_server.uri());
+        let body = client
+            .get_range(&url, 0, 4)
+            .expect("get_range should succeed");
+
+        assert_eq!(body, b"hello");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_get_range_full_response_when_no_range_support() {
+        let mock_server = MockServer::start().await;
+
+        // Server returns 200 (no partial content) — still valid, body returned
+        Mock::given(method("GET"))
+            .and(path("/file.zip"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(b"full body".as_slice()))
+            .mount(&mock_server)
+            .await;
+
+        let client = ReqwestHttpClient::new();
+        let url = format!("{}/file.zip", mock_server.uri());
+        let body = client
+            .get_range(&url, 0, 8)
+            .expect("get_range should succeed on 200");
+
+        assert_eq!(body, b"full body");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_supports_range_returns_true() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("HEAD"))
+            .and(path("/file.zip"))
+            .respond_with(ResponseTemplate::new(200).append_header("accept-ranges", "bytes"))
+            .mount(&mock_server)
+            .await;
+
+        let client = ReqwestHttpClient::new();
+        let url = format!("{}/file.zip", mock_server.uri());
+        let result = client.supports_range(&url).expect("supports_range");
+
+        assert!(result);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_supports_range_returns_false() {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("HEAD"))
+            .and(path("/file.zip"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let client = ReqwestHttpClient::new();
+        let url = format!("{}/file.zip", mock_server.uri());
+        let result = client.supports_range(&url).expect("supports_range");
+
+        assert!(!result);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_head_network_error_returns_domain_error() {
+        let client = ReqwestHttpClient::new();
+        // Use an invalid URL that will fail to connect
+        let result = client.head("http://127.0.0.1:1");
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            DomainError::StorageError(msg) => {
+                assert!(msg.contains("HTTP request failed"));
+            }
+            other => panic!("expected StorageError, got {other:?}"),
+        }
+    }
+}

--- a/src-tauri/src/adapters/driven/network/reqwest_client.rs
+++ b/src-tauri/src/adapters/driven/network/reqwest_client.rs
@@ -46,7 +46,7 @@ impl Default for ReqwestHttpClient {
 }
 
 fn map_reqwest_error(err: reqwest::Error) -> DomainError {
-    DomainError::StorageError(format!("HTTP request failed: {err}"))
+    DomainError::NetworkError(format!("HTTP request failed: {err}"))
 }
 
 /// Run an async future on the current tokio runtime from a sync context.
@@ -58,11 +58,12 @@ where
     F: std::future::Future + Send,
     F::Output: Send,
 {
-    let handle = Handle::current();
+    let handle = Handle::try_current()
+        .map_err(|_| DomainError::NetworkError("no tokio runtime available".into()))?;
     std::thread::scope(|s| {
         s.spawn(|| handle.block_on(future))
             .join()
-            .map_err(|_| DomainError::StorageError("HTTP thread panicked".into()))
+            .map_err(|_| DomainError::NetworkError("HTTP thread panicked".into()))
     })
 }
 
@@ -112,7 +113,7 @@ impl HttpClient for ReqwestHttpClient {
                 .map_err(map_reqwest_error)?;
 
             if !response.status().is_success() {
-                return Err(DomainError::StorageError(format!(
+                return Err(DomainError::NetworkError(format!(
                     "HTTP {} for range request on {url}",
                     response.status()
                 )));
@@ -246,10 +247,10 @@ mod tests {
 
         assert!(result.is_err());
         match result.unwrap_err() {
-            DomainError::StorageError(msg) => {
+            DomainError::NetworkError(msg) => {
                 assert!(msg.contains("HTTP request failed"));
             }
-            other => panic!("expected StorageError, got {other:?}"),
+            other => panic!("expected NetworkError, got {other:?}"),
         }
     }
 }

--- a/src-tauri/src/adapters/driven/network/reqwest_client.rs
+++ b/src-tauri/src/adapters/driven/network/reqwest_client.rs
@@ -112,10 +112,19 @@ impl HttpClient for ReqwestHttpClient {
                 .await
                 .map_err(map_reqwest_error)?;
 
-            if !response.status().is_success() {
+            let status = response.status();
+            if !status.is_success() {
                 return Err(DomainError::NetworkError(format!(
-                    "HTTP {} for range request on {url}",
-                    response.status()
+                    "HTTP {status} for range request on {url}",
+                )));
+            }
+
+            // If we requested a non-zero range but got 200 instead of 206,
+            // the server ignored our Range header — return error to prevent
+            // writing full-body data at a non-zero offset
+            if start > 0 && status == reqwest::StatusCode::OK {
+                return Err(DomainError::NetworkError(format!(
+                    "server returned 200 instead of 206 for range request on {url}",
                 )));
             }
 

--- a/src-tauri/src/adapters/driven/network/segment_worker.rs
+++ b/src-tauri/src/adapters/driven/network/segment_worker.rs
@@ -214,6 +214,21 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Segme
         }
     }
 
+    // Verify we received the expected number of bytes (for ranged segments)
+    let expected_bytes = end_byte
+        .saturating_sub(start_byte)
+        .saturating_sub(already_downloaded);
+    if end_byte != u64::MAX && bytes_downloaded < expected_bytes {
+        let msg =
+            format!("truncated response: got {bytes_downloaded} bytes, expected {expected_bytes}");
+        event_bus.publish(DomainEvent::SegmentFailed {
+            download_id,
+            segment_id: segment_index,
+            error: msg.clone(),
+        });
+        return Err(SegmentError::Http(msg));
+    }
+
     event_bus.publish(DomainEvent::SegmentCompleted {
         download_id,
         segment_id: segment_index,

--- a/src-tauri/src/adapters/driven/network/segment_worker.rs
+++ b/src-tauri/src/adapters/driven/network/segment_worker.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 use tokio::sync::watch;
@@ -8,6 +9,15 @@ use tokio_util::sync::CancellationToken;
 use crate::domain::event::DomainEvent;
 use crate::domain::model::download::DownloadId;
 use crate::domain::ports::driven::{EventBus, FileStorage};
+
+/// Typed error for segment download failures.
+#[derive(Debug, PartialEq)]
+pub(crate) enum SegmentError {
+    Cancelled,
+    Http(String),
+    Storage(String),
+    PauseChannelClosed,
+}
 
 /// Parameters for a single segment download.
 pub(crate) struct SegmentParams {
@@ -26,13 +36,15 @@ pub(crate) struct SegmentParams {
     pub dest_path: PathBuf,
     pub pause_rx: watch::Receiver<bool>,
     pub cancel_token: CancellationToken,
+    /// Shared atomic counter for aggregate progress across all segments.
+    pub shared_downloaded: Arc<AtomicU64>,
 }
 
 /// Downloads a single byte range and writes it to disk.
 ///
 /// Returns the total number of bytes downloaded for this segment.
 /// The caller (DownloadEngine orchestrator) handles retry logic.
-pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, String> {
+pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, SegmentError> {
     let SegmentParams {
         client,
         file_storage,
@@ -45,8 +57,9 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Strin
         already_downloaded,
         total_file_size,
         dest_path,
-        pause_rx,
+        mut pause_rx,
         cancel_token,
+        shared_downloaded,
     } = params;
     event_bus.publish(DomainEvent::SegmentStarted {
         download_id,
@@ -63,29 +76,34 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Strin
         return Ok(0);
     }
 
-    // HTTP Range header is inclusive on both ends
-    let range_header = format!("bytes={}-{}", effective_start, end_byte - 1);
-    tracing::debug!(
-        download_id = download_id.0,
-        segment_id = segment_index,
-        range = %range_header,
-        "starting segment download"
-    );
+    // Build the request, conditionally adding Range header
+    let mut req = client.get(&url);
+    if end_byte != u64::MAX {
+        let range_header = format!("bytes={}-{}", effective_start, end_byte - 1);
+        tracing::debug!(
+            download_id = download_id.0,
+            segment_id = segment_index,
+            range = %range_header,
+            "starting segment download"
+        );
+        req = req.header("Range", &range_header);
+    } else {
+        tracing::debug!(
+            download_id = download_id.0,
+            segment_id = segment_index,
+            "starting full download (no range)"
+        );
+    }
 
-    let response = client
-        .get(&url)
-        .header("Range", &range_header)
-        .send()
-        .await
-        .map_err(|e| {
-            let msg = format!("HTTP request failed: {e}");
-            event_bus.publish(DomainEvent::SegmentFailed {
-                download_id,
-                segment_id: segment_index,
-                error: msg.clone(),
-            });
-            msg
-        })?;
+    let response = req.send().await.map_err(|e| {
+        let msg = format!("HTTP request failed: {e}");
+        event_bus.publish(DomainEvent::SegmentFailed {
+            download_id,
+            segment_id: segment_index,
+            error: msg.clone(),
+        });
+        SegmentError::Http(msg)
+    })?;
 
     let status = response.status();
     if !status.is_success() {
@@ -95,7 +113,18 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Strin
             segment_id: segment_index,
             error: msg.clone(),
         });
-        return Err(msg);
+        return Err(SegmentError::Http(msg));
+    }
+
+    // If we requested a range but got 200 (not 206), the server ignored our Range header
+    if effective_start > 0 && status == reqwest::StatusCode::OK {
+        let msg = "server returned 200 instead of 206 for ranged request".to_string();
+        event_bus.publish(DomainEvent::SegmentFailed {
+            download_id,
+            segment_id: segment_index,
+            error: msg.clone(),
+        });
+        return Err(SegmentError::Http(msg));
     }
 
     let mut offset = effective_start;
@@ -105,24 +134,23 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Strin
 
     loop {
         if cancel_token.is_cancelled() {
-            return Err("cancelled".to_string());
+            return Err(SegmentError::Cancelled);
         }
 
-        // Check pause state — if paused, wait for state change
-        {
-            let paused = *pause_rx.borrow();
-            if paused {
-                let mut rx = pause_rx.clone();
-                loop {
-                    if cancel_token.is_cancelled() {
-                        return Err("cancelled".to_string());
+        // Check pause state — if paused, wait with cancellation support
+        if *pause_rx.borrow() {
+            loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        return Err(SegmentError::Cancelled);
                     }
-                    // Wait for a change in the pause signal
-                    if rx.changed().await.is_err() {
-                        return Err("pause channel closed".to_string());
-                    }
-                    if !*rx.borrow() {
-                        break;
+                    result = pause_rx.changed() => {
+                        if result.is_err() {
+                            return Err(SegmentError::PauseChannelClosed);
+                        }
+                        if !*pause_rx.borrow() {
+                            break;
+                        }
                     }
                 }
             }
@@ -135,7 +163,7 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Strin
                 segment_id: segment_index,
                 error: msg.clone(),
             });
-            msg
+            SegmentError::Http(msg)
         })?;
 
         let Some(chunk) = chunk else {
@@ -150,7 +178,7 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Strin
 
         tokio::task::spawn_blocking(move || storage.write_segment(&path, offset, &data))
             .await
-            .map_err(|e| e.to_string())?
+            .map_err(|e| SegmentError::Storage(e.to_string()))?
             .map_err(|e| {
                 let msg = e.to_string();
                 event_bus.publish(DomainEvent::SegmentFailed {
@@ -158,16 +186,18 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Strin
                     segment_id: segment_index,
                     error: msg.clone(),
                 });
-                msg
+                SegmentError::Storage(msg)
             })?;
 
         offset += chunk_len;
         bytes_downloaded += chunk_len;
 
+        let total_so_far = shared_downloaded.fetch_add(chunk_len, Ordering::Relaxed) + chunk_len;
+
         if last_progress.elapsed() >= Duration::from_millis(500) {
             event_bus.publish(DomainEvent::DownloadProgress {
                 id: download_id,
-                downloaded_bytes: already_downloaded + bytes_downloaded,
+                downloaded_bytes: total_so_far,
                 total_bytes: total_file_size,
             });
             last_progress = Instant::now();
@@ -195,6 +225,7 @@ mod tests {
 
     use std::path::Path;
     use std::sync::Mutex;
+    use std::sync::atomic::AtomicU64;
 
     use wiremock::matchers::{header_exists, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -204,8 +235,10 @@ mod tests {
 
     // --- Mock implementations ---
 
+    type WriteRecord = (PathBuf, u64, Vec<u8>);
+
     struct MockFileStorage {
-        writes: Arc<Mutex<Vec<(PathBuf, u64, Vec<u8>)>>>,
+        writes: Arc<Mutex<Vec<WriteRecord>>>,
     }
 
     impl MockFileStorage {
@@ -306,6 +339,7 @@ mod tests {
             dest_path: dest.clone(),
             pause_rx,
             cancel_token: cancel,
+            shared_downloaded: Arc::new(AtomicU64::new(0)),
         })
         .await;
 
@@ -356,11 +390,12 @@ mod tests {
             dest_path: PathBuf::from("/tmp/cancel_test.bin"),
             pause_rx,
             cancel_token: cancel,
+            shared_downloaded: Arc::new(AtomicU64::new(0)),
         })
         .await;
 
         assert!(result.is_err());
-        assert_eq!(result.unwrap_err(), "cancelled");
+        assert_eq!(result.unwrap_err(), SegmentError::Cancelled);
     }
 
     #[tokio::test]
@@ -406,6 +441,7 @@ mod tests {
             dest_path: PathBuf::from("/tmp/pause_test.bin"),
             pause_rx,
             cancel_token: cancel,
+            shared_downloaded: Arc::new(AtomicU64::new(0)),
         })
         .await;
 
@@ -448,6 +484,7 @@ mod tests {
             dest_path: PathBuf::from("/tmp/progress_test.bin"),
             pause_rx,
             cancel_token: cancel,
+            shared_downloaded: Arc::new(AtomicU64::new(0)),
         })
         .await;
 
@@ -505,6 +542,7 @@ mod tests {
             dest_path: PathBuf::from("/tmp/events_test.bin"),
             pause_rx,
             cancel_token: cancel,
+            shared_downloaded: Arc::new(AtomicU64::new(0)),
         })
         .await;
 
@@ -555,6 +593,7 @@ mod tests {
             dest_path: PathBuf::from("/tmp/done_test.bin"),
             pause_rx,
             cancel_token: cancel,
+            shared_downloaded: Arc::new(AtomicU64::new(0)),
         })
         .await;
 

--- a/src-tauri/src/adapters/driven/network/segment_worker.rs
+++ b/src-tauri/src/adapters/driven/network/segment_worker.rs
@@ -173,8 +173,18 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Segme
 
         let storage = file_storage.clone();
         let path = dest_path.clone();
-        let data = chunk.to_vec();
-        let chunk_len = data.len() as u64;
+        let mut data = chunk.to_vec();
+        let mut chunk_len = data.len() as u64;
+
+        // Clamp writes to segment boundary to prevent writing past end_byte
+        if end_byte != u64::MAX && offset + chunk_len > end_byte {
+            let allowed = end_byte.saturating_sub(offset) as usize;
+            data.truncate(allowed);
+            chunk_len = allowed as u64;
+            if chunk_len == 0 {
+                break;
+            }
+        }
 
         tokio::task::spawn_blocking(move || storage.write_segment(&path, offset, &data))
             .await

--- a/src-tauri/src/adapters/driven/network/segment_worker.rs
+++ b/src-tauri/src/adapters/driven/network/segment_worker.rs
@@ -1,0 +1,591 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+use crate::domain::event::DomainEvent;
+use crate::domain::model::download::DownloadId;
+use crate::domain::ports::driven::{EventBus, FileStorage};
+
+/// Parameters for a single segment download.
+pub(crate) struct SegmentParams {
+    pub client: reqwest::Client,
+    pub file_storage: Arc<dyn FileStorage>,
+    pub event_bus: Arc<dyn EventBus>,
+    pub download_id: DownloadId,
+    pub segment_index: u32,
+    pub url: String,
+    pub start_byte: u64,
+    /// Exclusive upper bound of this segment's byte range.
+    pub end_byte: u64,
+    pub already_downloaded: u64,
+    /// Total size of the entire file (used in progress events).
+    pub total_file_size: u64,
+    pub dest_path: PathBuf,
+    pub pause_rx: watch::Receiver<bool>,
+    pub cancel_token: CancellationToken,
+}
+
+/// Downloads a single byte range and writes it to disk.
+///
+/// Returns the total number of bytes downloaded for this segment.
+/// The caller (DownloadEngine orchestrator) handles retry logic.
+pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, String> {
+    let SegmentParams {
+        client,
+        file_storage,
+        event_bus,
+        download_id,
+        segment_index,
+        url,
+        start_byte,
+        end_byte,
+        already_downloaded,
+        total_file_size,
+        dest_path,
+        pause_rx,
+        cancel_token,
+    } = params;
+    event_bus.publish(DomainEvent::SegmentStarted {
+        download_id,
+        segment_id: segment_index,
+    });
+
+    let effective_start = start_byte + already_downloaded;
+
+    if effective_start >= end_byte {
+        event_bus.publish(DomainEvent::SegmentCompleted {
+            download_id,
+            segment_id: segment_index,
+        });
+        return Ok(0);
+    }
+
+    // HTTP Range header is inclusive on both ends
+    let range_header = format!("bytes={}-{}", effective_start, end_byte - 1);
+    tracing::debug!(
+        download_id = download_id.0,
+        segment_id = segment_index,
+        range = %range_header,
+        "starting segment download"
+    );
+
+    let response = client
+        .get(&url)
+        .header("Range", &range_header)
+        .send()
+        .await
+        .map_err(|e| {
+            let msg = format!("HTTP request failed: {e}");
+            event_bus.publish(DomainEvent::SegmentFailed {
+                download_id,
+                segment_id: segment_index,
+                error: msg.clone(),
+            });
+            msg
+        })?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let msg = format!("HTTP error status: {status}");
+        event_bus.publish(DomainEvent::SegmentFailed {
+            download_id,
+            segment_id: segment_index,
+            error: msg.clone(),
+        });
+        return Err(msg);
+    }
+
+    let mut offset = effective_start;
+    let mut bytes_downloaded: u64 = 0;
+    let mut last_progress = Instant::now();
+    let mut response = response;
+
+    loop {
+        if cancel_token.is_cancelled() {
+            return Err("cancelled".to_string());
+        }
+
+        // Check pause state — if paused, wait for state change
+        {
+            let paused = *pause_rx.borrow();
+            if paused {
+                let mut rx = pause_rx.clone();
+                loop {
+                    if cancel_token.is_cancelled() {
+                        return Err("cancelled".to_string());
+                    }
+                    // Wait for a change in the pause signal
+                    if rx.changed().await.is_err() {
+                        return Err("pause channel closed".to_string());
+                    }
+                    if !*rx.borrow() {
+                        break;
+                    }
+                }
+            }
+        }
+
+        let chunk = response.chunk().await.map_err(|e| {
+            let msg = format!("chunk read error: {e}");
+            event_bus.publish(DomainEvent::SegmentFailed {
+                download_id,
+                segment_id: segment_index,
+                error: msg.clone(),
+            });
+            msg
+        })?;
+
+        let Some(chunk) = chunk else {
+            // Stream ended
+            break;
+        };
+
+        let storage = file_storage.clone();
+        let path = dest_path.clone();
+        let data = chunk.to_vec();
+        let chunk_len = data.len() as u64;
+
+        tokio::task::spawn_blocking(move || storage.write_segment(&path, offset, &data))
+            .await
+            .map_err(|e| e.to_string())?
+            .map_err(|e| {
+                let msg = e.to_string();
+                event_bus.publish(DomainEvent::SegmentFailed {
+                    download_id,
+                    segment_id: segment_index,
+                    error: msg.clone(),
+                });
+                msg
+            })?;
+
+        offset += chunk_len;
+        bytes_downloaded += chunk_len;
+
+        if last_progress.elapsed() >= Duration::from_millis(500) {
+            event_bus.publish(DomainEvent::DownloadProgress {
+                id: download_id,
+                downloaded_bytes: already_downloaded + bytes_downloaded,
+                total_bytes: total_file_size,
+            });
+            last_progress = Instant::now();
+        }
+    }
+
+    event_bus.publish(DomainEvent::SegmentCompleted {
+        download_id,
+        segment_id: segment_index,
+    });
+
+    tracing::debug!(
+        download_id = download_id.0,
+        segment_id = segment_index,
+        bytes = bytes_downloaded,
+        "segment download complete"
+    );
+
+    Ok(bytes_downloaded)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    use wiremock::matchers::{header_exists, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    use crate::domain::error::DomainError;
+    use crate::domain::model::meta::DownloadMeta;
+
+    // --- Mock implementations ---
+
+    struct MockFileStorage {
+        writes: Arc<Mutex<Vec<(PathBuf, u64, Vec<u8>)>>>,
+    }
+
+    impl MockFileStorage {
+        fn new() -> Self {
+            Self {
+                writes: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+    }
+
+    impl FileStorage for MockFileStorage {
+        fn create_file(&self, _path: &Path, _size: u64) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn write_segment(&self, path: &Path, offset: u64, data: &[u8]) -> Result<(), DomainError> {
+            self.writes
+                .lock()
+                .unwrap()
+                .push((path.to_path_buf(), offset, data.to_vec()));
+            Ok(())
+        }
+
+        fn read_meta(&self, _path: &Path) -> Result<Option<DownloadMeta>, DomainError> {
+            Ok(None)
+        }
+
+        fn write_meta(&self, _path: &Path, _meta: &DownloadMeta) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn delete_meta(&self, _path: &Path) -> Result<(), DomainError> {
+            Ok(())
+        }
+    }
+
+    struct CollectingEventBus {
+        events: Arc<Mutex<Vec<DomainEvent>>>,
+    }
+
+    impl CollectingEventBus {
+        fn new() -> Self {
+            Self {
+                events: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn collected(&self) -> Vec<DomainEvent> {
+            self.events.lock().unwrap().clone()
+        }
+    }
+
+    impl EventBus for CollectingEventBus {
+        fn publish(&self, event: DomainEvent) {
+            self.events.lock().unwrap().push(event);
+        }
+
+        fn subscribe(&self, _handler: Box<dyn Fn(&DomainEvent) + Send + Sync + 'static>) {}
+    }
+
+    // --- Helpers ---
+
+    fn make_client() -> reqwest::Client {
+        reqwest::Client::new()
+    }
+
+    // --- Tests ---
+
+    #[tokio::test]
+    async fn test_segment_downloads_and_writes_to_file() {
+        let server = MockServer::start().await;
+        let body = vec![b'a'; 1000];
+
+        Mock::given(method("GET"))
+            .and(path("/file"))
+            .and(header_exists("Range"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(body.clone()))
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let (_, pause_rx) = watch::channel(false);
+        let cancel = CancellationToken::new();
+        let dest = PathBuf::from("/tmp/test_segment.bin");
+
+        let result = download_segment(SegmentParams {
+            client: make_client(),
+            file_storage: storage.clone(),
+            event_bus: bus.clone(),
+            download_id: DownloadId(1),
+            segment_index: 0,
+            url: format!("{}/file", server.uri()),
+            start_byte: 0,
+            end_byte: 1000,
+            already_downloaded: 0,
+            total_file_size: 0,
+            dest_path: dest.clone(),
+            pause_rx,
+            cancel_token: cancel,
+        })
+        .await;
+
+        assert!(result.is_ok(), "expected Ok, got {result:?}");
+        assert_eq!(result.unwrap(), 1000);
+
+        let writes = storage.writes.lock().unwrap();
+        assert!(!writes.is_empty(), "expected writes to file");
+
+        let total_written: u64 = writes.iter().map(|(_, _, data)| data.len() as u64).sum();
+        assert_eq!(total_written, 1000);
+
+        // First write must start at offset 0
+        assert_eq!(writes[0].1, 0);
+    }
+
+    #[tokio::test]
+    async fn test_segment_cancellation_stops_download() {
+        let server = MockServer::start().await;
+        // Serve a large body so streaming has multiple chunks
+        let body = vec![b'x'; 100_000];
+
+        Mock::given(method("GET"))
+            .and(path("/file"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let (_, pause_rx) = watch::channel(false);
+        let cancel = CancellationToken::new();
+
+        // Cancel immediately
+        cancel.cancel();
+
+        let result = download_segment(SegmentParams {
+            client: make_client(),
+            file_storage: storage.clone(),
+            event_bus: bus.clone(),
+            download_id: DownloadId(2),
+            segment_index: 0,
+            url: format!("{}/file", server.uri()),
+            start_byte: 0,
+            end_byte: 100_000,
+            already_downloaded: 0,
+            total_file_size: 0,
+            dest_path: PathBuf::from("/tmp/cancel_test.bin"),
+            pause_rx,
+            cancel_token: cancel,
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "cancelled");
+    }
+
+    #[tokio::test]
+    async fn test_segment_pause_and_resume() {
+        let server = MockServer::start().await;
+        let body = vec![b'p'; 1000];
+
+        Mock::given(method("GET"))
+            .and(path("/file"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let (pause_tx, pause_rx) = watch::channel(false);
+        let cancel = CancellationToken::new();
+
+        // Start paused, then resume after a short delay
+        pause_tx.send(true).unwrap();
+
+        let cancel_clone = cancel.clone();
+        let pause_tx_clone = pause_tx.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            pause_tx_clone.send(false).unwrap();
+            // Give the download time to complete, then cancel if not done
+            tokio::time::sleep(Duration::from_millis(500)).await;
+            cancel_clone.cancel();
+        });
+
+        let result = download_segment(SegmentParams {
+            client: make_client(),
+            file_storage: storage.clone(),
+            event_bus: bus.clone(),
+            download_id: DownloadId(3),
+            segment_index: 0,
+            url: format!("{}/file", server.uri()),
+            start_byte: 0,
+            end_byte: 1000,
+            already_downloaded: 0,
+            total_file_size: 0,
+            dest_path: PathBuf::from("/tmp/pause_test.bin"),
+            pause_rx,
+            cancel_token: cancel,
+        })
+        .await;
+
+        // Should complete after being unpaused, not be cancelled
+        // (cancel fires at 550ms, download should finish in <500ms after unpausing)
+        assert!(
+            result.is_ok(),
+            "expected completion after resume, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_segment_publishes_progress_events() {
+        let server = MockServer::start().await;
+        // Body larger than a single chunk to trigger progress events
+        let body = vec![b'z'; 10_000];
+
+        Mock::given(method("GET"))
+            .and(path("/file"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let (_, pause_rx) = watch::channel(false);
+        let cancel = CancellationToken::new();
+
+        let _result = download_segment(SegmentParams {
+            client: make_client(),
+            file_storage: storage.clone(),
+            event_bus: bus.clone(),
+            download_id: DownloadId(4),
+            segment_index: 0,
+            url: format!("{}/file", server.uri()),
+            start_byte: 0,
+            end_byte: 10_000,
+            already_downloaded: 0,
+            total_file_size: 0,
+            dest_path: PathBuf::from("/tmp/progress_test.bin"),
+            pause_rx,
+            cancel_token: cancel,
+        })
+        .await;
+
+        let events = bus.collected();
+        // At least SegmentStarted and SegmentCompleted must be present
+        let has_started = events.iter().any(|e| {
+            matches!(
+                e,
+                DomainEvent::SegmentStarted {
+                    download_id: DownloadId(4),
+                    segment_id: 0
+                }
+            )
+        });
+        let has_completed = events.iter().any(|e| {
+            matches!(
+                e,
+                DomainEvent::SegmentCompleted {
+                    download_id: DownloadId(4),
+                    segment_id: 0
+                }
+            )
+        });
+        assert!(has_started, "SegmentStarted not published");
+        assert!(has_completed, "SegmentCompleted not published");
+    }
+
+    #[tokio::test]
+    async fn test_segment_publishes_start_and_complete() {
+        let server = MockServer::start().await;
+        let body = vec![b's'; 512];
+
+        Mock::given(method("GET"))
+            .and(path("/file"))
+            .respond_with(ResponseTemplate::new(206).set_body_bytes(body))
+            .mount(&server)
+            .await;
+
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let (_, pause_rx) = watch::channel(false);
+        let cancel = CancellationToken::new();
+
+        let result = download_segment(SegmentParams {
+            client: make_client(),
+            file_storage: storage.clone(),
+            event_bus: bus.clone(),
+            download_id: DownloadId(5),
+            segment_index: 1,
+            url: format!("{}/file", server.uri()),
+            start_byte: 0,
+            end_byte: 512,
+            already_downloaded: 0,
+            total_file_size: 0,
+            dest_path: PathBuf::from("/tmp/events_test.bin"),
+            pause_rx,
+            cancel_token: cancel,
+        })
+        .await;
+
+        assert!(result.is_ok());
+
+        let events = bus.collected();
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                DomainEvent::SegmentStarted {
+                    download_id: DownloadId(5),
+                    segment_id: 1
+                }
+            )),
+            "SegmentStarted missing"
+        );
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                DomainEvent::SegmentCompleted {
+                    download_id: DownloadId(5),
+                    segment_id: 1
+                }
+            )),
+            "SegmentCompleted missing"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_segment_already_completed() {
+        // already_downloaded == end_byte - start_byte  →  segment done, return Ok(0)
+        let storage = Arc::new(MockFileStorage::new());
+        let bus = Arc::new(CollectingEventBus::new());
+        let (_, pause_rx) = watch::channel(false);
+        let cancel = CancellationToken::new();
+
+        let result = download_segment(SegmentParams {
+            client: make_client(),
+            file_storage: storage.clone(),
+            event_bus: bus.clone(),
+            download_id: DownloadId(6),
+            segment_index: 0,
+            url: "http://unused.example.com/file".to_string(),
+            start_byte: 0,
+            end_byte: 1000,
+            already_downloaded: 1000, // already fully downloaded
+            total_file_size: 1000,
+            dest_path: PathBuf::from("/tmp/done_test.bin"),
+            pause_rx,
+            cancel_token: cancel,
+        })
+        .await;
+
+        assert_eq!(
+            result,
+            Ok(0),
+            "expected Ok(0) for already-completed segment"
+        );
+
+        let events = bus.collected();
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                DomainEvent::SegmentStarted {
+                    download_id: DownloadId(6),
+                    segment_id: 0
+                }
+            )),
+            "SegmentStarted missing"
+        );
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                DomainEvent::SegmentCompleted {
+                    download_id: DownloadId(6),
+                    segment_id: 0
+                }
+            )),
+            "SegmentCompleted missing"
+        );
+        // No writes to storage
+        assert!(storage.writes.lock().unwrap().is_empty());
+    }
+}

--- a/src-tauri/src/application/command_bus.rs
+++ b/src-tauri/src/application/command_bus.rs
@@ -170,6 +170,10 @@ mod tests {
             Ok(())
         }
 
+        fn resume(&self, _id: DownloadId) -> Result<(), DomainError> {
+            Ok(())
+        }
+
         fn cancel(&self, _id: DownloadId) -> Result<(), DomainError> {
             Ok(())
         }

--- a/src-tauri/src/domain/error.rs
+++ b/src-tauri/src/domain/error.rs
@@ -19,6 +19,7 @@ pub enum DomainError {
     NotFound(String),
     AlreadyExists(String),
     StorageError(String),
+    NetworkError(String),
     ValidationError(String),
 }
 
@@ -48,6 +49,9 @@ impl std::fmt::Display for DomainError {
             }
             DomainError::StorageError(msg) => {
                 write!(f, "Storage error: {msg}")
+            }
+            DomainError::NetworkError(msg) => {
+                write!(f, "Network error: {msg}")
             }
             DomainError::ValidationError(msg) => {
                 write!(f, "Validation error: {msg}")

--- a/src-tauri/src/domain/ports/driven/download_engine.rs
+++ b/src-tauri/src/domain/ports/driven/download_engine.rs
@@ -28,6 +28,9 @@ pub trait DownloadEngine: Send + Sync {
     /// Pause an active download, preserving segment progress.
     fn pause(&self, id: DownloadId) -> Result<(), DomainError>;
 
+    /// Resume a previously paused download.
+    fn resume(&self, id: DownloadId) -> Result<(), DomainError>;
+
     /// Cancel an active download and discard partial data.
     fn cancel(&self, id: DownloadId) -> Result<(), DomainError>;
 }

--- a/src-tauri/src/domain/ports/driven/mod.rs
+++ b/src-tauri/src/domain/ports/driven/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 mod tests;
 
 pub mod clipboard_observer;

--- a/src-tauri/src/domain/ports/driven/tests.rs
+++ b/src-tauri/src/domain/ports/driven/tests.rs
@@ -3,787 +3,788 @@
 //! Verifies that each trait can be implemented with an in-memory mock,
 //! and that all mocks satisfy Send + Sync bounds.
 
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-    use std::path::Path;
-    use std::sync::Mutex;
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Mutex;
 
-    use crate::domain::error::DomainError;
-    use crate::domain::event::DomainEvent;
-    use crate::domain::model::config::{AppConfig, ConfigPatch};
-    use crate::domain::model::credential::Credential;
-    use crate::domain::model::download::{Download, DownloadId, DownloadState};
-    use crate::domain::model::http::HttpResponse;
-    use crate::domain::model::meta::DownloadMeta;
-    use crate::domain::model::plugin::{PluginCategory, PluginInfo, PluginManifest};
-    use crate::domain::model::views::{
-        DownloadDetailView, DownloadFilter, DownloadView, HistoryEntry, SortOrder, StateCountMap,
-        StatsView,
-    };
-    use crate::domain::ports::driven::*;
+use crate::domain::error::DomainError;
+use crate::domain::event::DomainEvent;
+use crate::domain::model::config::{AppConfig, ConfigPatch};
+use crate::domain::model::credential::Credential;
+use crate::domain::model::download::{Download, DownloadId, DownloadState};
+use crate::domain::model::http::HttpResponse;
+use crate::domain::model::meta::DownloadMeta;
+use crate::domain::model::plugin::{PluginCategory, PluginInfo, PluginManifest};
+use crate::domain::model::views::{
+    DownloadDetailView, DownloadFilter, DownloadView, HistoryEntry, SortOrder, StateCountMap,
+    StatsView,
+};
+use crate::domain::ports::driven::*;
 
-    // ── InMemoryDownloadRepository ───────────────────────────────────
+// ── InMemoryDownloadRepository ───────────────────────────────────
 
-    struct InMemoryDownloadRepository {
-        store: Mutex<HashMap<u64, Download>>,
-    }
+struct InMemoryDownloadRepository {
+    store: Mutex<HashMap<u64, Download>>,
+}
 
-    impl InMemoryDownloadRepository {
-        fn new() -> Self {
-            Self {
-                store: Mutex::new(HashMap::new()),
-            }
+impl InMemoryDownloadRepository {
+    fn new() -> Self {
+        Self {
+            store: Mutex::new(HashMap::new()),
         }
     }
+}
 
-    impl DownloadRepository for InMemoryDownloadRepository {
-        fn find_by_id(&self, id: DownloadId) -> Result<Option<Download>, DomainError> {
-            Ok(self.store.lock().unwrap().get(&id.0).cloned())
-        }
-
-        fn save(&self, download: &Download) -> Result<(), DomainError> {
-            self.store
-                .lock()
-                .unwrap()
-                .insert(download.id().0, download.clone());
-            Ok(())
-        }
-
-        fn delete(&self, id: DownloadId) -> Result<(), DomainError> {
-            self.store.lock().unwrap().remove(&id.0);
-            Ok(())
-        }
-
-        fn find_by_state(&self, state: DownloadState) -> Result<Vec<Download>, DomainError> {
-            Ok(self
-                .store
-                .lock()
-                .unwrap()
-                .values()
-                .filter(|d| d.state() == state)
-                .cloned()
-                .collect())
-        }
+impl DownloadRepository for InMemoryDownloadRepository {
+    fn find_by_id(&self, id: DownloadId) -> Result<Option<Download>, DomainError> {
+        Ok(self.store.lock().unwrap().get(&id.0).cloned())
     }
 
-    // ── InMemoryDownloadReadRepository ──────────────────────────────
-
-    struct InMemoryDownloadReadRepository;
-
-    impl DownloadReadRepository for InMemoryDownloadReadRepository {
-        fn find_downloads(
-            &self,
-            _filter: Option<DownloadFilter>,
-            _sort: Option<SortOrder>,
-            _limit: Option<usize>,
-            _offset: Option<usize>,
-        ) -> Result<Vec<DownloadView>, DomainError> {
-            Ok(vec![])
-        }
-
-        fn find_download_detail(
-            &self,
-            _id: DownloadId,
-        ) -> Result<Option<DownloadDetailView>, DomainError> {
-            Ok(None)
-        }
-
-        fn count_by_state(&self) -> Result<StateCountMap, DomainError> {
-            Ok(HashMap::new())
-        }
-    }
-
-    // ── CollectingEventBus ──────────────────────────────────────────
-
-    struct CollectingEventBus {
-        events: Mutex<Vec<DomainEvent>>,
-    }
-
-    impl CollectingEventBus {
-        fn new() -> Self {
-            Self {
-                events: Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    impl EventBus for CollectingEventBus {
-        fn publish(&self, event: DomainEvent) {
-            self.events.lock().unwrap().push(event);
-        }
-
-        fn subscribe(&self, _handler: Box<dyn Fn(&DomainEvent) + Send + Sync>) {
-            // No-op for testing
-        }
-    }
-
-    // ── InMemoryFileStorage ─────────────────────────────────────────
-
-    struct InMemoryFileStorage {
-        files: Mutex<HashMap<String, Vec<u8>>>,
-        metas: Mutex<HashMap<String, DownloadMeta>>,
-    }
-
-    impl InMemoryFileStorage {
-        fn new() -> Self {
-            Self {
-                files: Mutex::new(HashMap::new()),
-                metas: Mutex::new(HashMap::new()),
-            }
-        }
-    }
-
-    impl FileStorage for InMemoryFileStorage {
-        fn create_file(&self, path: &Path, size: u64) -> Result<(), DomainError> {
-            self.files.lock().unwrap().insert(
-                path.to_string_lossy().into_owned(),
-                vec![0u8; size as usize],
-            );
-            Ok(())
-        }
-
-        fn write_segment(&self, path: &Path, offset: u64, data: &[u8]) -> Result<(), DomainError> {
-            let key = path.to_string_lossy().into_owned();
-            let mut files = self.files.lock().unwrap();
-            if let Some(file) = files.get_mut(&key) {
-                let start = offset as usize;
-                let end = start + data.len();
-                if end <= file.len() {
-                    file[start..end].copy_from_slice(data);
-                }
-            }
-            Ok(())
-        }
-
-        fn read_meta(&self, path: &Path) -> Result<Option<DownloadMeta>, DomainError> {
-            Ok(self
-                .metas
-                .lock()
-                .unwrap()
-                .get(&path.to_string_lossy().into_owned())
-                .cloned())
-        }
-
-        fn write_meta(&self, path: &Path, meta: &DownloadMeta) -> Result<(), DomainError> {
-            self.metas
-                .lock()
-                .unwrap()
-                .insert(path.to_string_lossy().into_owned(), meta.clone());
-            Ok(())
-        }
-
-        fn delete_meta(&self, path: &Path) -> Result<(), DomainError> {
-            self.metas
-                .lock()
-                .unwrap()
-                .remove(&path.to_string_lossy().into_owned());
-            Ok(())
-        }
-    }
-
-    // ── FakeHttpClient ──────────────────────────────────────────────
-
-    struct FakeHttpClient;
-
-    impl HttpClient for FakeHttpClient {
-        fn head(&self, _url: &str) -> Result<HttpResponse, DomainError> {
-            Ok(HttpResponse {
-                status_code: 200,
-                headers: HashMap::from([
-                    ("content-length".to_string(), vec!["1024".to_string()]),
-                    ("accept-ranges".to_string(), vec!["bytes".to_string()]),
-                ]),
-                body: vec![],
-            })
-        }
-
-        fn get_range(&self, _url: &str, start: u64, end: u64) -> Result<Vec<u8>, DomainError> {
-            let size = (end - start + 1) as usize;
-            Ok(vec![0xAB; size])
-        }
-
-        fn supports_range(&self, _url: &str) -> Result<bool, DomainError> {
-            Ok(true)
-        }
-    }
-
-    // ── InMemoryCredentialStore ─────────────────────────────────────
-
-    struct InMemoryCredentialStore {
-        store: Mutex<HashMap<String, Credential>>,
-    }
-
-    impl InMemoryCredentialStore {
-        fn new() -> Self {
-            Self {
-                store: Mutex::new(HashMap::new()),
-            }
-        }
-    }
-
-    impl CredentialStore for InMemoryCredentialStore {
-        fn get(&self, service: &str) -> Result<Option<Credential>, DomainError> {
-            Ok(self.store.lock().unwrap().get(service).cloned())
-        }
-
-        fn store(&self, service: &str, credential: &Credential) -> Result<(), DomainError> {
-            self.store
-                .lock()
-                .unwrap()
-                .insert(service.to_string(), credential.clone());
-            Ok(())
-        }
-
-        fn delete(&self, service: &str) -> Result<(), DomainError> {
-            self.store.lock().unwrap().remove(service);
-            Ok(())
-        }
-    }
-
-    // ── InMemoryConfigStore ───────────────────────────────────────────
-
-    struct InMemoryConfigStore {
-        config: Mutex<AppConfig>,
-    }
-
-    impl InMemoryConfigStore {
-        fn new() -> Self {
-            Self {
-                config: Mutex::new(AppConfig::default()),
-            }
-        }
-    }
-
-    impl ConfigStore for InMemoryConfigStore {
-        fn get_config(&self) -> Result<AppConfig, DomainError> {
-            Ok(self.config.lock().unwrap().clone())
-        }
-
-        fn update_config(&self, patch: ConfigPatch) -> Result<AppConfig, DomainError> {
-            let mut config = self.config.lock().unwrap();
-            if let Some(dir) = patch.download_dir {
-                config.download_dir = dir;
-            }
-            if let Some(max) = patch.max_concurrent_downloads {
-                config.max_concurrent_downloads = max;
-            }
-            if let Some(max) = patch.max_segments_per_download {
-                config.max_segments_per_download = max;
-            }
-            if let Some(limit) = patch.speed_limit_bytes_per_sec {
-                config.speed_limit_bytes_per_sec = limit;
-            }
-            if let Some(auto) = patch.auto_extract {
-                config.auto_extract = auto;
-            }
-            if let Some(theme) = patch.theme {
-                config.theme = theme;
-            }
-            if let Some(locale) = patch.locale {
-                config.locale = locale;
-            }
-            if let Some(monitoring) = patch.clipboard_monitoring {
-                config.clipboard_monitoring = monitoring;
-            }
-            if let Some(minimize) = patch.minimize_to_tray {
-                config.minimize_to_tray = minimize;
-            }
-            Ok(config.clone())
-        }
-    }
-
-    // ── InMemoryHistoryRepository ───────────────────────────────────
-
-    struct InMemoryHistoryRepository {
-        entries: Mutex<Vec<HistoryEntry>>,
-    }
-
-    impl InMemoryHistoryRepository {
-        fn new() -> Self {
-            Self {
-                entries: Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    impl HistoryRepository for InMemoryHistoryRepository {
-        fn record(&self, entry: &HistoryEntry) -> Result<(), DomainError> {
-            self.entries.lock().unwrap().push(entry.clone());
-            Ok(())
-        }
-
-        fn find_recent(&self, limit: usize) -> Result<Vec<HistoryEntry>, DomainError> {
-            let entries = self.entries.lock().unwrap();
-            Ok(entries.iter().rev().take(limit).cloned().collect())
-        }
-
-        fn find_by_download(&self, id: DownloadId) -> Result<Vec<HistoryEntry>, DomainError> {
-            let entries = self.entries.lock().unwrap();
-            Ok(entries
-                .iter()
-                .filter(|e| e.download_id == id)
-                .cloned()
-                .collect())
-        }
-
-        fn delete_older_than(&self, before_timestamp: u64) -> Result<u64, DomainError> {
-            let mut entries = self.entries.lock().unwrap();
-            let before = entries.len();
-            entries.retain(|e| e.completed_at >= before_timestamp);
-            Ok((before - entries.len()) as u64)
-        }
-    }
-
-    // ── InMemoryStatsRepository ─────────────────────────────────────
-
-    struct InMemoryStatsRepository {
-        total_bytes: Mutex<u64>,
-        total_files: Mutex<u64>,
-    }
-
-    impl InMemoryStatsRepository {
-        fn new() -> Self {
-            Self {
-                total_bytes: Mutex::new(0),
-                total_files: Mutex::new(0),
-            }
-        }
-    }
-
-    impl StatsRepository for InMemoryStatsRepository {
-        fn record_completed(&self, bytes: u64, _avg_speed: u64) -> Result<(), DomainError> {
-            *self.total_bytes.lock().unwrap() += bytes;
-            *self.total_files.lock().unwrap() += 1;
-            Ok(())
-        }
-
-        fn get_stats(&self) -> Result<StatsView, DomainError> {
-            Ok(StatsView {
-                total_downloaded_bytes: *self.total_bytes.lock().unwrap(),
-                total_files: *self.total_files.lock().unwrap(),
-                avg_speed: 0,
-                peak_speed: 0,
-                success_rate: 1.0,
-                daily_volumes: vec![],
-                top_hosts: vec![],
-            })
-        }
-    }
-
-    // ── FakeClipboardObserver ───────────────────────────────────────
-
-    struct FakeClipboardObserver {
-        urls: Mutex<Vec<String>>,
-        running: Mutex<bool>,
-    }
-
-    impl FakeClipboardObserver {
-        fn new() -> Self {
-            Self {
-                urls: Mutex::new(Vec::new()),
-                running: Mutex::new(false),
-            }
-        }
-    }
-
-    impl ClipboardObserver for FakeClipboardObserver {
-        fn start(&self) -> Result<(), DomainError> {
-            *self.running.lock().unwrap() = true;
-            Ok(())
-        }
-
-        fn stop(&self) -> Result<(), DomainError> {
-            *self.running.lock().unwrap() = false;
-            Ok(())
-        }
-
-        fn get_urls(&self) -> Result<Vec<String>, DomainError> {
-            Ok(self.urls.lock().unwrap().drain(..).collect())
-        }
-    }
-
-    // ── FakePluginLoader ────────────────────────────────────────────
-
-    struct FakePluginLoader {
-        plugins: Mutex<HashMap<String, PluginInfo>>,
-    }
-
-    impl FakePluginLoader {
-        fn new() -> Self {
-            Self {
-                plugins: Mutex::new(HashMap::new()),
-            }
-        }
-    }
-
-    impl PluginLoader for FakePluginLoader {
-        fn load(&self, manifest: &PluginManifest) -> Result<(), DomainError> {
-            let info = manifest.info().clone();
-            self.plugins
-                .lock()
-                .unwrap()
-                .insert(info.name().to_string(), info);
-            Ok(())
-        }
-
-        fn unload(&self, name: &str) -> Result<(), DomainError> {
-            self.plugins.lock().unwrap().remove(name);
-            Ok(())
-        }
-
-        fn resolve_url(&self, _url: &str) -> Result<Option<PluginInfo>, DomainError> {
-            Ok(None)
-        }
-
-        fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
-            Ok(self.plugins.lock().unwrap().values().cloned().collect())
-        }
-    }
-
-    // ── FakeDownloadEngine ──────────────────────────────────────────
-
-    struct FakeDownloadEngine {
-        started: Mutex<Vec<DownloadId>>,
-    }
-
-    impl FakeDownloadEngine {
-        fn new() -> Self {
-            Self {
-                started: Mutex::new(Vec::new()),
-            }
-        }
-    }
-
-    impl DownloadEngine for FakeDownloadEngine {
-        fn start(&self, download: &Download) -> Result<(), DomainError> {
-            self.started.lock().unwrap().push(download.id());
-            Ok(())
-        }
-
-        fn pause(&self, _id: DownloadId) -> Result<(), DomainError> {
-            Ok(())
-        }
-
-        fn cancel(&self, _id: DownloadId) -> Result<(), DomainError> {
-            Ok(())
-        }
-    }
-
-    // ── Send + Sync compile-time assertions ─────────────────────────
-
-    fn assert_send_sync<T: Send + Sync>() {}
-
-    #[test]
-    fn all_driven_port_mocks_are_send_sync() {
-        assert_send_sync::<InMemoryDownloadRepository>();
-        assert_send_sync::<InMemoryDownloadReadRepository>();
-        assert_send_sync::<CollectingEventBus>();
-        assert_send_sync::<InMemoryFileStorage>();
-        assert_send_sync::<FakeHttpClient>();
-        assert_send_sync::<InMemoryCredentialStore>();
-        assert_send_sync::<InMemoryConfigStore>();
-        assert_send_sync::<InMemoryHistoryRepository>();
-        assert_send_sync::<InMemoryStatsRepository>();
-        assert_send_sync::<FakeClipboardObserver>();
-        assert_send_sync::<FakePluginLoader>();
-        assert_send_sync::<FakeDownloadEngine>();
-    }
-
-    // ── Functional tests ────────────────────────────────────────────
-
-    #[test]
-    fn download_repository_save_and_find() {
-        let repo = InMemoryDownloadRepository::new();
-        let url = crate::domain::model::download::Url::new("https://example.com/file.zip").unwrap();
-        let download = Download::new(
-            DownloadId(1),
-            url,
-            "file.zip".to_string(),
-            "/tmp".to_string(),
-        );
-
-        repo.save(&download).unwrap();
-        let found = repo.find_by_id(DownloadId(1)).unwrap();
-        assert!(found.is_some());
-        assert_eq!(found.unwrap().file_name(), "file.zip");
-    }
-
-    #[test]
-    fn download_repository_find_by_state() {
-        let repo = InMemoryDownloadRepository::new();
-        let url = crate::domain::model::download::Url::new("https://example.com/a.zip").unwrap();
-        let download = Download::new(DownloadId(1), url, "a.zip".to_string(), "/tmp".to_string());
-
-        repo.save(&download).unwrap();
-        let queued = repo.find_by_state(DownloadState::Queued).unwrap();
-        assert_eq!(queued.len(), 1);
-
-        let downloading = repo.find_by_state(DownloadState::Downloading).unwrap();
-        assert!(downloading.is_empty());
-    }
-
-    #[test]
-    fn download_repository_delete() {
-        let repo = InMemoryDownloadRepository::new();
-        let url = crate::domain::model::download::Url::new("https://example.com/b.zip").unwrap();
-        let download = Download::new(DownloadId(2), url, "b.zip".to_string(), "/tmp".to_string());
-
-        repo.save(&download).unwrap();
-        repo.delete(DownloadId(2)).unwrap();
-        assert!(repo.find_by_id(DownloadId(2)).unwrap().is_none());
-    }
-
-    #[test]
-    fn download_read_repository_has_no_save_method() {
-        // This is a compile-time check: DownloadReadRepository doesn't expose save().
-        // If someone adds save() to the trait, this test file won't compile
-        // because InMemoryDownloadReadRepository doesn't implement it.
-        let repo = InMemoryDownloadReadRepository;
-        let _ = repo.count_by_state().unwrap();
-    }
-
-    #[test]
-    fn event_bus_collects_events() {
-        let bus = CollectingEventBus::new();
-        bus.publish(DomainEvent::DownloadStarted { id: DownloadId(1) });
-        bus.publish(DomainEvent::DownloadCompleted { id: DownloadId(1) });
-        assert_eq!(bus.events.lock().unwrap().len(), 2);
-    }
-
-    #[test]
-    fn file_storage_create_and_write() {
-        let storage = InMemoryFileStorage::new();
-        let path = Path::new("/tmp/test.bin");
-
-        storage.create_file(path, 1024).unwrap();
-        storage.write_segment(path, 0, &[1, 2, 3, 4]).unwrap();
-
-        let file = storage.files.lock().unwrap();
-        let data = file.get("/tmp/test.bin").unwrap();
-        assert_eq!(&data[0..4], &[1, 2, 3, 4]);
-        assert_eq!(data.len(), 1024);
-    }
-
-    #[test]
-    fn file_storage_meta_roundtrip() {
-        let storage = InMemoryFileStorage::new();
-        let path = Path::new("/tmp/test.vortex-meta");
-        let meta = DownloadMeta {
-            download_id: DownloadId(42),
-            url: "https://example.com/file.zip".to_string(),
-            file_name: "file.zip".to_string(),
-            total_bytes: Some(1024),
-            segments: vec![],
-            checksum_expected: None,
-            created_at: 100,
-            updated_at: 200,
-        };
-
-        storage.write_meta(path, &meta).unwrap();
-        let loaded = storage.read_meta(path).unwrap().unwrap();
-        assert_eq!(loaded.download_id, DownloadId(42));
-        assert_eq!(loaded.total_bytes, Some(1024));
-
-        storage.delete_meta(path).unwrap();
-        assert!(storage.read_meta(path).unwrap().is_none());
-    }
-
-    #[test]
-    fn http_client_head_and_range() {
-        let client = FakeHttpClient;
-
-        let head = client.head("https://example.com/file.zip").unwrap();
-        assert_eq!(head.status_code, 200);
-        assert!(head.is_success());
-        assert_eq!(head.content_length(), Some(1024));
-
-        let range_data = client
-            .get_range("https://example.com/file.zip", 0, 99)
-            .unwrap();
-        assert_eq!(range_data.len(), 100);
-
-        assert!(
-            client
-                .supports_range("https://example.com/file.zip")
-                .unwrap()
-        );
-    }
-
-    #[test]
-    fn credential_store_crud() {
-        let store = InMemoryCredentialStore::new();
-        let cred = Credential::new("test-user", "test-value");
-
-        assert!(store.get("mega").unwrap().is_none());
-
-        store.store("mega", &cred).unwrap();
-        let loaded = store.get("mega").unwrap().unwrap();
-        assert_eq!(loaded.username(), "test-user");
-        assert_eq!(loaded.password(), "test-value");
-
-        store.delete("mega").unwrap();
-        assert!(store.get("mega").unwrap().is_none());
-    }
-
-    #[test]
-    fn config_store_get_and_update() {
-        let store = InMemoryConfigStore::new();
-        let config = store.get_config().unwrap();
-        assert_eq!(config.max_concurrent_downloads, 3);
-
-        let patch = ConfigPatch {
-            max_concurrent_downloads: Some(10),
-            download_dir: Some(Some("/downloads".to_string())),
-            ..Default::default()
-        };
-        let updated = store.update_config(patch).unwrap();
-        assert_eq!(updated.max_concurrent_downloads, 10);
-        assert_eq!(updated.download_dir, Some("/downloads".to_string()));
-    }
-
-    #[test]
-    fn history_repository_record_and_find() {
-        let repo = InMemoryHistoryRepository::new();
-        let entry = HistoryEntry {
-            download_id: DownloadId(1),
-            file_name: "file.zip".to_string(),
-            url: "https://example.com/file.zip".to_string(),
-            total_bytes: 1024,
-            completed_at: 1000,
-            duration_seconds: 60,
-            avg_speed: 17,
-            destination_path: "/tmp/file.zip".to_string(),
-        };
-
-        repo.record(&entry).unwrap();
-        let recent = repo.find_recent(10).unwrap();
-        assert_eq!(recent.len(), 1);
-        assert_eq!(recent[0].file_name, "file.zip");
-
-        let by_dl = repo.find_by_download(DownloadId(1)).unwrap();
-        assert_eq!(by_dl.len(), 1);
-
-        let deleted = repo.delete_older_than(2000).unwrap();
-        assert_eq!(deleted, 1);
-        assert!(repo.find_recent(10).unwrap().is_empty());
-    }
-
-    #[test]
-    fn stats_repository_record_and_get() {
-        let repo = InMemoryStatsRepository::new();
-        repo.record_completed(1024, 512).unwrap();
-        repo.record_completed(2048, 1024).unwrap();
-
-        let stats = repo.get_stats().unwrap();
-        assert_eq!(stats.total_downloaded_bytes, 3072);
-        assert_eq!(stats.total_files, 2);
-    }
-
-    #[test]
-    fn clipboard_observer_lifecycle() {
-        let observer = FakeClipboardObserver::new();
-        observer.start().unwrap();
-        assert!(*observer.running.lock().unwrap());
-
-        // Simulate clipboard detection
-        observer
-            .urls
+    fn save(&self, download: &Download) -> Result<(), DomainError> {
+        self.store
             .lock()
             .unwrap()
-            .push("https://example.com".to_string());
-        let urls = observer.get_urls().unwrap();
-        assert_eq!(urls.len(), 1);
-
-        // Buffer drained after get_urls
-        assert!(observer.get_urls().unwrap().is_empty());
-
-        observer.stop().unwrap();
-        assert!(!*observer.running.lock().unwrap());
+            .insert(download.id().0, download.clone());
+        Ok(())
     }
 
-    #[test]
-    fn plugin_loader_lifecycle() {
-        let loader = FakePluginLoader::new();
-        let info = PluginInfo::new(
-            "test-plugin".to_string(),
-            "1.0.0".to_string(),
-            "A test plugin".to_string(),
-            "author".to_string(),
-            PluginCategory::Crawler,
+    fn delete(&self, id: DownloadId) -> Result<(), DomainError> {
+        self.store.lock().unwrap().remove(&id.0);
+        Ok(())
+    }
+
+    fn find_by_state(&self, state: DownloadState) -> Result<Vec<Download>, DomainError> {
+        Ok(self
+            .store
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|d| d.state() == state)
+            .cloned()
+            .collect())
+    }
+}
+
+// ── InMemoryDownloadReadRepository ──────────────────────────────
+
+struct InMemoryDownloadReadRepository;
+
+impl DownloadReadRepository for InMemoryDownloadReadRepository {
+    fn find_downloads(
+        &self,
+        _filter: Option<DownloadFilter>,
+        _sort: Option<SortOrder>,
+        _limit: Option<usize>,
+        _offset: Option<usize>,
+    ) -> Result<Vec<DownloadView>, DomainError> {
+        Ok(vec![])
+    }
+
+    fn find_download_detail(
+        &self,
+        _id: DownloadId,
+    ) -> Result<Option<DownloadDetailView>, DomainError> {
+        Ok(None)
+    }
+
+    fn count_by_state(&self) -> Result<StateCountMap, DomainError> {
+        Ok(HashMap::new())
+    }
+}
+
+// ── CollectingEventBus ──────────────────────────────────────────
+
+struct CollectingEventBus {
+    events: Mutex<Vec<DomainEvent>>,
+}
+
+impl CollectingEventBus {
+    fn new() -> Self {
+        Self {
+            events: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl EventBus for CollectingEventBus {
+    fn publish(&self, event: DomainEvent) {
+        self.events.lock().unwrap().push(event);
+    }
+
+    fn subscribe(&self, _handler: Box<dyn Fn(&DomainEvent) + Send + Sync>) {
+        // No-op for testing
+    }
+}
+
+// ── InMemoryFileStorage ─────────────────────────────────────────
+
+struct InMemoryFileStorage {
+    files: Mutex<HashMap<String, Vec<u8>>>,
+    metas: Mutex<HashMap<String, DownloadMeta>>,
+}
+
+impl InMemoryFileStorage {
+    fn new() -> Self {
+        Self {
+            files: Mutex::new(HashMap::new()),
+            metas: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl FileStorage for InMemoryFileStorage {
+    fn create_file(&self, path: &Path, size: u64) -> Result<(), DomainError> {
+        self.files.lock().unwrap().insert(
+            path.to_string_lossy().into_owned(),
+            vec![0u8; size as usize],
         );
-        let manifest = PluginManifest::new(info);
-
-        loader.load(&manifest).unwrap();
-        let loaded = loader.list_loaded().unwrap();
-        assert_eq!(loaded.len(), 1);
-        assert_eq!(loaded[0].name(), "test-plugin");
-
-        assert!(loader.resolve_url("https://example.com").unwrap().is_none());
-
-        loader.unload("test-plugin").unwrap();
-        assert!(loader.list_loaded().unwrap().is_empty());
+        Ok(())
     }
 
-    #[test]
-    fn download_engine_fire_and_forget() {
-        let engine = FakeDownloadEngine::new();
-        let url = crate::domain::model::download::Url::new("https://example.com/big.iso").unwrap();
-        let download = Download::new(
-            DownloadId(42),
-            url,
-            "big.iso".to_string(),
-            "/tmp".to_string(),
-        );
-
-        engine.start(&download).unwrap();
-        assert_eq!(engine.started.lock().unwrap().len(), 1);
-        assert_eq!(engine.started.lock().unwrap()[0], DownloadId(42));
-
-        engine.pause(DownloadId(42)).unwrap();
-        engine.cancel(DownloadId(42)).unwrap();
-    }
-
-    #[test]
-    fn credential_debug_redacts_password() {
-        let cred = Credential::new("test-user", "test-credential-value");
-        let debug_output = format!("{cred:?}");
-        assert!(debug_output.contains("user"));
-        assert!(debug_output.contains("<redacted>"));
-        assert!(!debug_output.contains("test-credential-value"));
-    }
-
-    // ── Driving port compile-time checks ────────────────────────────
-
-    #[test]
-    fn driving_port_traits_compile() {
-        use crate::domain::ports::driving::{Command, CommandHandler, Query, QueryHandler};
-
-        // Verify marker traits can be implemented
-        struct TestCommand;
-        impl Command for TestCommand {}
-
-        struct TestQuery;
-        impl Query for TestQuery {}
-
-        // Verify handler traits can be implemented
-        struct TestCommandHandler;
-        impl CommandHandler<TestCommand> for TestCommandHandler {
-            type Output = u64;
-            async fn handle(&self, _cmd: TestCommand) -> Result<u64, DomainError> {
-                Ok(42)
+    fn write_segment(&self, path: &Path, offset: u64, data: &[u8]) -> Result<(), DomainError> {
+        let key = path.to_string_lossy().into_owned();
+        let mut files = self.files.lock().unwrap();
+        if let Some(file) = files.get_mut(&key) {
+            let start = offset as usize;
+            let end = start + data.len();
+            if end <= file.len() {
+                file[start..end].copy_from_slice(data);
             }
         }
-
-        struct TestQueryHandler;
-        impl QueryHandler<TestQuery> for TestQueryHandler {
-            type Output = String;
-            async fn handle(&self, _query: TestQuery) -> Result<String, DomainError> {
-                Ok("result".to_string())
-            }
-        }
-
-        assert_send_sync::<TestCommandHandler>();
-        assert_send_sync::<TestQueryHandler>();
+        Ok(())
     }
+
+    fn read_meta(&self, path: &Path) -> Result<Option<DownloadMeta>, DomainError> {
+        Ok(self
+            .metas
+            .lock()
+            .unwrap()
+            .get(&path.to_string_lossy().into_owned())
+            .cloned())
+    }
+
+    fn write_meta(&self, path: &Path, meta: &DownloadMeta) -> Result<(), DomainError> {
+        self.metas
+            .lock()
+            .unwrap()
+            .insert(path.to_string_lossy().into_owned(), meta.clone());
+        Ok(())
+    }
+
+    fn delete_meta(&self, path: &Path) -> Result<(), DomainError> {
+        self.metas
+            .lock()
+            .unwrap()
+            .remove(&path.to_string_lossy().into_owned());
+        Ok(())
+    }
+}
+
+// ── FakeHttpClient ──────────────────────────────────────────────
+
+struct FakeHttpClient;
+
+impl HttpClient for FakeHttpClient {
+    fn head(&self, _url: &str) -> Result<HttpResponse, DomainError> {
+        Ok(HttpResponse {
+            status_code: 200,
+            headers: HashMap::from([
+                ("content-length".to_string(), vec!["1024".to_string()]),
+                ("accept-ranges".to_string(), vec!["bytes".to_string()]),
+            ]),
+            body: vec![],
+        })
+    }
+
+    fn get_range(&self, _url: &str, start: u64, end: u64) -> Result<Vec<u8>, DomainError> {
+        let size = (end - start + 1) as usize;
+        Ok(vec![0xAB; size])
+    }
+
+    fn supports_range(&self, _url: &str) -> Result<bool, DomainError> {
+        Ok(true)
+    }
+}
+
+// ── InMemoryCredentialStore ─────────────────────────────────────
+
+struct InMemoryCredentialStore {
+    store: Mutex<HashMap<String, Credential>>,
+}
+
+impl InMemoryCredentialStore {
+    fn new() -> Self {
+        Self {
+            store: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl CredentialStore for InMemoryCredentialStore {
+    fn get(&self, service: &str) -> Result<Option<Credential>, DomainError> {
+        Ok(self.store.lock().unwrap().get(service).cloned())
+    }
+
+    fn store(&self, service: &str, credential: &Credential) -> Result<(), DomainError> {
+        self.store
+            .lock()
+            .unwrap()
+            .insert(service.to_string(), credential.clone());
+        Ok(())
+    }
+
+    fn delete(&self, service: &str) -> Result<(), DomainError> {
+        self.store.lock().unwrap().remove(service);
+        Ok(())
+    }
+}
+
+// ── InMemoryConfigStore ───────────────────────────────────────────
+
+struct InMemoryConfigStore {
+    config: Mutex<AppConfig>,
+}
+
+impl InMemoryConfigStore {
+    fn new() -> Self {
+        Self {
+            config: Mutex::new(AppConfig::default()),
+        }
+    }
+}
+
+impl ConfigStore for InMemoryConfigStore {
+    fn get_config(&self) -> Result<AppConfig, DomainError> {
+        Ok(self.config.lock().unwrap().clone())
+    }
+
+    fn update_config(&self, patch: ConfigPatch) -> Result<AppConfig, DomainError> {
+        let mut config = self.config.lock().unwrap();
+        if let Some(dir) = patch.download_dir {
+            config.download_dir = dir;
+        }
+        if let Some(max) = patch.max_concurrent_downloads {
+            config.max_concurrent_downloads = max;
+        }
+        if let Some(max) = patch.max_segments_per_download {
+            config.max_segments_per_download = max;
+        }
+        if let Some(limit) = patch.speed_limit_bytes_per_sec {
+            config.speed_limit_bytes_per_sec = limit;
+        }
+        if let Some(auto) = patch.auto_extract {
+            config.auto_extract = auto;
+        }
+        if let Some(theme) = patch.theme {
+            config.theme = theme;
+        }
+        if let Some(locale) = patch.locale {
+            config.locale = locale;
+        }
+        if let Some(monitoring) = patch.clipboard_monitoring {
+            config.clipboard_monitoring = monitoring;
+        }
+        if let Some(minimize) = patch.minimize_to_tray {
+            config.minimize_to_tray = minimize;
+        }
+        Ok(config.clone())
+    }
+}
+
+// ── InMemoryHistoryRepository ───────────────────────────────────
+
+struct InMemoryHistoryRepository {
+    entries: Mutex<Vec<HistoryEntry>>,
+}
+
+impl InMemoryHistoryRepository {
+    fn new() -> Self {
+        Self {
+            entries: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl HistoryRepository for InMemoryHistoryRepository {
+    fn record(&self, entry: &HistoryEntry) -> Result<(), DomainError> {
+        self.entries.lock().unwrap().push(entry.clone());
+        Ok(())
+    }
+
+    fn find_recent(&self, limit: usize) -> Result<Vec<HistoryEntry>, DomainError> {
+        let entries = self.entries.lock().unwrap();
+        Ok(entries.iter().rev().take(limit).cloned().collect())
+    }
+
+    fn find_by_download(&self, id: DownloadId) -> Result<Vec<HistoryEntry>, DomainError> {
+        let entries = self.entries.lock().unwrap();
+        Ok(entries
+            .iter()
+            .filter(|e| e.download_id == id)
+            .cloned()
+            .collect())
+    }
+
+    fn delete_older_than(&self, before_timestamp: u64) -> Result<u64, DomainError> {
+        let mut entries = self.entries.lock().unwrap();
+        let before = entries.len();
+        entries.retain(|e| e.completed_at >= before_timestamp);
+        Ok((before - entries.len()) as u64)
+    }
+}
+
+// ── InMemoryStatsRepository ─────────────────────────────────────
+
+struct InMemoryStatsRepository {
+    total_bytes: Mutex<u64>,
+    total_files: Mutex<u64>,
+}
+
+impl InMemoryStatsRepository {
+    fn new() -> Self {
+        Self {
+            total_bytes: Mutex::new(0),
+            total_files: Mutex::new(0),
+        }
+    }
+}
+
+impl StatsRepository for InMemoryStatsRepository {
+    fn record_completed(&self, bytes: u64, _avg_speed: u64) -> Result<(), DomainError> {
+        *self.total_bytes.lock().unwrap() += bytes;
+        *self.total_files.lock().unwrap() += 1;
+        Ok(())
+    }
+
+    fn get_stats(&self) -> Result<StatsView, DomainError> {
+        Ok(StatsView {
+            total_downloaded_bytes: *self.total_bytes.lock().unwrap(),
+            total_files: *self.total_files.lock().unwrap(),
+            avg_speed: 0,
+            peak_speed: 0,
+            success_rate: 1.0,
+            daily_volumes: vec![],
+            top_hosts: vec![],
+        })
+    }
+}
+
+// ── FakeClipboardObserver ───────────────────────────────────────
+
+struct FakeClipboardObserver {
+    urls: Mutex<Vec<String>>,
+    running: Mutex<bool>,
+}
+
+impl FakeClipboardObserver {
+    fn new() -> Self {
+        Self {
+            urls: Mutex::new(Vec::new()),
+            running: Mutex::new(false),
+        }
+    }
+}
+
+impl ClipboardObserver for FakeClipboardObserver {
+    fn start(&self) -> Result<(), DomainError> {
+        *self.running.lock().unwrap() = true;
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<(), DomainError> {
+        *self.running.lock().unwrap() = false;
+        Ok(())
+    }
+
+    fn get_urls(&self) -> Result<Vec<String>, DomainError> {
+        Ok(self.urls.lock().unwrap().drain(..).collect())
+    }
+}
+
+// ── FakePluginLoader ────────────────────────────────────────────
+
+struct FakePluginLoader {
+    plugins: Mutex<HashMap<String, PluginInfo>>,
+}
+
+impl FakePluginLoader {
+    fn new() -> Self {
+        Self {
+            plugins: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl PluginLoader for FakePluginLoader {
+    fn load(&self, manifest: &PluginManifest) -> Result<(), DomainError> {
+        let info = manifest.info().clone();
+        self.plugins
+            .lock()
+            .unwrap()
+            .insert(info.name().to_string(), info);
+        Ok(())
+    }
+
+    fn unload(&self, name: &str) -> Result<(), DomainError> {
+        self.plugins.lock().unwrap().remove(name);
+        Ok(())
+    }
+
+    fn resolve_url(&self, _url: &str) -> Result<Option<PluginInfo>, DomainError> {
+        Ok(None)
+    }
+
+    fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
+        Ok(self.plugins.lock().unwrap().values().cloned().collect())
+    }
+}
+
+// ── FakeDownloadEngine ──────────────────────────────────────────
+
+struct FakeDownloadEngine {
+    started: Mutex<Vec<DownloadId>>,
+}
+
+impl FakeDownloadEngine {
+    fn new() -> Self {
+        Self {
+            started: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl DownloadEngine for FakeDownloadEngine {
+    fn start(&self, download: &Download) -> Result<(), DomainError> {
+        self.started.lock().unwrap().push(download.id());
+        Ok(())
+    }
+
+    fn pause(&self, _id: DownloadId) -> Result<(), DomainError> {
+        Ok(())
+    }
+
+    fn resume(&self, _id: DownloadId) -> Result<(), DomainError> {
+        Ok(())
+    }
+
+    fn cancel(&self, _id: DownloadId) -> Result<(), DomainError> {
+        Ok(())
+    }
+}
+
+// ── Send + Sync compile-time assertions ─────────────────────────
+
+fn assert_send_sync<T: Send + Sync>() {}
+
+#[test]
+fn all_driven_port_mocks_are_send_sync() {
+    assert_send_sync::<InMemoryDownloadRepository>();
+    assert_send_sync::<InMemoryDownloadReadRepository>();
+    assert_send_sync::<CollectingEventBus>();
+    assert_send_sync::<InMemoryFileStorage>();
+    assert_send_sync::<FakeHttpClient>();
+    assert_send_sync::<InMemoryCredentialStore>();
+    assert_send_sync::<InMemoryConfigStore>();
+    assert_send_sync::<InMemoryHistoryRepository>();
+    assert_send_sync::<InMemoryStatsRepository>();
+    assert_send_sync::<FakeClipboardObserver>();
+    assert_send_sync::<FakePluginLoader>();
+    assert_send_sync::<FakeDownloadEngine>();
+}
+
+// ── Functional tests ────────────────────────────────────────────
+
+#[test]
+fn download_repository_save_and_find() {
+    let repo = InMemoryDownloadRepository::new();
+    let url = crate::domain::model::download::Url::new("https://example.com/file.zip").unwrap();
+    let download = Download::new(
+        DownloadId(1),
+        url,
+        "file.zip".to_string(),
+        "/tmp".to_string(),
+    );
+
+    repo.save(&download).unwrap();
+    let found = repo.find_by_id(DownloadId(1)).unwrap();
+    assert!(found.is_some());
+    assert_eq!(found.unwrap().file_name(), "file.zip");
+}
+
+#[test]
+fn download_repository_find_by_state() {
+    let repo = InMemoryDownloadRepository::new();
+    let url = crate::domain::model::download::Url::new("https://example.com/a.zip").unwrap();
+    let download = Download::new(DownloadId(1), url, "a.zip".to_string(), "/tmp".to_string());
+
+    repo.save(&download).unwrap();
+    let queued = repo.find_by_state(DownloadState::Queued).unwrap();
+    assert_eq!(queued.len(), 1);
+
+    let downloading = repo.find_by_state(DownloadState::Downloading).unwrap();
+    assert!(downloading.is_empty());
+}
+
+#[test]
+fn download_repository_delete() {
+    let repo = InMemoryDownloadRepository::new();
+    let url = crate::domain::model::download::Url::new("https://example.com/b.zip").unwrap();
+    let download = Download::new(DownloadId(2), url, "b.zip".to_string(), "/tmp".to_string());
+
+    repo.save(&download).unwrap();
+    repo.delete(DownloadId(2)).unwrap();
+    assert!(repo.find_by_id(DownloadId(2)).unwrap().is_none());
+}
+
+#[test]
+fn download_read_repository_has_no_save_method() {
+    // This is a compile-time check: DownloadReadRepository doesn't expose save().
+    // If someone adds save() to the trait, this test file won't compile
+    // because InMemoryDownloadReadRepository doesn't implement it.
+    let repo = InMemoryDownloadReadRepository;
+    let _ = repo.count_by_state().unwrap();
+}
+
+#[test]
+fn event_bus_collects_events() {
+    let bus = CollectingEventBus::new();
+    bus.publish(DomainEvent::DownloadStarted { id: DownloadId(1) });
+    bus.publish(DomainEvent::DownloadCompleted { id: DownloadId(1) });
+    assert_eq!(bus.events.lock().unwrap().len(), 2);
+}
+
+#[test]
+fn file_storage_create_and_write() {
+    let storage = InMemoryFileStorage::new();
+    let path = Path::new("/tmp/test.bin");
+
+    storage.create_file(path, 1024).unwrap();
+    storage.write_segment(path, 0, &[1, 2, 3, 4]).unwrap();
+
+    let file = storage.files.lock().unwrap();
+    let data = file.get("/tmp/test.bin").unwrap();
+    assert_eq!(&data[0..4], &[1, 2, 3, 4]);
+    assert_eq!(data.len(), 1024);
+}
+
+#[test]
+fn file_storage_meta_roundtrip() {
+    let storage = InMemoryFileStorage::new();
+    let path = Path::new("/tmp/test.vortex-meta");
+    let meta = DownloadMeta {
+        download_id: DownloadId(42),
+        url: "https://example.com/file.zip".to_string(),
+        file_name: "file.zip".to_string(),
+        total_bytes: Some(1024),
+        segments: vec![],
+        checksum_expected: None,
+        created_at: 100,
+        updated_at: 200,
+    };
+
+    storage.write_meta(path, &meta).unwrap();
+    let loaded = storage.read_meta(path).unwrap().unwrap();
+    assert_eq!(loaded.download_id, DownloadId(42));
+    assert_eq!(loaded.total_bytes, Some(1024));
+
+    storage.delete_meta(path).unwrap();
+    assert!(storage.read_meta(path).unwrap().is_none());
+}
+
+#[test]
+fn http_client_head_and_range() {
+    let client = FakeHttpClient;
+
+    let head = client.head("https://example.com/file.zip").unwrap();
+    assert_eq!(head.status_code, 200);
+    assert!(head.is_success());
+    assert_eq!(head.content_length(), Some(1024));
+
+    let range_data = client
+        .get_range("https://example.com/file.zip", 0, 99)
+        .unwrap();
+    assert_eq!(range_data.len(), 100);
+
+    assert!(
+        client
+            .supports_range("https://example.com/file.zip")
+            .unwrap()
+    );
+}
+
+#[test]
+fn credential_store_crud() {
+    let store = InMemoryCredentialStore::new();
+    let cred = Credential::new("test-user", "test-value");
+
+    assert!(store.get("mega").unwrap().is_none());
+
+    store.store("mega", &cred).unwrap();
+    let loaded = store.get("mega").unwrap().unwrap();
+    assert_eq!(loaded.username(), "test-user");
+    assert_eq!(loaded.password(), "test-value");
+
+    store.delete("mega").unwrap();
+    assert!(store.get("mega").unwrap().is_none());
+}
+
+#[test]
+fn config_store_get_and_update() {
+    let store = InMemoryConfigStore::new();
+    let config = store.get_config().unwrap();
+    assert_eq!(config.max_concurrent_downloads, 3);
+
+    let patch = ConfigPatch {
+        max_concurrent_downloads: Some(10),
+        download_dir: Some(Some("/downloads".to_string())),
+        ..Default::default()
+    };
+    let updated = store.update_config(patch).unwrap();
+    assert_eq!(updated.max_concurrent_downloads, 10);
+    assert_eq!(updated.download_dir, Some("/downloads".to_string()));
+}
+
+#[test]
+fn history_repository_record_and_find() {
+    let repo = InMemoryHistoryRepository::new();
+    let entry = HistoryEntry {
+        download_id: DownloadId(1),
+        file_name: "file.zip".to_string(),
+        url: "https://example.com/file.zip".to_string(),
+        total_bytes: 1024,
+        completed_at: 1000,
+        duration_seconds: 60,
+        avg_speed: 17,
+        destination_path: "/tmp/file.zip".to_string(),
+    };
+
+    repo.record(&entry).unwrap();
+    let recent = repo.find_recent(10).unwrap();
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].file_name, "file.zip");
+
+    let by_dl = repo.find_by_download(DownloadId(1)).unwrap();
+    assert_eq!(by_dl.len(), 1);
+
+    let deleted = repo.delete_older_than(2000).unwrap();
+    assert_eq!(deleted, 1);
+    assert!(repo.find_recent(10).unwrap().is_empty());
+}
+
+#[test]
+fn stats_repository_record_and_get() {
+    let repo = InMemoryStatsRepository::new();
+    repo.record_completed(1024, 512).unwrap();
+    repo.record_completed(2048, 1024).unwrap();
+
+    let stats = repo.get_stats().unwrap();
+    assert_eq!(stats.total_downloaded_bytes, 3072);
+    assert_eq!(stats.total_files, 2);
+}
+
+#[test]
+fn clipboard_observer_lifecycle() {
+    let observer = FakeClipboardObserver::new();
+    observer.start().unwrap();
+    assert!(*observer.running.lock().unwrap());
+
+    // Simulate clipboard detection
+    observer
+        .urls
+        .lock()
+        .unwrap()
+        .push("https://example.com".to_string());
+    let urls = observer.get_urls().unwrap();
+    assert_eq!(urls.len(), 1);
+
+    // Buffer drained after get_urls
+    assert!(observer.get_urls().unwrap().is_empty());
+
+    observer.stop().unwrap();
+    assert!(!*observer.running.lock().unwrap());
+}
+
+#[test]
+fn plugin_loader_lifecycle() {
+    let loader = FakePluginLoader::new();
+    let info = PluginInfo::new(
+        "test-plugin".to_string(),
+        "1.0.0".to_string(),
+        "A test plugin".to_string(),
+        "author".to_string(),
+        PluginCategory::Crawler,
+    );
+    let manifest = PluginManifest::new(info);
+
+    loader.load(&manifest).unwrap();
+    let loaded = loader.list_loaded().unwrap();
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].name(), "test-plugin");
+
+    assert!(loader.resolve_url("https://example.com").unwrap().is_none());
+
+    loader.unload("test-plugin").unwrap();
+    assert!(loader.list_loaded().unwrap().is_empty());
+}
+
+#[test]
+fn download_engine_fire_and_forget() {
+    let engine = FakeDownloadEngine::new();
+    let url = crate::domain::model::download::Url::new("https://example.com/big.iso").unwrap();
+    let download = Download::new(
+        DownloadId(42),
+        url,
+        "big.iso".to_string(),
+        "/tmp".to_string(),
+    );
+
+    engine.start(&download).unwrap();
+    assert_eq!(engine.started.lock().unwrap().len(), 1);
+    assert_eq!(engine.started.lock().unwrap()[0], DownloadId(42));
+
+    engine.pause(DownloadId(42)).unwrap();
+    engine.cancel(DownloadId(42)).unwrap();
+}
+
+#[test]
+fn credential_debug_redacts_password() {
+    let cred = Credential::new("test-user", "test-credential-value");
+    let debug_output = format!("{cred:?}");
+    assert!(debug_output.contains("user"));
+    assert!(debug_output.contains("<redacted>"));
+    assert!(!debug_output.contains("test-credential-value"));
+}
+
+// ── Driving port compile-time checks ────────────────────────────
+
+#[test]
+fn driving_port_traits_compile() {
+    use crate::domain::ports::driving::{Command, CommandHandler, Query, QueryHandler};
+
+    // Verify marker traits can be implemented
+    struct TestCommand;
+    impl Command for TestCommand {}
+
+    struct TestQuery;
+    impl Query for TestQuery {}
+
+    // Verify handler traits can be implemented
+    struct TestCommandHandler;
+    impl CommandHandler<TestCommand> for TestCommandHandler {
+        type Output = u64;
+        async fn handle(&self, _cmd: TestCommand) -> Result<u64, DomainError> {
+            Ok(42)
+        }
+    }
+
+    struct TestQueryHandler;
+    impl QueryHandler<TestQuery> for TestQueryHandler {
+        type Output = String;
+        async fn handle(&self, _query: TestQuery) -> Result<String, DomainError> {
+            Ok("result".to_string())
+        }
+    }
+
+    assert_send_sync::<TestCommandHandler>();
+    assert_send_sync::<TestQueryHandler>();
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,8 @@ pub mod domain;
 // Public API — concrete types for app wiring (main.rs, Tauri setup, integration tests)
 pub use adapters::driven::event::TokioEventBus;
 pub use adapters::driven::event::spawn_tauri_event_bridge;
+pub use adapters::driven::network::ReqwestHttpClient;
+pub use adapters::driven::network::SegmentedDownloadEngine;
 pub use adapters::driven::sqlite::connection;
 pub use adapters::driven::sqlite::download_read_repo::SqliteDownloadReadRepo;
 pub use adapters::driven::sqlite::download_repo::SqliteDownloadRepo;


### PR DESCRIPTION
## Summary
- Implement `ReqwestHttpClient` adapter (HttpClient port): HEAD requests, byte-range GET, range detection with connect/request timeouts
- Implement `SegmentedDownloadEngine` adapter (DownloadEngine port): parallel segment downloads via JoinSet, pause via watch channel, cancel via CancellationToken, HEAD-based size detection, single-segment fallback
- Implement `segment_worker` async function: streaming HTTP chunks, spawn_blocking file writes, throttled progress events (500ms), pause/resume and cancellation support
- Add dependencies: reqwest (stream), tokio-util, futures-util, bytes, wiremock (dev)

## Architecture
All three modules live in `src-tauri/src/adapters/driven/network/` following the hexagonal architecture pattern. The download engine uses reqwest directly for streaming (not through the sync HttpClient port) since segment downloads need async streaming. Pause/cancel signals propagate to all workers via shared watch channel and CancellationToken.

## Tests
18 new tests (6 per module) using wiremock mock HTTP server:
- ReqwestHttpClient: HEAD parsing, range requests, range detection, error handling
- segment_worker: download + write, cancellation, pause/resume, progress events, already-completed segments
- SegmentedDownloadEngine: multi-segment download, single-segment fallback, pause signal, cancel, unknown ID errors

## Acceptance criteria (spec 08)
- [x] File downloaded correctly with N parallel segments
- [ ] Checksum verification (deferred to task 09 - File Storage)
- [x] Single-segment fallback when server doesn't support Range
- [x] DownloadProgress events emitted during download
- [x] Pause stops all workers, Resume relaunches
- [x] Cancel stops and cleans up
- [x] Total speed is sum of segment speeds

## Test plan
- [ ] `cargo test --workspace` passes (163 tests)
- [ ] `cargo clippy --workspace -- -D warnings` clean
- [ ] `npx vitest run` passes (7 tests)
- [ ] CI pipeline passes on Linux/macOS/Windows

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a segmented download engine with parallel HTTP range requests, pause/resume/cancel, and throttled progress events. Meets task 08; checksum verification moves to task 09.

- **New Features**
  - `SegmentedDownloadEngine`: parallel segments with HEAD-based size detection, file pre-allocation, single-segment fallback, and pause/resume/cancel; configurable min segment size via `with_min_segment_bytes()` (default 64KB).
  - `ReqwestHttpClient`: HEAD, byte-range GET, and range support detection; segment worker streams chunks with safe file writes and ~500ms progress updates.

- **Bug Fixes**
  - HTTP correctness: omit Range for unknown/no-range; require 206 for offset>0; fallback sends no Range; detect truncated responses by verifying segment byte count.
  - Reliability/concurrency: drop lock before pause/resume publish to avoid deadlocks; pre-spawn cancellation checks; cancel() cleanup handled by the task to prevent ID reuse races.
  - Safety: clamp writes to the segment end boundary; guard against duplicate `start()`; avoid runtime handle panics; use typed errors with `DomainError::NetworkError`.
  - Progress: accurate aggregated progress via shared `Arc<AtomicU64>`; fixed pause loop with `tokio::select`.

<sup>Written for commit 4f38fc937b4817574e571c229d28c0d49e101d37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Segmented download engine with parallel HTTP Range downloads, configurable segments (64KB min) and single-segment fallback.
  * Pause, resume, and cancel controls for active downloads; real-time download events and progress updates (throttled ~500ms).
  * New event system and Tauri bridge with a React hook for consuming events.

* **New Integrations**
  * New HTTP client adapter using reqwest for HEAD and ranged GET requests.

* **Documentation**
  * CHANGELOG updated.

* **Tests**
  * Comprehensive tests for download flows, pause/resume, cancel, and range fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->