### PR TITLE
feat(plugin): implement plugin host functions with capability-based security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,3 +75,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - WASM file size limit (100 MB) to prevent OOM
   - Atomic insert via DashMap entry API to prevent TOCTOU races
   - `Container` and `Notifier` plugin categories added to domain model
+  - Plugin host functions: http_request, log, get_config/set_config, get_state/set_state, get_credential, run_subprocess
+  - Capability-based security for plugin host function access

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4616,6 +4616,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6974,6 +6975,7 @@ checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 name = "vortex"
 version = "0.0.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "bytes",
  "dashmap",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 sea-orm = { version = "1.1.20", features = ["sqlx-sqlite", "runtime-tokio-native-tls", "macros"] }
 sea-orm-migration = { version = "1.1.20", features = ["sqlx-sqlite", "runtime-tokio-native-tls"] }
 tokio = { version = "1.51.0", features = ["full"] }
-reqwest = { version = "0.13.2", features = ["stream"] }
+anyhow = "1"
+reqwest = { version = "0.13.2", features = ["stream", "blocking"] }
 tokio-util = { version = "0.7.18", features = ["rt"] }
 futures-util = "0.3.32"
 bytes = "1.11.1"

--- a/src-tauri/src/adapters/driven/plugin/capabilities.rs
+++ b/src-tauri/src/adapters/driven/plugin/capabilities.rs
@@ -19,6 +19,7 @@ impl SharedHostResources {
     /// Create shared resources with a 30-second HTTP timeout and no credential store.
     pub fn new() -> Self {
         let http_client = reqwest::blocking::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
             .timeout(std::time::Duration::from_secs(30))
             .build()
             .expect("failed to build reqwest blocking client");

--- a/src-tauri/src/adapters/driven/plugin/capabilities.rs
+++ b/src-tauri/src/adapters/driven/plugin/capabilities.rs
@@ -1,0 +1,278 @@
+//! Capability-based host function registration for WASM plugins.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+
+use crate::domain::model::plugin::PluginManifest;
+use crate::domain::ports::driven::CredentialStore;
+
+/// Shared resources across all plugins (singleton).
+pub struct SharedHostResources {
+    pub(crate) http_client: reqwest::blocking::Client,
+    pub(crate) credential_store: Option<Arc<dyn CredentialStore>>,
+    pub(crate) plugin_configs: DashMap<String, DashMap<String, String>>,
+    pub(crate) plugin_states: DashMap<String, DashMap<String, String>>,
+}
+
+impl SharedHostResources {
+    /// Create shared resources with a 30-second HTTP timeout and no credential store.
+    pub fn new() -> Self {
+        let http_client = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .expect("failed to build reqwest blocking client");
+        Self {
+            http_client,
+            credential_store: None,
+            plugin_configs: DashMap::new(),
+            plugin_states: DashMap::new(),
+        }
+    }
+
+    /// Attach a credential store to be used by host functions.
+    pub fn with_credential_store(mut self, store: Arc<dyn CredentialStore>) -> Self {
+        self.credential_store = Some(store);
+        self
+    }
+
+    pub fn http_client(&self) -> &reqwest::blocking::Client {
+        &self.http_client
+    }
+
+    pub fn credential_store(&self) -> Option<&Arc<dyn CredentialStore>> {
+        self.credential_store.as_ref()
+    }
+
+    pub fn plugin_configs(&self) -> &DashMap<String, DashMap<String, String>> {
+        &self.plugin_configs
+    }
+
+    pub fn plugin_states(&self) -> &DashMap<String, DashMap<String, String>> {
+        &self.plugin_states
+    }
+}
+
+impl Default for SharedHostResources {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Per-plugin context passed as UserData to host functions.
+pub struct PluginHostContext {
+    pub(crate) plugin_name: String,
+    pub(crate) capabilities: Vec<String>,
+    pub(crate) shared: Arc<SharedHostResources>,
+}
+
+/// Build host functions based on manifest capabilities.
+///
+/// Always registers the six base functions (log, get/set config, get/set state, get credential).
+/// Conditionally registers http_request and run_subprocess based on declared capabilities.
+pub fn build_host_functions(
+    manifest: &PluginManifest,
+    shared: &Arc<SharedHostResources>,
+) -> Vec<extism::Function> {
+    let name = manifest.info().name().to_string();
+
+    // Ensure per-plugin config/state maps exist before any function runs.
+    shared.plugin_configs.entry(name.clone()).or_default();
+    shared.plugin_states.entry(name.clone()).or_default();
+
+    let ctx = PluginHostContext {
+        plugin_name: name,
+        capabilities: manifest.capabilities().to_vec(),
+        shared: Arc::clone(shared),
+    };
+    let user_data = extism::UserData::new(ctx);
+
+    let mut functions = vec![
+        super::host_functions::make_log_function(user_data.clone()),
+        super::host_functions::make_get_config_function(user_data.clone()),
+        super::host_functions::make_set_config_function(user_data.clone()),
+        super::host_functions::make_get_state_function(user_data.clone()),
+        super::host_functions::make_set_state_function(user_data.clone()),
+        super::host_functions::make_get_credential_function(user_data.clone()),
+    ];
+
+    if manifest.has_capability("http") {
+        functions.push(super::host_functions::make_http_request_function(
+            user_data.clone(),
+        ));
+    }
+
+    if manifest
+        .capabilities()
+        .iter()
+        .any(|c| c.starts_with("subprocess:"))
+    {
+        functions.push(super::host_functions::make_run_subprocess_function(
+            user_data.clone(),
+        ));
+    }
+
+    functions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::model::plugin::{PluginCategory, PluginInfo, PluginManifest};
+
+    fn make_manifest_with_caps(caps: Vec<&str>) -> PluginManifest {
+        let info = PluginInfo::new(
+            "test-plugin".to_string(),
+            "1.0.0".to_string(),
+            "Test plugin".to_string(),
+            "tester".to_string(),
+            PluginCategory::Utility,
+        );
+        PluginManifest::new(info).with_capabilities(caps.into_iter().map(String::from).collect())
+    }
+
+    #[test]
+    fn test_build_host_functions_all_capabilities() {
+        let shared = Arc::new(SharedHostResources::new());
+        let manifest =
+            make_manifest_with_caps(vec!["http", "subprocess:ffmpeg", "subprocess:yt-dlp"]);
+
+        let functions = build_host_functions(&manifest, &shared);
+
+        // 6 base + http + subprocess = 8
+        assert_eq!(functions.len(), 8);
+    }
+
+    #[test]
+    fn test_build_host_functions_minimal() {
+        let shared = Arc::new(SharedHostResources::new());
+        let manifest = make_manifest_with_caps(vec![]);
+
+        let functions = build_host_functions(&manifest, &shared);
+
+        // Only 6 base functions
+        assert_eq!(functions.len(), 6);
+    }
+
+    #[test]
+    fn test_shared_resources_default() {
+        let shared = SharedHostResources::default();
+
+        assert!(shared.credential_store().is_none());
+        assert!(shared.plugin_configs().is_empty());
+        assert!(shared.plugin_states().is_empty());
+    }
+
+    #[test]
+    fn test_build_host_functions_initializes_plugin_maps() {
+        let shared = Arc::new(SharedHostResources::new());
+        let manifest = make_manifest_with_caps(vec![]);
+
+        build_host_functions(&manifest, &shared);
+
+        assert!(shared.plugin_configs().contains_key("test-plugin"));
+        assert!(shared.plugin_states().contains_key("test-plugin"));
+    }
+
+    #[test]
+    fn test_http_request_denied_without_capability() {
+        let shared = Arc::new(SharedHostResources::new());
+        let manifest = make_manifest_with_caps(vec![]);
+
+        let functions = build_host_functions(&manifest, &shared);
+
+        // No http cap: only 6 base functions, no http_request
+        assert_eq!(functions.len(), 6);
+        assert!(!functions.iter().any(|f| f.name() == "http_request"));
+    }
+
+    #[test]
+    fn test_build_host_functions_http_only() {
+        let shared = Arc::new(SharedHostResources::new());
+        let manifest = make_manifest_with_caps(vec!["http"]);
+
+        let functions = build_host_functions(&manifest, &shared);
+
+        // 6 base + http_request = 7
+        assert_eq!(functions.len(), 7);
+        assert!(functions.iter().any(|f| f.name() == "http_request"));
+    }
+
+    #[test]
+    fn test_build_host_functions_subprocess_only() {
+        let shared = Arc::new(SharedHostResources::new());
+        let manifest = make_manifest_with_caps(vec!["subprocess:ffmpeg"]);
+
+        let functions = build_host_functions(&manifest, &shared);
+
+        // 6 base + run_subprocess = 7
+        assert_eq!(functions.len(), 7);
+        assert!(functions.iter().any(|f| f.name() == "run_subprocess"));
+    }
+
+    #[test]
+    fn test_get_credential_returns_credential() {
+        use crate::domain::model::credential::Credential;
+        use crate::domain::ports::driven::CredentialStore;
+
+        struct MockCredentialStore;
+        impl CredentialStore for MockCredentialStore {
+            fn get(
+                &self,
+                service: &str,
+            ) -> Result<Option<Credential>, crate::domain::error::DomainError> {
+                if service == "test-service" {
+                    Ok(Some(Credential::new("user", "pass")))
+                } else {
+                    Ok(None)
+                }
+            }
+            fn store(
+                &self,
+                _: &str,
+                _: &Credential,
+            ) -> Result<(), crate::domain::error::DomainError> {
+                Ok(())
+            }
+            fn delete(&self, _: &str) -> Result<(), crate::domain::error::DomainError> {
+                Ok(())
+            }
+        }
+
+        let shared = Arc::new(
+            SharedHostResources::new().with_credential_store(Arc::new(MockCredentialStore)),
+        );
+
+        let cred = shared
+            .credential_store()
+            .unwrap()
+            .get("test-service")
+            .unwrap();
+        assert!(cred.is_some());
+        let cred = cred.unwrap();
+        assert_eq!(cred.username(), "user");
+        assert_eq!(cred.password(), "pass");
+
+        let missing = shared
+            .credential_store()
+            .unwrap()
+            .get("unknown-service")
+            .unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[test]
+    fn test_subprocess_denied_unauthorized_binary() {
+        // Verify capability check logic: only declared binaries are allowed
+        let caps: Vec<String> = vec!["subprocess:ffmpeg".to_string()];
+
+        let allowed_binary = "ffmpeg";
+        let denied_binary = "yt-dlp";
+
+        let allowed_cap = format!("subprocess:{allowed_binary}");
+        let denied_cap = format!("subprocess:{denied_binary}");
+
+        assert!(caps.iter().any(|c| c == &allowed_cap));
+        assert!(!caps.iter().any(|c| c == &denied_cap));
+    }
+}

--- a/src-tauri/src/adapters/driven/plugin/capabilities.rs
+++ b/src-tauri/src/adapters/driven/plugin/capabilities.rs
@@ -1,6 +1,8 @@
 //! Capability-based host function registration for WASM plugins.
 
+use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use dashmap::DashMap;
 
@@ -10,21 +12,28 @@ use crate::domain::ports::driven::CredentialStore;
 /// Shared resources across all plugins (singleton).
 pub struct SharedHostResources {
     pub(crate) http_client: reqwest::blocking::Client,
+    http_timeout: Duration,
     pub(crate) credential_store: Option<Arc<dyn CredentialStore>>,
     pub(crate) plugin_configs: DashMap<String, DashMap<String, String>>,
     pub(crate) plugin_states: DashMap<String, DashMap<String, String>>,
 }
 
 impl SharedHostResources {
+    fn http_client_builder(timeout: Duration) -> reqwest::blocking::ClientBuilder {
+        reqwest::blocking::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(timeout)
+    }
+
     /// Create shared resources with a 30-second HTTP timeout and no credential store.
     pub fn new() -> Self {
-        let http_client = reqwest::blocking::Client::builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .timeout(std::time::Duration::from_secs(30))
+        let http_timeout = Duration::from_secs(30);
+        let http_client = Self::http_client_builder(http_timeout)
             .build()
             .expect("failed to build reqwest blocking client");
         Self {
             http_client,
+            http_timeout,
             credential_store: None,
             plugin_configs: DashMap::new(),
             plugin_states: DashMap::new(),
@@ -39,6 +48,16 @@ impl SharedHostResources {
 
     pub fn http_client(&self) -> &reqwest::blocking::Client {
         &self.http_client
+    }
+
+    pub fn http_client_for_host(
+        &self,
+        host: &str,
+        addrs: &[SocketAddr],
+    ) -> Result<reqwest::blocking::Client, reqwest::Error> {
+        Self::http_client_builder(self.http_timeout)
+            .resolve_to_addrs(host, addrs)
+            .build()
     }
 
     pub fn credential_store(&self) -> Option<&Arc<dyn CredentialStore>> {

--- a/src-tauri/src/adapters/driven/plugin/extism_loader.rs
+++ b/src-tauri/src/adapters/driven/plugin/extism_loader.rs
@@ -7,19 +7,22 @@ use crate::domain::error::DomainError;
 use crate::domain::model::plugin::{PluginInfo, PluginManifest};
 use crate::domain::ports::driven::PluginLoader;
 
+use super::capabilities::{SharedHostResources, build_host_functions};
 use super::manifest::find_wasm_file;
 use super::registry::{LoadedPlugin, PluginRegistry};
 
 pub struct ExtismPluginLoader {
     registry: Arc<PluginRegistry>,
     plugins_dir: PathBuf,
+    shared_resources: Arc<SharedHostResources>,
 }
 
 impl ExtismPluginLoader {
-    pub fn new(plugins_dir: PathBuf) -> Self {
+    pub fn new(plugins_dir: PathBuf, shared_resources: Arc<SharedHostResources>) -> Self {
         Self {
             registry: Arc::new(PluginRegistry::new()),
             plugins_dir,
+            shared_resources,
         }
     }
 
@@ -63,7 +66,8 @@ impl PluginLoader for ExtismPluginLoader {
         })?;
 
         let extism_manifest = extism::Manifest::new([extism::Wasm::data(wasm_bytes)]);
-        let plugin = extism::Plugin::new(&extism_manifest, [], true)
+        let host_functions = build_host_functions(manifest, &self.shared_resources);
+        let plugin = extism::Plugin::new(&extism_manifest, host_functions, true)
             .map_err(|e| DomainError::PluginError(format!("failed to load plugin: {e}")))?;
 
         let loaded = LoadedPlugin {
@@ -160,7 +164,10 @@ description = "Test plugin"
     #[test]
     fn test_load_nonexistent_wasm() {
         let tmp = TempDir::new().unwrap();
-        let loader = ExtismPluginLoader::new(tmp.path().to_path_buf());
+        let loader = ExtismPluginLoader::new(
+            tmp.path().to_path_buf(),
+            Arc::new(SharedHostResources::new()),
+        );
         let manifest = make_manifest("ghost-plugin");
 
         // Plugin dir doesn't exist — should fail
@@ -172,7 +179,10 @@ description = "Test plugin"
     #[test]
     fn test_unload_not_found() {
         let tmp = TempDir::new().unwrap();
-        let loader = ExtismPluginLoader::new(tmp.path().to_path_buf());
+        let loader = ExtismPluginLoader::new(
+            tmp.path().to_path_buf(),
+            Arc::new(SharedHostResources::new()),
+        );
 
         let result = loader.unload("nonexistent");
         assert!(result.is_err());
@@ -182,7 +192,10 @@ description = "Test plugin"
     #[test]
     fn test_resolve_url_no_plugins_returns_none() {
         let tmp = TempDir::new().unwrap();
-        let loader = ExtismPluginLoader::new(tmp.path().to_path_buf());
+        let loader = ExtismPluginLoader::new(
+            tmp.path().to_path_buf(),
+            Arc::new(SharedHostResources::new()),
+        );
 
         let result = loader.resolve_url("https://example.com/file.zip");
         assert!(result.is_ok());
@@ -192,7 +205,10 @@ description = "Test plugin"
     #[test]
     fn test_list_loaded_empty() {
         let tmp = TempDir::new().unwrap();
-        let loader = ExtismPluginLoader::new(tmp.path().to_path_buf());
+        let loader = ExtismPluginLoader::new(
+            tmp.path().to_path_buf(),
+            Arc::new(SharedHostResources::new()),
+        );
 
         let result = loader.list_loaded();
         assert!(result.is_ok());
@@ -203,7 +219,10 @@ description = "Test plugin"
     fn test_load_already_loaded_returns_error() {
         let tmp = TempDir::new().unwrap();
         setup_plugin_dir(tmp.path(), "dup-plugin");
-        let loader = ExtismPluginLoader::new(tmp.path().to_path_buf());
+        let loader = ExtismPluginLoader::new(
+            tmp.path().to_path_buf(),
+            Arc::new(SharedHostResources::new()),
+        );
         let manifest = make_manifest("dup-plugin");
 
         loader.load(&manifest).unwrap();
@@ -216,7 +235,10 @@ description = "Test plugin"
     fn test_unload_after_load() {
         let tmp = TempDir::new().unwrap();
         setup_plugin_dir(tmp.path(), "removable-plugin");
-        let loader = ExtismPluginLoader::new(tmp.path().to_path_buf());
+        let loader = ExtismPluginLoader::new(
+            tmp.path().to_path_buf(),
+            Arc::new(SharedHostResources::new()),
+        );
         let manifest = make_manifest("removable-plugin");
 
         loader.load(&manifest).unwrap();

--- a/src-tauri/src/adapters/driven/plugin/host_functions.rs
+++ b/src-tauri/src/adapters/driven/plugin/host_functions.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 use std::io::Read;
-use std::net::{IpAddr, ToSocketAddrs};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::process::Child;
 use std::time::{Duration, Instant};
 
@@ -89,7 +89,7 @@ fn write_output_string(
 }
 
 /// Reject URLs targeting internal/loopback networks (SSRF protection).
-fn validate_url_not_internal(url: &reqwest::Url) -> Result<(), extism::Error> {
+fn validate_url_not_internal(url: &reqwest::Url) -> Result<Option<Vec<SocketAddr>>, extism::Error> {
     if let Some(host) = url.host_str() {
         // Reject localhost variants
         if host == "localhost" || host.ends_with(".localhost") {
@@ -104,36 +104,54 @@ fn validate_url_not_internal(url: &reqwest::Url) -> Result<(), extism::Error> {
                     "http_request: requests to internal networks are forbidden"
                 ));
             }
-            return Ok(());
+            return Ok(None);
         }
 
         let port = url
             .port_or_known_default()
             .ok_or_else(|| anyhow::anyhow!("http_request: URL is missing a known port"))?;
 
-        let resolved_ips = (host, port)
+        let resolved_addrs = (host, port)
             .to_socket_addrs()
             .map_err(|e| anyhow::anyhow!("http_request: failed to resolve host '{host}': {e}"))?
-            .map(|socket_addr| socket_addr.ip())
             .collect::<Vec<_>>();
 
-        if resolved_ips.is_empty() {
+        if resolved_addrs.is_empty() {
             return Err(anyhow::anyhow!(
                 "http_request: host '{host}' did not resolve to any addresses"
             ));
         }
 
-        if resolved_ips.iter().any(is_forbidden_ip) {
+        if resolved_addrs
+            .iter()
+            .any(|addr| is_forbidden_ip(&addr.ip()))
+        {
             return Err(anyhow::anyhow!(
                 "http_request: requests to internal networks are forbidden"
             ));
         }
+
+        return Ok(Some(resolved_addrs));
     }
-    Ok(())
+    Ok(None)
+}
+
+fn normalize_ip(ip: &IpAddr) -> IpAddr {
+    match ip {
+        IpAddr::V4(v4) => IpAddr::V4(*v4),
+        IpAddr::V6(v6) => v6
+            .to_ipv4_mapped()
+            .map(IpAddr::V4)
+            .unwrap_or(IpAddr::V6(*v6)),
+    }
 }
 
 fn is_forbidden_ip(ip: &IpAddr) -> bool {
-    ip.is_loopback() || ip.is_unspecified() || is_private_ip(ip) || is_link_local(ip)
+    let normalized = normalize_ip(ip);
+    normalized.is_loopback()
+        || normalized.is_unspecified()
+        || is_private_ip(&normalized)
+        || is_link_local(&normalized)
 }
 
 fn is_private_ip(ip: &IpAddr) -> bool {
@@ -145,6 +163,9 @@ fn is_private_ip(ip: &IpAddr) -> bool {
                 || (octets[0] == 192 && octets[1] == 168)
         }
         IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_private_ip(&IpAddr::V4(v4));
+            }
             let segments = v6.segments();
             // fc00::/7 (unique local)
             (segments[0] & 0xfe00) == 0xfc00
@@ -160,6 +181,9 @@ fn is_link_local(ip: &IpAddr) -> bool {
             octets[0] == 169 && octets[1] == 254
         }
         IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_link_local(&IpAddr::V4(v4));
+            }
             let segments = v6.segments();
             // fe80::/10
             (segments[0] & 0xffc0) == 0xfe80
@@ -216,8 +240,9 @@ fn read_stream_capped<R: Read>(mut reader: R, max_bytes: usize) -> std::io::Resu
         if to_copy > 0 {
             bytes.extend_from_slice(&chunk[..to_copy]);
         }
-        if to_copy < read || bytes.len() >= max_bytes {
+        if to_copy < read {
             truncated = true;
+            break;
         }
     }
 
@@ -346,15 +371,22 @@ pub fn make_http_request_function(
                 .map_err(|e| anyhow::anyhow!("http_request: invalid URL '{}': {e}", req.url))?;
 
             // F1: SSRF protection — reject internal/loopback destinations
-            validate_url_not_internal(&url)?;
+            let resolved_addrs = validate_url_not_internal(&url)?;
 
-            // F6: Minimize mutex scope — clone the client, then release the lock
+            // F6: Minimize mutex scope — prepare the client, then release the lock
             let client = {
                 let guard = ud.get()?;
                 let ctx = guard
                     .lock()
                     .map_err(|_| anyhow::anyhow!("http_request: mutex poisoned"))?;
-                ctx.shared.http_client().clone()
+                match (url.host_str(), resolved_addrs.as_deref()) {
+                    (Some(host), Some(addrs)) => {
+                        ctx.shared.http_client_for_host(host, addrs).map_err(|e| {
+                            anyhow::anyhow!("http_request: failed to build client: {e}")
+                        })?
+                    }
+                    _ => ctx.shared.http_client().clone(),
+                }
             }; // Mutex released here — HTTP call runs without holding the lock
 
             let mut builder = client.request(method, url);
@@ -612,8 +644,6 @@ pub fn make_run_subprocess_function(
             let stderr_handle = spawn_output_reader(child.stderr.take());
 
             let (status, timed_out) = wait_for_child_with_timeout(&mut child, timeout)?;
-            let (stdout, stderr) = collect_subprocess_output(stdout_handle, stderr_handle)?;
-
             if timed_out {
                 return Err(anyhow::anyhow!(
                     "run_subprocess: '{}' timed out after {}ms",
@@ -621,6 +651,8 @@ pub fn make_run_subprocess_function(
                     timeout.as_millis()
                 ));
             }
+
+            let (stdout, stderr) = collect_subprocess_output(stdout_handle, stderr_handle)?;
 
             let resp = SubprocessResponse {
                 exit_code: status.code().unwrap_or(-1),
@@ -725,5 +757,32 @@ mod tests {
             "subprocess:yt-dlp".to_string(),
         ];
         assert!(ctx_caps2.iter().any(|c| c == &cap_key));
+    }
+
+    #[test]
+    fn test_ipv4_mapped_ipv6_is_forbidden() {
+        let loopback = "::ffff:127.0.0.1".parse::<IpAddr>().unwrap();
+        let private = "::ffff:10.0.0.1".parse::<IpAddr>().unwrap();
+        let link_local = "::ffff:169.254.169.254".parse::<IpAddr>().unwrap();
+
+        assert!(is_forbidden_ip(&loopback));
+        assert!(is_forbidden_ip(&private));
+        assert!(is_forbidden_ip(&link_local));
+    }
+
+    #[test]
+    fn test_read_stream_capped_only_marks_truncated_when_extra_bytes_exist() {
+        let exact = vec![b'a'; MAX_SUBPROCESS_OUTPUT_BYTES];
+        let exact_output =
+            read_stream_capped(std::io::Cursor::new(exact), MAX_SUBPROCESS_OUTPUT_BYTES).unwrap();
+        assert!(!exact_output.truncated);
+        assert_eq!(exact_output.bytes.len(), MAX_SUBPROCESS_OUTPUT_BYTES);
+
+        let too_long = vec![b'a'; MAX_SUBPROCESS_OUTPUT_BYTES + 1];
+        let too_long_output =
+            read_stream_capped(std::io::Cursor::new(too_long), MAX_SUBPROCESS_OUTPUT_BYTES)
+                .unwrap();
+        assert!(too_long_output.truncated);
+        assert_eq!(too_long_output.bytes.len(), MAX_SUBPROCESS_OUTPUT_BYTES);
     }
 }

--- a/src-tauri/src/adapters/driven/plugin/host_functions.rs
+++ b/src-tauri/src/adapters/driven/plugin/host_functions.rs
@@ -1,0 +1,591 @@
+//! Host function implementations for WASM plugins.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use serde::{Deserialize, Serialize};
+
+use super::capabilities::PluginHostContext;
+
+// ── JSON types ────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct HttpRequest {
+    method: String,
+    url: String,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    body: Option<String>,
+}
+
+#[derive(Serialize)]
+struct HttpResponse {
+    status: u16,
+    headers: HashMap<String, String>,
+    body: String,
+}
+
+#[derive(Deserialize)]
+struct LogRequest {
+    level: String,
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct SubprocessRequest {
+    binary: String,
+    #[serde(default)]
+    args: Vec<String>,
+    timeout_ms: Option<u64>,
+}
+
+#[derive(Serialize)]
+struct SubprocessResponse {
+    exit_code: i32,
+    stdout: String,
+    stderr: String,
+}
+
+#[derive(Deserialize)]
+struct ConfigEntry {
+    key: String,
+    value: String,
+}
+
+#[derive(Serialize)]
+struct CredentialResponse {
+    username: String,
+    password: String,
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn read_input_string(
+    plugin: &mut extism::CurrentPlugin,
+    inputs: &[extism::Val],
+) -> Result<String, extism::Error> {
+    let bytes: Vec<u8> = plugin.memory_get_val(&inputs[0])?;
+    String::from_utf8(bytes).map_err(|e| anyhow::anyhow!("invalid utf-8 input: {e}"))
+}
+
+fn write_output_string(
+    plugin: &mut extism::CurrentPlugin,
+    outputs: &mut [extism::Val],
+    value: &str,
+) -> Result<(), extism::Error> {
+    plugin.memory_set_val(&mut outputs[0], value.as_bytes())
+}
+
+/// Reject URLs targeting internal/loopback networks (SSRF protection).
+fn validate_url_not_internal(url: &reqwest::Url) -> Result<(), extism::Error> {
+    if let Some(host) = url.host_str() {
+        // Reject localhost variants
+        if host == "localhost" || host.ends_with(".localhost") {
+            return Err(anyhow::anyhow!(
+                "http_request: requests to localhost are forbidden"
+            ));
+        }
+        // Reject internal IPs
+        if let Ok(ip) = host.parse::<IpAddr>()
+            && (ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) || is_link_local(&ip))
+        {
+            return Err(anyhow::anyhow!(
+                "http_request: requests to internal networks are forbidden"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn is_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            octets[0] == 10
+                || (octets[0] == 172 && (16..=31).contains(&octets[1]))
+                || (octets[0] == 192 && octets[1] == 168)
+        }
+        IpAddr::V6(v6) => {
+            let segments = v6.segments();
+            // fc00::/7 (unique local)
+            (segments[0] & 0xfe00) == 0xfc00
+        }
+    }
+}
+
+fn is_link_local(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            let octets = v4.octets();
+            // 169.254.0.0/16 (includes AWS metadata 169.254.169.254)
+            octets[0] == 169 && octets[1] == 254
+        }
+        IpAddr::V6(v6) => {
+            let segments = v6.segments();
+            // fe80::/10
+            (segments[0] & 0xffc0) == 0xfe80
+        }
+    }
+}
+
+/// Validate subprocess binary name has no path components.
+fn validate_binary_name(binary: &str) -> Result<(), extism::Error> {
+    if binary.is_empty()
+        || binary.contains('/')
+        || binary.contains('\\')
+        || binary.contains("..")
+        || binary.contains('\0')
+    {
+        return Err(anyhow::anyhow!(
+            "run_subprocess: invalid binary name '{binary}'"
+        ));
+    }
+    Ok(())
+}
+
+// ── Host functions ────────────────────────────────────────────────────────────
+
+/// Route plugin log messages through the `tracing` framework.
+pub fn make_log_function(user_data: extism::UserData<PluginHostContext>) -> extism::Function {
+    extism::Function::new(
+        "log",
+        [extism::ValType::I64],
+        [],
+        user_data,
+        |plugin, inputs, _outputs, ud| {
+            let input = read_input_string(plugin, inputs)?;
+            let req: LogRequest = serde_json::from_str(&input)
+                .map_err(|e| anyhow::anyhow!("log: invalid JSON: {e}"))?;
+            let guard = ud.get()?;
+            let ctx = guard
+                .lock()
+                .map_err(|_| anyhow::anyhow!("log: mutex poisoned"))?;
+            let plugin_name = ctx.plugin_name.as_str();
+            match req.level.as_str() {
+                "error" => tracing::error!(plugin = plugin_name, "{}", req.message),
+                "warn" => tracing::warn!(plugin = plugin_name, "{}", req.message),
+                "debug" => tracing::debug!(plugin = plugin_name, "{}", req.message),
+                _ => tracing::info!(plugin = plugin_name, "{}", req.message),
+            }
+            Ok(())
+        },
+    )
+}
+
+/// Execute an HTTP request using the shared blocking client.
+pub fn make_http_request_function(
+    user_data: extism::UserData<PluginHostContext>,
+) -> extism::Function {
+    extism::Function::new(
+        "http_request",
+        [extism::ValType::I64],
+        [extism::ValType::I64],
+        user_data,
+        |plugin, inputs, outputs, ud| {
+            let input = read_input_string(plugin, inputs)?;
+            let req: HttpRequest = serde_json::from_str(&input)
+                .map_err(|e| anyhow::anyhow!("http_request: invalid JSON: {e}"))?;
+
+            let method = reqwest::Method::from_bytes(req.method.as_bytes())
+                .map_err(|_| anyhow::anyhow!("http_request: invalid method: {}", req.method))?;
+
+            let url: reqwest::Url = req
+                .url
+                .parse()
+                .map_err(|e| anyhow::anyhow!("http_request: invalid URL '{}': {e}", req.url))?;
+
+            // F1: SSRF protection — reject internal/loopback destinations
+            validate_url_not_internal(&url)?;
+
+            // F6: Minimize mutex scope — clone the client, then release the lock
+            let client = {
+                let guard = ud.get()?;
+                let ctx = guard
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("http_request: mutex poisoned"))?;
+                ctx.shared.http_client().clone()
+            }; // Mutex released here — HTTP call runs without holding the lock
+
+            let mut builder = client.request(method, url);
+            for (k, v) in &req.headers {
+                builder = builder.header(k.as_str(), v.as_str());
+            }
+            if let Some(body) = req.body {
+                builder = builder.body(body);
+            }
+
+            let response = builder
+                .send()
+                .map_err(|e| anyhow::anyhow!("http_request: request failed: {e}"))?;
+
+            // F2: Check Content-Length before reading body into memory
+            const MAX_BODY: u64 = 100 * 1024 * 1024;
+            if let Some(len) = response.content_length()
+                && len > MAX_BODY
+            {
+                return Err(anyhow::anyhow!(
+                    "http_request: Content-Length {len} exceeds 100 MB limit"
+                ));
+            }
+
+            let status = response.status().as_u16();
+            let resp_headers: HashMap<String, String> = response
+                .headers()
+                .iter()
+                .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
+                .collect();
+
+            let body_bytes = response
+                .bytes()
+                .map_err(|e| anyhow::anyhow!("http_request: failed to read body: {e}"))?;
+            if body_bytes.len() as u64 > MAX_BODY {
+                return Err(anyhow::anyhow!(
+                    "http_request: response body exceeds 100 MB limit"
+                ));
+            }
+            let body = String::from_utf8_lossy(&body_bytes).into_owned();
+
+            let http_resp = HttpResponse {
+                status,
+                headers: resp_headers,
+                body,
+            };
+            let json = serde_json::to_string(&http_resp)
+                .map_err(|e| anyhow::anyhow!("http_request: failed to serialize response: {e}"))?;
+
+            write_output_string(plugin, outputs, &json)
+        },
+    )
+}
+
+/// Read a per-plugin config value by key.
+pub fn make_get_config_function(
+    user_data: extism::UserData<PluginHostContext>,
+) -> extism::Function {
+    extism::Function::new(
+        "get_config",
+        [extism::ValType::I64],
+        [extism::ValType::I64],
+        user_data,
+        |plugin, inputs, outputs, ud| {
+            let key = read_input_string(plugin, inputs)?;
+            let guard = ud.get()?;
+            let ctx = guard
+                .lock()
+                .map_err(|_| anyhow::anyhow!("get_config: mutex poisoned"))?;
+
+            let value = ctx
+                .shared
+                .plugin_configs()
+                .get(&ctx.plugin_name)
+                .and_then(|m| m.get(&key).map(|v| v.clone()))
+                .unwrap_or_default();
+
+            write_output_string(plugin, outputs, &value)
+        },
+    )
+}
+
+/// Store a per-plugin config key/value pair.
+pub fn make_set_config_function(
+    user_data: extism::UserData<PluginHostContext>,
+) -> extism::Function {
+    extism::Function::new(
+        "set_config",
+        [extism::ValType::I64],
+        [],
+        user_data,
+        |plugin, inputs, _outputs, ud| {
+            let input = read_input_string(plugin, inputs)?;
+            let entry: ConfigEntry = serde_json::from_str(&input)
+                .map_err(|e| anyhow::anyhow!("set_config: invalid JSON: {e}"))?;
+
+            let guard = ud.get()?;
+            let ctx = guard
+                .lock()
+                .map_err(|_| anyhow::anyhow!("set_config: mutex poisoned"))?;
+
+            ctx.shared
+                .plugin_configs()
+                .entry(ctx.plugin_name.clone())
+                .or_default()
+                .insert(entry.key, entry.value);
+
+            Ok(())
+        },
+    )
+}
+
+/// Read a per-plugin ephemeral state value by key.
+pub fn make_get_state_function(user_data: extism::UserData<PluginHostContext>) -> extism::Function {
+    extism::Function::new(
+        "get_state",
+        [extism::ValType::I64],
+        [extism::ValType::I64],
+        user_data,
+        |plugin, inputs, outputs, ud| {
+            let key = read_input_string(plugin, inputs)?;
+            let guard = ud.get()?;
+            let ctx = guard
+                .lock()
+                .map_err(|_| anyhow::anyhow!("get_state: mutex poisoned"))?;
+
+            let value = ctx
+                .shared
+                .plugin_states()
+                .get(&ctx.plugin_name)
+                .and_then(|m| m.get(&key).map(|v| v.clone()))
+                .unwrap_or_default();
+
+            write_output_string(plugin, outputs, &value)
+        },
+    )
+}
+
+/// Store a per-plugin ephemeral state key/value pair.
+pub fn make_set_state_function(user_data: extism::UserData<PluginHostContext>) -> extism::Function {
+    extism::Function::new(
+        "set_state",
+        [extism::ValType::I64],
+        [],
+        user_data,
+        |plugin, inputs, _outputs, ud| {
+            let input = read_input_string(plugin, inputs)?;
+            let entry: ConfigEntry = serde_json::from_str(&input)
+                .map_err(|e| anyhow::anyhow!("set_state: invalid JSON: {e}"))?;
+
+            let guard = ud.get()?;
+            let ctx = guard
+                .lock()
+                .map_err(|_| anyhow::anyhow!("set_state: mutex poisoned"))?;
+
+            ctx.shared
+                .plugin_states()
+                .entry(ctx.plugin_name.clone())
+                .or_default()
+                .insert(entry.key, entry.value);
+
+            Ok(())
+        },
+    )
+}
+
+/// Retrieve a credential from the store, scoped to the plugin's own service name.
+pub fn make_get_credential_function(
+    user_data: extism::UserData<PluginHostContext>,
+) -> extism::Function {
+    extism::Function::new(
+        "get_credential",
+        [extism::ValType::I64],
+        [extism::ValType::I64],
+        user_data,
+        |plugin, inputs, outputs, ud| {
+            let service = read_input_string(plugin, inputs)?;
+            // F3: Scope credential access — plugins can only read credentials
+            // matching their own name to prevent cross-plugin credential theft.
+            let (store, plugin_name) = {
+                let guard = ud.get()?;
+                let ctx = guard
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("get_credential: mutex poisoned"))?;
+
+                if service != ctx.plugin_name {
+                    return Err(anyhow::anyhow!(
+                        "get_credential: plugin '{}' cannot access credentials for service '{service}'",
+                        ctx.plugin_name
+                    ));
+                }
+
+                let store = ctx.shared.credential_store().cloned().ok_or_else(|| {
+                    anyhow::anyhow!("get_credential: no credential store configured")
+                })?;
+                (store, ctx.plugin_name.clone())
+            };
+
+            let cred = store
+                .get(&plugin_name)
+                .map_err(|e| anyhow::anyhow!("get_credential: store error: {e}"))?
+                .ok_or_else(|| anyhow::anyhow!("get_credential: no credential found"))?;
+
+            let resp = CredentialResponse {
+                username: cred.username().to_string(),
+                password: cred.password().to_string(),
+            };
+            let json = serde_json::to_string(&resp).map_err(|e| {
+                anyhow::anyhow!("get_credential: failed to serialize response: {e}")
+            })?;
+
+            write_output_string(plugin, outputs, &json)
+        },
+    )
+}
+
+/// Run a subprocess binary declared in the plugin's `subprocess:` capabilities.
+pub fn make_run_subprocess_function(
+    user_data: extism::UserData<PluginHostContext>,
+) -> extism::Function {
+    extism::Function::new(
+        "run_subprocess",
+        [extism::ValType::I64],
+        [extism::ValType::I64],
+        user_data,
+        |plugin, inputs, outputs, ud| {
+            let input = read_input_string(plugin, inputs)?;
+            let req: SubprocessRequest = serde_json::from_str(&input)
+                .map_err(|e| anyhow::anyhow!("run_subprocess: invalid JSON: {e}"))?;
+
+            // F4: Validate binary name has no path components
+            validate_binary_name(&req.binary)?;
+
+            // F6: Minimize mutex scope — check capability then release
+            {
+                let guard = ud.get()?;
+                let ctx = guard
+                    .lock()
+                    .map_err(|_| anyhow::anyhow!("run_subprocess: mutex poisoned"))?;
+
+                let required_cap = format!("subprocess:{}", req.binary);
+                if !ctx.capabilities.iter().any(|c| c == &required_cap) {
+                    return Err(anyhow::anyhow!(
+                        "run_subprocess: binary '{}' not listed in plugin capabilities",
+                        req.binary
+                    ));
+                }
+            } // Mutex released here — subprocess runs without holding the lock
+
+            let timeout = std::time::Duration::from_millis(req.timeout_ms.unwrap_or(60_000));
+            let binary = req.binary.clone();
+
+            let child = std::process::Command::new(&req.binary)
+                .args(&req.args)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::piped())
+                .spawn()
+                .map_err(|e| {
+                    anyhow::anyhow!("run_subprocess: failed to spawn '{}': {e}", req.binary)
+                })?;
+
+            // Run wait_with_output on a helper thread so we can enforce a timeout.
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let _ = tx.send(child.wait_with_output());
+            });
+
+            let output = match rx.recv_timeout(timeout) {
+                Ok(result) => result.map_err(|e| {
+                    anyhow::anyhow!("run_subprocess: failed to collect output: {e}")
+                })?,
+                Err(_) => {
+                    return Err(anyhow::anyhow!(
+                        "run_subprocess: '{}' timed out after {}ms",
+                        binary,
+                        timeout.as_millis()
+                    ));
+                }
+            };
+
+            let resp = SubprocessResponse {
+                exit_code: output.status.code().unwrap_or(-1),
+                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            };
+            let json = serde_json::to_string(&resp).map_err(|e| {
+                anyhow::anyhow!("run_subprocess: failed to serialize response: {e}")
+            })?;
+
+            write_output_string(plugin, outputs, &json)
+        },
+    )
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::adapters::driven::plugin::capabilities::SharedHostResources;
+
+    #[test]
+    fn test_log_request_deserialization() {
+        let json = r#"{"level":"info","message":"hello from plugin"}"#;
+        let req: LogRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.level, "info");
+        assert_eq!(req.message, "hello from plugin");
+    }
+
+    #[test]
+    fn test_http_request_deserialization() {
+        let json = r#"{"method":"GET","url":"https://example.com","headers":{"Accept":"text/html"},"body":null}"#;
+        let req: HttpRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.method, "GET");
+        assert_eq!(req.url, "https://example.com");
+        assert_eq!(
+            req.headers.get("Accept").map(String::as_str),
+            Some("text/html")
+        );
+        assert!(req.body.is_none());
+    }
+
+    #[test]
+    fn test_subprocess_request_deserialization() {
+        let json = r#"{"binary":"yt-dlp","args":["--no-playlist","https://example.com"],"timeout_ms":5000}"#;
+        let req: SubprocessRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.binary, "yt-dlp");
+        assert_eq!(req.args, vec!["--no-playlist", "https://example.com"]);
+        assert_eq!(req.timeout_ms, Some(5000));
+    }
+
+    #[test]
+    fn test_get_set_config_round_trip() {
+        let shared = std::sync::Arc::new(SharedHostResources::new());
+        let plugin_name = "round-trip-plugin";
+
+        shared
+            .plugin_configs()
+            .entry(plugin_name.to_string())
+            .or_default()
+            .insert("my_key".to_string(), "my_value".to_string());
+
+        let value = shared
+            .plugin_configs()
+            .get(plugin_name)
+            .and_then(|m| m.get("my_key").map(|v| v.clone()))
+            .unwrap_or_default();
+
+        assert_eq!(value, "my_value");
+    }
+
+    #[test]
+    fn test_get_set_state_round_trip() {
+        let shared = std::sync::Arc::new(SharedHostResources::new());
+        let plugin_name = "state-plugin";
+
+        shared
+            .plugin_states()
+            .entry(plugin_name.to_string())
+            .or_default()
+            .insert("session".to_string(), "abc123".to_string());
+
+        let value = shared
+            .plugin_states()
+            .get(plugin_name)
+            .and_then(|m| m.get("session").map(|v| v.clone()))
+            .unwrap_or_default();
+
+        assert_eq!(value, "abc123");
+    }
+
+    #[test]
+    fn test_subprocess_binary_validation() {
+        let ctx_caps: Vec<String> = vec!["subprocess:ffmpeg".to_string()];
+        let required = "yt-dlp";
+        let cap_key = format!("subprocess:{required}");
+        assert!(!ctx_caps.iter().any(|c| c == &cap_key));
+
+        let ctx_caps2: Vec<String> = vec![
+            "subprocess:ffmpeg".to_string(),
+            "subprocess:yt-dlp".to_string(),
+        ];
+        assert!(ctx_caps2.iter().any(|c| c == &cap_key));
+    }
+}

--- a/src-tauri/src/adapters/driven/plugin/host_functions.rs
+++ b/src-tauri/src/adapters/driven/plugin/host_functions.rs
@@ -1,7 +1,10 @@
 //! Host function implementations for WASM plugins.
 
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::io::Read;
+use std::net::{IpAddr, ToSocketAddrs};
+use std::process::Child;
+use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
 
@@ -58,6 +61,15 @@ struct CredentialResponse {
     password: String,
 }
 
+struct CapturedOutput {
+    bytes: Vec<u8>,
+    truncated: bool,
+}
+
+const MAX_HTTP_BODY_BYTES: u64 = 100 * 1024 * 1024;
+const MAX_SUBPROCESS_OUTPUT_BYTES: usize = 1024 * 1024;
+const SUBPROCESS_POLL_INTERVAL: Duration = Duration::from_millis(25);
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 fn read_input_string(
@@ -85,16 +97,43 @@ fn validate_url_not_internal(url: &reqwest::Url) -> Result<(), extism::Error> {
                 "http_request: requests to localhost are forbidden"
             ));
         }
-        // Reject internal IPs
-        if let Ok(ip) = host.parse::<IpAddr>()
-            && (ip.is_loopback() || ip.is_unspecified() || is_private_ip(&ip) || is_link_local(&ip))
-        {
+
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            if is_forbidden_ip(&ip) {
+                return Err(anyhow::anyhow!(
+                    "http_request: requests to internal networks are forbidden"
+                ));
+            }
+            return Ok(());
+        }
+
+        let port = url
+            .port_or_known_default()
+            .ok_or_else(|| anyhow::anyhow!("http_request: URL is missing a known port"))?;
+
+        let resolved_ips = (host, port)
+            .to_socket_addrs()
+            .map_err(|e| anyhow::anyhow!("http_request: failed to resolve host '{host}': {e}"))?
+            .map(|socket_addr| socket_addr.ip())
+            .collect::<Vec<_>>();
+
+        if resolved_ips.is_empty() {
+            return Err(anyhow::anyhow!(
+                "http_request: host '{host}' did not resolve to any addresses"
+            ));
+        }
+
+        if resolved_ips.iter().any(is_forbidden_ip) {
             return Err(anyhow::anyhow!(
                 "http_request: requests to internal networks are forbidden"
             ));
         }
     }
     Ok(())
+}
+
+fn is_forbidden_ip(ip: &IpAddr) -> bool {
+    ip.is_loopback() || ip.is_unspecified() || is_private_ip(ip) || is_link_local(ip)
 }
 
 fn is_private_ip(ip: &IpAddr) -> bool {
@@ -141,6 +180,118 @@ fn validate_binary_name(binary: &str) -> Result<(), extism::Error> {
         ));
     }
     Ok(())
+}
+
+fn read_http_body_capped(
+    response: &mut reqwest::blocking::Response,
+) -> Result<Vec<u8>, extism::Error> {
+    let mut limited_reader = response.take(MAX_HTTP_BODY_BYTES + 1);
+    let mut body_bytes = Vec::new();
+    limited_reader
+        .read_to_end(&mut body_bytes)
+        .map_err(|e| anyhow::anyhow!("http_request: failed to read body: {e}"))?;
+
+    if body_bytes.len() as u64 > MAX_HTTP_BODY_BYTES {
+        return Err(anyhow::anyhow!(
+            "http_request: response body exceeds 100 MB limit"
+        ));
+    }
+
+    Ok(body_bytes)
+}
+
+fn read_stream_capped<R: Read>(mut reader: R, max_bytes: usize) -> std::io::Result<CapturedOutput> {
+    let mut bytes = Vec::new();
+    let mut truncated = false;
+    let mut chunk = [0_u8; 8192];
+
+    loop {
+        let read = reader.read(&mut chunk)?;
+        if read == 0 {
+            break;
+        }
+
+        let remaining = max_bytes.saturating_sub(bytes.len());
+        let to_copy = remaining.min(read);
+        if to_copy > 0 {
+            bytes.extend_from_slice(&chunk[..to_copy]);
+        }
+        if to_copy < read || bytes.len() >= max_bytes {
+            truncated = true;
+        }
+    }
+
+    Ok(CapturedOutput { bytes, truncated })
+}
+
+fn spawn_output_reader<T>(
+    stream: Option<T>,
+) -> std::thread::JoinHandle<std::io::Result<CapturedOutput>>
+where
+    T: Read + Send + 'static,
+{
+    std::thread::spawn(move || match stream {
+        Some(stream) => read_stream_capped(stream, MAX_SUBPROCESS_OUTPUT_BYTES),
+        None => Ok(CapturedOutput {
+            bytes: Vec::new(),
+            truncated: false,
+        }),
+    })
+}
+
+fn decode_captured_output(output: CapturedOutput) -> String {
+    let mut text = String::from_utf8_lossy(&output.bytes).into_owned();
+    if output.truncated {
+        text.push_str("\n[truncated]");
+    }
+    text
+}
+
+fn collect_subprocess_output(
+    stdout_handle: std::thread::JoinHandle<std::io::Result<CapturedOutput>>,
+    stderr_handle: std::thread::JoinHandle<std::io::Result<CapturedOutput>>,
+) -> Result<(String, String), extism::Error> {
+    let stdout = stdout_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("run_subprocess: stdout reader thread panicked"))?
+        .map_err(|e| anyhow::anyhow!("run_subprocess: failed to read stdout: {e}"))?;
+    let stderr = stderr_handle
+        .join()
+        .map_err(|_| anyhow::anyhow!("run_subprocess: stderr reader thread panicked"))?
+        .map_err(|e| anyhow::anyhow!("run_subprocess: failed to read stderr: {e}"))?;
+
+    Ok((
+        decode_captured_output(stdout),
+        decode_captured_output(stderr),
+    ))
+}
+
+fn wait_for_child_with_timeout(
+    child: &mut Child,
+    timeout: Duration,
+) -> Result<(std::process::ExitStatus, bool), extism::Error> {
+    let started_at = Instant::now();
+
+    loop {
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|e| anyhow::anyhow!("run_subprocess: failed to poll child status: {e}"))?
+        {
+            return Ok((status, false));
+        }
+
+        if started_at.elapsed() >= timeout {
+            child.kill().map_err(|e| {
+                anyhow::anyhow!("run_subprocess: failed to kill timed out process: {e}")
+            })?;
+            let status = child.wait().map_err(|e| {
+                anyhow::anyhow!("run_subprocess: failed to reap timed out process: {e}")
+            })?;
+            return Ok((status, true));
+        }
+
+        std::thread::sleep(SUBPROCESS_POLL_INTERVAL);
+    }
 }
 
 // ── Host functions ────────────────────────────────────────────────────────────
@@ -214,14 +365,13 @@ pub fn make_http_request_function(
                 builder = builder.body(body);
             }
 
-            let response = builder
+            let mut response = builder
                 .send()
                 .map_err(|e| anyhow::anyhow!("http_request: request failed: {e}"))?;
 
             // F2: Check Content-Length before reading body into memory
-            const MAX_BODY: u64 = 100 * 1024 * 1024;
             if let Some(len) = response.content_length()
-                && len > MAX_BODY
+                && len > MAX_HTTP_BODY_BYTES
             {
                 return Err(anyhow::anyhow!(
                     "http_request: Content-Length {len} exceeds 100 MB limit"
@@ -235,14 +385,7 @@ pub fn make_http_request_function(
                 .map(|(k, v)| (k.as_str().to_string(), v.to_str().unwrap_or("").to_string()))
                 .collect();
 
-            let body_bytes = response
-                .bytes()
-                .map_err(|e| anyhow::anyhow!("http_request: failed to read body: {e}"))?;
-            if body_bytes.len() as u64 > MAX_BODY {
-                return Err(anyhow::anyhow!(
-                    "http_request: response body exceeds 100 MB limit"
-                ));
-            }
+            let body_bytes = read_http_body_capped(&mut response)?;
             let body = String::from_utf8_lossy(&body_bytes).into_owned();
 
             let http_resp = HttpResponse {
@@ -456,7 +599,7 @@ pub fn make_run_subprocess_function(
             let timeout = std::time::Duration::from_millis(req.timeout_ms.unwrap_or(60_000));
             let binary = req.binary.clone();
 
-            let child = std::process::Command::new(&req.binary)
+            let mut child = std::process::Command::new(&req.binary)
                 .args(&req.args)
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())
@@ -465,29 +608,24 @@ pub fn make_run_subprocess_function(
                     anyhow::anyhow!("run_subprocess: failed to spawn '{}': {e}", req.binary)
                 })?;
 
-            // Run wait_with_output on a helper thread so we can enforce a timeout.
-            let (tx, rx) = std::sync::mpsc::channel();
-            std::thread::spawn(move || {
-                let _ = tx.send(child.wait_with_output());
-            });
+            let stdout_handle = spawn_output_reader(child.stdout.take());
+            let stderr_handle = spawn_output_reader(child.stderr.take());
 
-            let output = match rx.recv_timeout(timeout) {
-                Ok(result) => result.map_err(|e| {
-                    anyhow::anyhow!("run_subprocess: failed to collect output: {e}")
-                })?,
-                Err(_) => {
-                    return Err(anyhow::anyhow!(
-                        "run_subprocess: '{}' timed out after {}ms",
-                        binary,
-                        timeout.as_millis()
-                    ));
-                }
-            };
+            let (status, timed_out) = wait_for_child_with_timeout(&mut child, timeout)?;
+            let (stdout, stderr) = collect_subprocess_output(stdout_handle, stderr_handle)?;
+
+            if timed_out {
+                return Err(anyhow::anyhow!(
+                    "run_subprocess: '{}' timed out after {}ms",
+                    binary,
+                    timeout.as_millis()
+                ));
+            }
 
             let resp = SubprocessResponse {
-                exit_code: output.status.code().unwrap_or(-1),
-                stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                exit_code: status.code().unwrap_or(-1),
+                stdout,
+                stderr,
             };
             let json = serde_json::to_string(&resp).map_err(|e| {
                 anyhow::anyhow!("run_subprocess: failed to serialize response: {e}")

--- a/src-tauri/src/adapters/driven/plugin/mod.rs
+++ b/src-tauri/src/adapters/driven/plugin/mod.rs
@@ -1,4 +1,6 @@
+pub mod capabilities;
 pub mod extism_loader;
+pub mod host_functions;
 pub mod manifest;
 pub mod registry;
 pub mod watcher;

--- a/src-tauri/src/adapters/driven/plugin/watcher.rs
+++ b/src-tauri/src/adapters/driven/plugin/watcher.rs
@@ -114,7 +114,11 @@ mod tests {
     use tempfile::TempDir;
 
     fn make_loader(plugins_dir: &std::path::Path) -> Arc<ExtismPluginLoader> {
-        Arc::new(ExtismPluginLoader::new(plugins_dir.to_path_buf()))
+        use crate::adapters::driven::plugin::capabilities::SharedHostResources;
+        Arc::new(ExtismPluginLoader::new(
+            plugins_dir.to_path_buf(),
+            Arc::new(SharedHostResources::new()),
+        ))
     }
 
     fn setup_plugin_dir(plugins_dir: &std::path::Path, name: &str) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ pub use application::read_models::{
 };
 pub use application::services::QueueManager;
 
+pub use adapters::driven::plugin::capabilities::SharedHostResources;
 pub use adapters::driven::plugin::{ExtismPluginLoader, PluginRegistry, PluginWatcher};
 pub use adapters::driving::tauri_ipc::{
     self, AppState, download_cancel, download_count_by_state, download_detail, download_list,


### PR DESCRIPTION
## Summary

- Implements all 6 host functions exposed to WASM plugins: `http_request`, `log`, `get_config`, `set_config`, `get_state`, `get_credential`, `run_subprocess`
- Adds capability-based registration: `http_request` and `run_subprocess` are only registered when the manifest declares the matching capability
- Addresses all CRITICAL/HIGH findings from adversarial review (F1 SSRF, F2 OOM, F3 credential scoping, F4 path traversal, F6 mutex scope, F7 no unsafe)

## Security hardening

| Finding | Fix |
|---------|-----|
| F1 SSRF | Rejects localhost, RFC1918, link-local (169.254/16 incl. AWS metadata), fc00::/7, fe80::/10 |
| F2 OOM | Content-Length pre-check + post-read body guard (100 MB limit) |
| F3 credential scoping | Plugin can only read credentials keyed to its own name |
| F4 path traversal | Binary name rejected if it contains `/`, `\`, `..`, or null bytes |
| F6 mutex scope | Lock released before HTTP call and subprocess spawn |
| F7 unsafe removal | No `unsafe` code in host function implementations |

## Test plan

- [x] 284 tests pass (`cargo test --workspace`)
- [x] Clippy clean (`cargo clippy --workspace -- -D warnings`)
- [x] pre-commit hooks pass (no-secrets, rust-fmt, rust-clippy)
- [x] All spec success criteria checked in `14-plugin-host-functions.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements capability-based host functions for WASM plugins and integrates them with the Extism loader via `SharedHostResources`. `http_request` and `run_subprocess` are only registered when declared in the manifest (meets Linear 14).

- **New Features**
  - Six base host functions: `log`, `get_config`, `set_config`, `get_state`, `set_state`, `get_credential`.
  - Capability-gated: `http_request` (`http`) and `run_subprocess` (`subprocess:<bin>`).
  - Security: SSRF defense with DNS resolve + address pinning; 100 MB HTTP cap with Content-Length pre-check; subprocess 60s default timeout and 1 MB stdout/stderr cap; per-plugin credential scoping; binary name validation; minimized mutex scope; no `unsafe`.
  - `SharedHostResources`: blocking HTTP client (30s timeout, redirects disabled, address pinning), optional credential store; Extism loader now requires it and builds host functions per manifest.

- **Dependencies**
  - Added `anyhow`.
  - Enabled `reqwest` `blocking` feature.

<sup>Written for commit c94bf2104073881c9c81729765fb40c948ecdd59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can call new host functions: HTTP requests, logging, config/state get/set, credential retrieval, and subprocess execution.
  * Plugins declare capabilities to enable specific host functions; host functions are registered per-plugin.

* **Security**
  * Capability-based access control enforces per-plugin permissions.
  * HTTP requests, subprocesses, and credential access include URL/IP validation, binary validation, timeouts, and response/output size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->