### PR TITLE
feat(core): implement file storage adapter with .vortex-meta persistence (task 09)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,3 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Segment worker with streaming HTTP chunks, progress throttling (500ms), and CancellationToken
   - Configurable segment count with 64KB minimum segment size
   - Single-segment fallback when server doesn't support Range requests
+- File storage adapter: `FsFileStorage` implementing `FileStorage` port
+  - Sparse file pre-allocation via `set_len()` (no disk space wasted)
+  - Segment writes at arbitrary byte offsets with seek + write_all
+  - `.vortex-meta` bincode persistence for download resume state
+  - Atomic meta writes (write-to-tmp + rename) to prevent corruption on crash
+  - Graceful handling of corrupted `.vortex-meta` files (log warning, restart download)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -268,6 +268,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5873,6 +5893,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5952,9 +5978,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
 name = "vortex"
 version = "0.0.0"
 dependencies = [
+ "bincode",
  "bytes",
  "futures-util",
  "reqwest",
@@ -5964,6 +5997,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,8 @@ reqwest = { version = "0.13.2", features = ["stream"] }
 tokio-util = { version = "0.7.18", features = ["rt"] }
 futures-util = "0.3.32"
 bytes = "1.11.1"
+bincode = "2"
 
 [dev-dependencies]
+tempfile = "3.27.0"
 wiremock = "0.6.5"

--- a/src-tauri/src/adapters/driven/filesystem/file_storage.rs
+++ b/src-tauri/src/adapters/driven/filesystem/file_storage.rs
@@ -127,7 +127,9 @@ impl FileStorage for FsFileStorage {
         };
 
         // Reject oversized files before allocating memory.
-        let file_len = file.metadata().map(|m| m.len()).unwrap_or(0);
+        let file_len = file.metadata().map(|m| m.len()).map_err(|e| {
+            DomainError::StorageError(format!("failed to read metadata for {}: {e}", mp.display()))
+        })?;
         if file_len > meta_storage::MAX_META_SIZE as u64 {
             warn!(
                 path = %mp.display(),

--- a/src-tauri/src/adapters/driven/filesystem/file_storage.rs
+++ b/src-tauri/src/adapters/driven/filesystem/file_storage.rs
@@ -1,0 +1,341 @@
+//! Production [`FileStorage`] adapter backed by the local filesystem.
+//!
+//! Handles sparse file pre-allocation, segment writes at byte offsets,
+//! and `.vortex-meta` persistence (bincode) for download resume.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tracing::{debug, warn};
+
+use crate::domain::error::DomainError;
+use crate::domain::model::meta::DownloadMeta;
+use crate::domain::ports::driven::FileStorage;
+
+use super::meta_storage;
+
+/// Counter for unique temporary file names during atomic writes.
+static TMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Filesystem-backed implementation of [`FileStorage`].
+///
+/// Stateless — every method receives the target path explicitly.
+#[derive(Default)]
+pub struct FsFileStorage;
+
+impl FsFileStorage {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Build the `.vortex-meta` sidecar path from a download file path.
+///
+/// Appends `.vortex-meta` as a suffix to the file name, so
+/// `/tmp/downloads/file.zip` becomes `/tmp/downloads/file.zip.vortex-meta`.
+fn meta_path(download_path: &Path) -> PathBuf {
+    let file_name = download_path.file_name().unwrap_or_default().to_os_string();
+    let mut meta_name = file_name;
+    meta_name.push(".vortex-meta");
+    download_path.with_file_name(meta_name)
+}
+
+impl FileStorage for FsFileStorage {
+    /// Pre-allocate a sparse file at `path` with logical size `size`.
+    ///
+    /// **Precondition:** the file must not already exist with partial data,
+    /// as `File::create` truncates any existing content.
+    fn create_file(&self, path: &Path, size: u64) -> Result<(), DomainError> {
+        let file = File::create(path).map_err(|e| {
+            DomainError::StorageError(format!("failed to create {}: {e}", path.display()))
+        })?;
+        // set_len creates a sparse file — the OS only allocates blocks
+        // as data is actually written, so a 1 GB file uses ~0 bytes on disk.
+        file.set_len(size).map_err(|e| {
+            DomainError::StorageError(format!(
+                "failed to pre-allocate {} ({size} bytes): {e}",
+                path.display()
+            ))
+        })?;
+        debug!(path = %path.display(), size, "pre-allocated download file");
+        Ok(())
+    }
+
+    fn write_segment(&self, path: &Path, offset: u64, data: &[u8]) -> Result<(), DomainError> {
+        let mut file = OpenOptions::new().write(true).open(path).map_err(|e| {
+            DomainError::StorageError(format!(
+                "failed to open {} for writing: {e}",
+                path.display()
+            ))
+        })?;
+        file.seek(SeekFrom::Start(offset)).map_err(|e| {
+            DomainError::StorageError(format!(
+                "failed to seek to offset {offset} in {}: {e}",
+                path.display()
+            ))
+        })?;
+        file.write_all(data).map_err(|e| {
+            DomainError::StorageError(format!(
+                "failed to write {} bytes at offset {offset} in {}: {e}",
+                data.len(),
+                path.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn read_meta(&self, path: &Path) -> Result<Option<DownloadMeta>, DomainError> {
+        let mp = meta_path(path);
+        // Read directly and handle NotFound — avoids TOCTOU race with delete_meta.
+        let data = match fs::read(&mp) {
+            Ok(bytes) => bytes,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => {
+                return Err(DomainError::StorageError(format!(
+                    "failed to read {}: {e}",
+                    mp.display()
+                )));
+            }
+        };
+        match meta_storage::deserialize_meta(&data) {
+            Ok(meta) => Ok(Some(meta)),
+            Err(e) => {
+                warn!(
+                    path = %mp.display(),
+                    error = %e,
+                    "corrupted .vortex-meta file — ignoring and restarting download"
+                );
+                Ok(None)
+            }
+        }
+    }
+
+    fn write_meta(&self, path: &Path, meta: &DownloadMeta) -> Result<(), DomainError> {
+        let mp = meta_path(path);
+        let data = meta_storage::serialize_meta(meta)?;
+
+        // Atomic write: write to a uniquely-named temporary file then rename,
+        // so a crash during write never leaves a half-written .vortex-meta,
+        // and concurrent writers don't clobber each other's temp files.
+        let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let tmp = mp.with_extension(format!("vortex-meta.{n}.tmp"));
+        fs::write(&tmp, &data).map_err(|e| {
+            DomainError::StorageError(format!("failed to write {}: {e}", tmp.display()))
+        })?;
+        fs::rename(&tmp, &mp).map_err(|e| {
+            // Clean up orphaned tmp on rename failure
+            let _ = fs::remove_file(&tmp);
+            DomainError::StorageError(format!(
+                "failed to rename {} → {}: {e}",
+                tmp.display(),
+                mp.display()
+            ))
+        })?;
+        Ok(())
+    }
+
+    fn delete_meta(&self, path: &Path) -> Result<(), DomainError> {
+        let mp = meta_path(path);
+        match fs::remove_file(&mp) {
+            Ok(()) => {
+                debug!(path = %mp.display(), "deleted .vortex-meta");
+                Ok(())
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(DomainError::StorageError(format!(
+                "failed to delete {}: {e}",
+                mp.display()
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::download::DownloadId;
+    use crate::domain::model::meta::SegmentMeta;
+    use std::io::Read as _;
+
+    fn make_meta() -> DownloadMeta {
+        DownloadMeta {
+            download_id: DownloadId(99),
+            url: "https://example.com/large.bin".to_string(),
+            file_name: "large.bin".to_string(),
+            total_bytes: Some(2_000_000),
+            segments: vec![
+                SegmentMeta {
+                    id: 0,
+                    start_byte: 0,
+                    end_byte: 999_999,
+                    downloaded_bytes: 500_000,
+                    completed: false,
+                },
+                SegmentMeta {
+                    id: 1,
+                    start_byte: 1_000_000,
+                    end_byte: 1_999_999,
+                    downloaded_bytes: 1_000_000,
+                    completed: true,
+                },
+            ],
+            checksum_expected: None,
+            created_at: 1_700_000_000,
+            updated_at: 1_700_002_000,
+        }
+    }
+
+    #[test]
+    fn test_create_file_preallocates_correct_size() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("download.bin");
+        let storage = FsFileStorage::new();
+
+        storage
+            .create_file(&file_path, 1_048_576)
+            .expect("create_file should succeed");
+
+        let metadata = fs::metadata(&file_path).expect("file should exist");
+        assert_eq!(metadata.len(), 1_048_576);
+    }
+
+    #[test]
+    fn test_write_segment_at_offset() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("download.bin");
+        let storage = FsFileStorage::new();
+
+        storage
+            .create_file(&file_path, 100)
+            .expect("create_file should succeed");
+
+        storage
+            .write_segment(&file_path, 10, b"hello")
+            .expect("write_segment should succeed");
+
+        let mut buf = vec![0u8; 100];
+        let mut f = File::open(&file_path).expect("open");
+        f.read_exact(&mut buf).expect("read");
+
+        assert_eq!(&buf[10..15], b"hello");
+        assert_eq!(&buf[0..10], &[0u8; 10]);
+        assert_eq!(&buf[15..20], &[0u8; 5]);
+    }
+
+    #[test]
+    fn test_write_and_read_meta_round_trip() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("download.bin");
+        let storage = FsFileStorage::new();
+
+        let original = make_meta();
+        storage
+            .write_meta(&file_path, &original)
+            .expect("write_meta should succeed");
+
+        let restored = storage
+            .read_meta(&file_path)
+            .expect("read_meta should succeed")
+            .expect("meta should exist");
+
+        assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn test_delete_meta_removes_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("download.bin");
+        let storage = FsFileStorage::new();
+
+        storage
+            .write_meta(&file_path, &make_meta())
+            .expect("write_meta should succeed");
+
+        let mp = meta_path(&file_path);
+        assert!(mp.exists(), ".vortex-meta should exist before delete");
+
+        storage
+            .delete_meta(&file_path)
+            .expect("delete_meta should succeed");
+
+        assert!(!mp.exists(), ".vortex-meta should be gone after delete");
+    }
+
+    #[test]
+    fn test_read_meta_missing_file_returns_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("nonexistent.bin");
+        let storage = FsFileStorage::new();
+
+        let result = storage
+            .read_meta(&file_path)
+            .expect("read_meta should succeed even when file is missing");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_delete_meta_missing_file_succeeds() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("nonexistent.bin");
+        let storage = FsFileStorage::new();
+
+        storage
+            .delete_meta(&file_path)
+            .expect("delete_meta on missing file should succeed");
+    }
+
+    #[test]
+    fn test_write_segment_concurrent_multiple_offsets() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("download.bin");
+        let storage = FsFileStorage::new();
+
+        storage.create_file(&file_path, 300).expect("create_file");
+
+        storage
+            .write_segment(&file_path, 0, &[0xAA; 100])
+            .expect("segment 0");
+        storage
+            .write_segment(&file_path, 100, &[0xBB; 100])
+            .expect("segment 1");
+        storage
+            .write_segment(&file_path, 200, &[0xCC; 100])
+            .expect("segment 2");
+
+        let data = fs::read(&file_path).expect("read file");
+        assert_eq!(&data[0..100], &[0xAA; 100]);
+        assert_eq!(&data[100..200], &[0xBB; 100]);
+        assert_eq!(&data[200..300], &[0xCC; 100]);
+    }
+
+    #[test]
+    fn test_read_meta_corrupted_returns_none() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("download.bin");
+        let mp = meta_path(&file_path);
+
+        fs::write(&mp, b"not valid bincode").expect("write garbage");
+
+        let storage = FsFileStorage::new();
+        let result = storage
+            .read_meta(&file_path)
+            .expect("read_meta should succeed even with corruption");
+
+        assert!(
+            result.is_none(),
+            "corrupted meta should return None, not error"
+        );
+    }
+
+    #[test]
+    fn test_meta_path_handles_various_paths() {
+        let p = meta_path(Path::new("/tmp/downloads/file.zip"));
+        assert_eq!(p, PathBuf::from("/tmp/downloads/file.zip.vortex-meta"));
+
+        let p = meta_path(Path::new("/tmp/downloads/file"));
+        assert_eq!(p, PathBuf::from("/tmp/downloads/file.vortex-meta"));
+    }
+}

--- a/src-tauri/src/adapters/driven/filesystem/file_storage.rs
+++ b/src-tauri/src/adapters/driven/filesystem/file_storage.rs
@@ -4,7 +4,7 @@
 //! and `.vortex-meta` persistence (bincode) for download resume.
 
 use std::fs::{self, File, OpenOptions};
-use std::io::{Seek, SeekFrom, Write};
+use std::io::{Read as _, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -45,12 +45,17 @@ fn meta_path(download_path: &Path) -> PathBuf {
 impl FileStorage for FsFileStorage {
     /// Pre-allocate a sparse file at `path` with logical size `size`.
     ///
-    /// **Precondition:** the file must not already exist with partial data,
-    /// as `File::create` truncates any existing content.
+    /// Uses `create_new(true)` so the call **fails** if the file already
+    /// exists, preventing silent truncation of a partially downloaded file.
+    /// Callers should check for `.vortex-meta` and resume instead.
     fn create_file(&self, path: &Path, size: u64) -> Result<(), DomainError> {
-        let file = File::create(path).map_err(|e| {
-            DomainError::StorageError(format!("failed to create {}: {e}", path.display()))
-        })?;
+        let file = OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+            .map_err(|e| {
+                DomainError::StorageError(format!("failed to create {}: {e}", path.display()))
+            })?;
         // set_len creates a sparse file — the OS only allocates blocks
         // as data is actually written, so a 1 GB file uses ~0 bytes on disk.
         file.set_len(size).map_err(|e| {
@@ -70,6 +75,27 @@ impl FileStorage for FsFileStorage {
                 path.display()
             ))
         })?;
+
+        let file_len = file.metadata().map(|m| m.len()).map_err(|e| {
+            DomainError::StorageError(format!(
+                "failed to read metadata for {}: {e}",
+                path.display()
+            ))
+        })?;
+        let end = offset.checked_add(data.len() as u64).ok_or_else(|| {
+            DomainError::StorageError(format!(
+                "write would overflow u64: offset {offset} + {} bytes",
+                data.len()
+            ))
+        })?;
+        if end > file_len {
+            return Err(DomainError::StorageError(format!(
+                "write past EOF: offset {offset} + {} bytes > file size {file_len} in {}",
+                data.len(),
+                path.display()
+            )));
+        }
+
         file.seek(SeekFrom::Start(offset)).map_err(|e| {
             DomainError::StorageError(format!(
                 "failed to seek to offset {offset} in {}: {e}",
@@ -88,17 +114,37 @@ impl FileStorage for FsFileStorage {
 
     fn read_meta(&self, path: &Path) -> Result<Option<DownloadMeta>, DomainError> {
         let mp = meta_path(path);
-        // Read directly and handle NotFound — avoids TOCTOU race with delete_meta.
-        let data = match fs::read(&mp) {
-            Ok(bytes) => bytes,
+        // Open directly and handle NotFound — avoids TOCTOU race with delete_meta.
+        let mut file = match File::open(&mp) {
+            Ok(f) => f,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => {
                 return Err(DomainError::StorageError(format!(
-                    "failed to read {}: {e}",
+                    "failed to open {}: {e}",
                     mp.display()
                 )));
             }
         };
+
+        // Reject oversized files before allocating memory.
+        let file_len = file.metadata().map(|m| m.len()).unwrap_or(0);
+        if file_len > meta_storage::MAX_META_SIZE as u64 {
+            warn!(
+                path = %mp.display(),
+                size = file_len,
+                "oversized .vortex-meta file — ignoring"
+            );
+            return Ok(None);
+        }
+
+        let mut data = Vec::with_capacity(file_len as usize);
+        if let Err(e) = file.read_to_end(&mut data) {
+            return Err(DomainError::StorageError(format!(
+                "failed to read {}: {e}",
+                mp.display()
+            )));
+        }
+
         match meta_storage::deserialize_meta(&data) {
             Ok(meta) => Ok(Some(meta)),
             Err(e) => {
@@ -122,10 +168,10 @@ impl FileStorage for FsFileStorage {
         let n = TMP_COUNTER.fetch_add(1, Ordering::Relaxed);
         let tmp = mp.with_extension(format!("vortex-meta.{n}.tmp"));
         fs::write(&tmp, &data).map_err(|e| {
+            let _ = fs::remove_file(&tmp);
             DomainError::StorageError(format!("failed to write {}: {e}", tmp.display()))
         })?;
         fs::rename(&tmp, &mp).map_err(|e| {
-            // Clean up orphaned tmp on rename failure
             let _ = fs::remove_file(&tmp);
             DomainError::StorageError(format!(
                 "failed to rename {} → {}: {e}",
@@ -202,6 +248,23 @@ mod tests {
     }
 
     #[test]
+    fn test_create_file_fails_if_already_exists() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("download.bin");
+        let storage = FsFileStorage::new();
+
+        storage
+            .create_file(&file_path, 100)
+            .expect("first create should succeed");
+
+        let result = storage.create_file(&file_path, 100);
+        assert!(
+            result.is_err(),
+            "second create_file on existing file should fail"
+        );
+    }
+
+    #[test]
     fn test_write_segment_at_offset() {
         let dir = tempfile::tempdir().expect("tempdir");
         let file_path = dir.path().join("download.bin");
@@ -222,6 +285,21 @@ mod tests {
         assert_eq!(&buf[10..15], b"hello");
         assert_eq!(&buf[0..10], &[0u8; 10]);
         assert_eq!(&buf[15..20], &[0u8; 5]);
+    }
+
+    #[test]
+    fn test_write_segment_rejects_write_past_eof() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let file_path = dir.path().join("download.bin");
+        let storage = FsFileStorage::new();
+
+        storage.create_file(&file_path, 50).expect("create_file");
+
+        let result = storage.write_segment(&file_path, 40, &[0xAA; 20]);
+        assert!(
+            result.is_err(),
+            "write past EOF (40+20=60 > 50) should fail"
+        );
     }
 
     #[test]
@@ -288,7 +366,7 @@ mod tests {
     }
 
     #[test]
-    fn test_write_segment_concurrent_multiple_offsets() {
+    fn test_write_segment_multiple_offsets() {
         let dir = tempfile::tempdir().expect("tempdir");
         let file_path = dir.path().join("download.bin");
         let storage = FsFileStorage::new();

--- a/src-tauri/src/adapters/driven/filesystem/meta_storage.rs
+++ b/src-tauri/src/adapters/driven/filesystem/meta_storage.rs
@@ -4,14 +4,28 @@
 //! that derive `bincode::Encode`/`Decode`. The domain `DownloadMeta` is
 //! converted to/from these structs at the serialization boundary so the
 //! domain remains free of external dependencies.
+//!
+//! The on-disk format is versioned: a `version: u8` field is encoded first,
+//! allowing future schema migrations without silently discarding resume state.
 
 use crate::domain::error::DomainError;
 use crate::domain::model::download::DownloadId;
 use crate::domain::model::meta::{DownloadMeta, SegmentMeta};
 
-/// Serializable mirror of [`DownloadMeta`] for `.vortex-meta` files.
+/// Maximum size (bytes) for a `.vortex-meta` file. Files larger than this
+/// are rejected before allocation to prevent OOM on corrupted files.
+pub const MAX_META_SIZE: usize = 1 << 20; // 1 MiB
+
+/// Current schema version for the on-disk format.
+const FORMAT_VERSION: u8 = 1;
+
+/// Versioned, serializable mirror of [`DownloadMeta`] for `.vortex-meta` files.
+///
+/// The `version` field is encoded first so future readers can branch on it
+/// and migrate older formats instead of treating them as corruption.
 #[derive(bincode::Encode, bincode::Decode)]
 struct StoredDownloadMeta {
+    version: u8,
     download_id: u64,
     url: String,
     file_name: String,
@@ -35,6 +49,7 @@ struct StoredSegmentMeta {
 impl From<&DownloadMeta> for StoredDownloadMeta {
     fn from(meta: &DownloadMeta) -> Self {
         Self {
+            version: FORMAT_VERSION,
             download_id: meta.download_id.0,
             url: meta.url.clone(),
             file_name: meta.file_name.clone(),
@@ -95,15 +110,20 @@ pub fn serialize_meta(meta: &DownloadMeta) -> Result<Vec<u8>, DomainError> {
 
 /// Deserialize bytes from a `.vortex-meta` file back into [`DownloadMeta`].
 ///
-/// Limits allocation to 1 MiB to prevent OOM from corrupted files
-/// with inflated collection lengths.
+/// Limits allocation to [`MAX_META_SIZE`] to prevent OOM from corrupted files
+/// with inflated collection lengths. Rejects unknown format versions.
 pub fn deserialize_meta(data: &[u8]) -> Result<DownloadMeta, DomainError> {
-    const MAX_META_SIZE: usize = 1 << 20; // 1 MiB
     let config = bincode::config::standard().with_limit::<MAX_META_SIZE>();
     let (stored, _): (StoredDownloadMeta, _) =
         bincode::decode_from_slice(data, config).map_err(|e| {
             DomainError::StorageError(format!("failed to deserialize download meta: {e}"))
         })?;
+    if stored.version != FORMAT_VERSION {
+        return Err(DomainError::StorageError(format!(
+            "unsupported .vortex-meta version {} (expected {FORMAT_VERSION})",
+            stored.version
+        )));
+    }
     Ok(DownloadMeta::from(stored))
 }
 
@@ -174,5 +194,20 @@ mod tests {
         let bytes = serialize_meta(&meta).expect("serialize should succeed");
         let restored = deserialize_meta(&bytes).expect("deserialize should succeed");
         assert_eq!(meta, restored);
+    }
+
+    #[test]
+    fn test_unknown_version_returns_error() {
+        let meta = make_meta();
+        let mut bytes = serialize_meta(&meta).expect("serialize should succeed");
+        // Corrupt the version byte (first byte in bincode standard encoding)
+        bytes[0] = 99;
+        let result = deserialize_meta(&bytes);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("unsupported .vortex-meta version"),
+            "error should mention version: {err}"
+        );
     }
 }

--- a/src-tauri/src/adapters/driven/filesystem/meta_storage.rs
+++ b/src-tauri/src/adapters/driven/filesystem/meta_storage.rs
@@ -1,0 +1,178 @@
+//! Bincode serialization layer for download metadata.
+//!
+//! Provides adapter-level structs (`StoredDownloadMeta`, `StoredSegmentMeta`)
+//! that derive `bincode::Encode`/`Decode`. The domain `DownloadMeta` is
+//! converted to/from these structs at the serialization boundary so the
+//! domain remains free of external dependencies.
+
+use crate::domain::error::DomainError;
+use crate::domain::model::download::DownloadId;
+use crate::domain::model::meta::{DownloadMeta, SegmentMeta};
+
+/// Serializable mirror of [`DownloadMeta`] for `.vortex-meta` files.
+#[derive(bincode::Encode, bincode::Decode)]
+struct StoredDownloadMeta {
+    download_id: u64,
+    url: String,
+    file_name: String,
+    total_bytes: Option<u64>,
+    segments: Vec<StoredSegmentMeta>,
+    checksum_expected: Option<String>,
+    created_at: u64,
+    updated_at: u64,
+}
+
+/// Serializable mirror of [`SegmentMeta`].
+#[derive(bincode::Encode, bincode::Decode)]
+struct StoredSegmentMeta {
+    id: u32,
+    start_byte: u64,
+    end_byte: u64,
+    downloaded_bytes: u64,
+    completed: bool,
+}
+
+impl From<&DownloadMeta> for StoredDownloadMeta {
+    fn from(meta: &DownloadMeta) -> Self {
+        Self {
+            download_id: meta.download_id.0,
+            url: meta.url.clone(),
+            file_name: meta.file_name.clone(),
+            total_bytes: meta.total_bytes,
+            segments: meta.segments.iter().map(StoredSegmentMeta::from).collect(),
+            checksum_expected: meta.checksum_expected.clone(),
+            created_at: meta.created_at,
+            updated_at: meta.updated_at,
+        }
+    }
+}
+
+impl From<&SegmentMeta> for StoredSegmentMeta {
+    fn from(seg: &SegmentMeta) -> Self {
+        Self {
+            id: seg.id,
+            start_byte: seg.start_byte,
+            end_byte: seg.end_byte,
+            downloaded_bytes: seg.downloaded_bytes,
+            completed: seg.completed,
+        }
+    }
+}
+
+impl From<StoredDownloadMeta> for DownloadMeta {
+    fn from(stored: StoredDownloadMeta) -> Self {
+        Self {
+            download_id: DownloadId(stored.download_id),
+            url: stored.url,
+            file_name: stored.file_name,
+            total_bytes: stored.total_bytes,
+            segments: stored.segments.into_iter().map(SegmentMeta::from).collect(),
+            checksum_expected: stored.checksum_expected,
+            created_at: stored.created_at,
+            updated_at: stored.updated_at,
+        }
+    }
+}
+
+impl From<StoredSegmentMeta> for SegmentMeta {
+    fn from(stored: StoredSegmentMeta) -> Self {
+        Self {
+            id: stored.id,
+            start_byte: stored.start_byte,
+            end_byte: stored.end_byte,
+            downloaded_bytes: stored.downloaded_bytes,
+            completed: stored.completed,
+        }
+    }
+}
+
+/// Serialize a [`DownloadMeta`] to bytes for `.vortex-meta` persistence.
+pub fn serialize_meta(meta: &DownloadMeta) -> Result<Vec<u8>, DomainError> {
+    let stored = StoredDownloadMeta::from(meta);
+    bincode::encode_to_vec(&stored, bincode::config::standard())
+        .map_err(|e| DomainError::StorageError(format!("failed to serialize download meta: {e}")))
+}
+
+/// Deserialize bytes from a `.vortex-meta` file back into [`DownloadMeta`].
+///
+/// Limits allocation to 1 MiB to prevent OOM from corrupted files
+/// with inflated collection lengths.
+pub fn deserialize_meta(data: &[u8]) -> Result<DownloadMeta, DomainError> {
+    const MAX_META_SIZE: usize = 1 << 20; // 1 MiB
+    let config = bincode::config::standard().with_limit::<MAX_META_SIZE>();
+    let (stored, _): (StoredDownloadMeta, _) =
+        bincode::decode_from_slice(data, config).map_err(|e| {
+            DomainError::StorageError(format!("failed to deserialize download meta: {e}"))
+        })?;
+    Ok(DownloadMeta::from(stored))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_meta() -> DownloadMeta {
+        DownloadMeta {
+            download_id: DownloadId(42),
+            url: "https://example.com/file.zip".to_string(),
+            file_name: "file.zip".to_string(),
+            total_bytes: Some(1_000_000),
+            segments: vec![
+                SegmentMeta {
+                    id: 0,
+                    start_byte: 0,
+                    end_byte: 499_999,
+                    downloaded_bytes: 250_000,
+                    completed: false,
+                },
+                SegmentMeta {
+                    id: 1,
+                    start_byte: 500_000,
+                    end_byte: 999_999,
+                    downloaded_bytes: 500_000,
+                    completed: true,
+                },
+            ],
+            checksum_expected: Some("abc123".to_string()),
+            created_at: 1_700_000_000,
+            updated_at: 1_700_001_000,
+        }
+    }
+
+    #[test]
+    fn test_serialize_deserialize_roundtrip() {
+        let original = make_meta();
+        let bytes = serialize_meta(&original).expect("serialize should succeed");
+        let restored = deserialize_meta(&bytes).expect("deserialize should succeed");
+        assert_eq!(original, restored);
+    }
+
+    #[test]
+    fn test_deserialize_corrupted_data_returns_error() {
+        let corrupted = vec![0xFF, 0xFE, 0xFD, 0xFC];
+        let result = deserialize_meta(&corrupted);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("deserialize"),
+            "error should mention deserialization: {err}"
+        );
+    }
+
+    #[test]
+    fn test_empty_segments_roundtrip() {
+        let meta = DownloadMeta {
+            download_id: DownloadId(1),
+            url: "https://example.com/tiny".to_string(),
+            file_name: "tiny".to_string(),
+            total_bytes: None,
+            segments: vec![],
+            checksum_expected: None,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let bytes = serialize_meta(&meta).expect("serialize should succeed");
+        let restored = deserialize_meta(&bytes).expect("deserialize should succeed");
+        assert_eq!(meta, restored);
+    }
+}

--- a/src-tauri/src/adapters/driven/filesystem/meta_storage.rs
+++ b/src-tauri/src/adapters/driven/filesystem/meta_storage.rs
@@ -114,10 +114,15 @@ pub fn serialize_meta(meta: &DownloadMeta) -> Result<Vec<u8>, DomainError> {
 /// with inflated collection lengths. Rejects unknown format versions.
 pub fn deserialize_meta(data: &[u8]) -> Result<DownloadMeta, DomainError> {
     let config = bincode::config::standard().with_limit::<MAX_META_SIZE>();
-    let (stored, _): (StoredDownloadMeta, _) =
-        bincode::decode_from_slice(data, config).map_err(|e| {
+    let (stored, consumed): (StoredDownloadMeta, _) = bincode::decode_from_slice(data, config)
+        .map_err(|e| {
             DomainError::StorageError(format!("failed to deserialize download meta: {e}"))
         })?;
+    if consumed != data.len() {
+        return Err(DomainError::StorageError(
+            "failed to deserialize download meta: trailing bytes detected".to_string(),
+        ));
+    }
     if stored.version != FORMAT_VERSION {
         return Err(DomainError::StorageError(format!(
             "unsupported .vortex-meta version {} (expected {FORMAT_VERSION})",

--- a/src-tauri/src/adapters/driven/filesystem/mod.rs
+++ b/src-tauri/src/adapters/driven/filesystem/mod.rs
@@ -1,0 +1,6 @@
+//! Filesystem adapter — file I/O and `.vortex-meta` persistence.
+
+mod file_storage;
+mod meta_storage;
+
+pub use file_storage::FsFileStorage;

--- a/src-tauri/src/adapters/driven/mod.rs
+++ b/src-tauri/src/adapters/driven/mod.rs
@@ -1,5 +1,6 @@
 //! Driven adapters — implementations of domain port traits.
 
 pub mod event;
+pub mod filesystem;
 pub mod network;
 pub mod sqlite;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ pub mod domain;
 // Public API — concrete types for app wiring (main.rs, Tauri setup, integration tests)
 pub use adapters::driven::event::TokioEventBus;
 pub use adapters::driven::event::spawn_tauri_event_bridge;
+pub use adapters::driven::filesystem::FsFileStorage;
 pub use adapters::driven::network::ReqwestHttpClient;
 pub use adapters::driven::network::SegmentedDownloadEngine;
 pub use adapters::driven::sqlite::connection;


### PR DESCRIPTION
## Summary
- Implements `FsFileStorage` adapter for the `FileStorage` domain port
- Sparse file pre-allocation via `set_len()` — no disk space wasted on large downloads
- Segment writes at arbitrary byte offsets using seek + write_all
- `.vortex-meta` bincode 2.x persistence for download resume state
- Atomic meta writes (unique tmp file per call + rename) to prevent corruption on crash
- Graceful handling of corrupted `.vortex-meta` files (log warning, return None)
- TOCTOU-safe `read_meta` (direct fs::read, match NotFound)
- OOM-safe deserialization (1 MiB limit via bincode config)
- Adapter-level `StoredDownloadMeta`/`StoredSegmentMeta` structs with `From`/`Into` conversions — domain stays pure (no external deps)

## Files
| File | Action |
|------|--------|
| `adapters/driven/filesystem/file_storage.rs` | NEW — FsFileStorage impl |
| `adapters/driven/filesystem/meta_storage.rs` | NEW — bincode serialization layer |
| `adapters/driven/filesystem/mod.rs` | NEW — module wiring |
| `adapters/driven/mod.rs` | MODIFIED — add filesystem module |
| `lib.rs` | MODIFIED — export FsFileStorage |
| `Cargo.toml` | MODIFIED — add bincode 2.x, tempfile (dev) |
| `CHANGELOG.md` | MODIFIED — document new adapter |

## Test plan
- [x] `test_create_file_preallocates_correct_size` — sparse file creation
- [x] `test_write_segment_at_offset` — seek + write at specific offset
- [x] `test_write_and_read_meta_round_trip` — serialize/deserialize roundtrip
- [x] `test_delete_meta_removes_file` — cleanup after completion
- [x] `test_read_meta_missing_file_returns_none` — no file = no error
- [x] `test_delete_meta_missing_file_succeeds` — idempotent delete
- [x] `test_write_segment_concurrent_multiple_offsets` — multi-segment writes
- [x] `test_read_meta_corrupted_returns_none` — graceful corruption handling
- [x] `test_meta_path_handles_various_paths` — path construction edge cases
- [x] `test_serialize_deserialize_roundtrip` — bincode roundtrip
- [x] `test_deserialize_corrupted_data_returns_error` — corrupt bincode
- [x] `test_empty_segments_roundtrip` — empty segment list
- [x] All 175 tests pass, clippy clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a filesystem-backed file storage adapter with crash-safe, versioned `.vortex-meta` persistence to enable reliable download resume. Fulfills Linear task 09.

- **New Features**
  - Implemented FsFileStorage with sparse pre-allocation and segment writes at byte offsets.
  - Versioned `.vortex-meta` via `bincode` v2 (v1); enforces 1 MiB cap and rejects unknown versions, trailing bytes, and oversized files.
  - Atomic metadata updates (unique tmp + rename) with cleanup on failure; TOCTOU-safe reads that propagate metadata errors; graceful handling of missing/corrupt meta.
  - Safer I/O: `create_new(true)` to avoid truncating existing files and bounds checks to reject writes past EOF.

- **Dependencies**
  - Added `bincode` 2.
  - Added dev dependency `tempfile`.

<sup>Written for commit 9e62a3ea2f837f6a9464c731eb2e60e305604c78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Filesystem-backed download storage with sparse allocation and offset-based segment writes.
  * Persistent resume support via sidecar metadata so interrupted downloads continue from last progress.

* **Reliability**
  * Atomic metadata updates to prevent corruption on crashes.
  * Detects and recovers from corrupted metadata by warning and restarting affected downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->