### PR TITLE
feat(ui): implement Tauri IPC data layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
+        "@tanstack/react-query": "^5.97.0",
         "@tauri-apps/api": "^2.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -3688,6 +3689,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.97.0.tgz",
+      "integrity": "sha512-QdpLP5VzVMgo4VtaPppRA2W04UFjIqX+bxke/ZJhE5cfd5UPkRzqIAJQt9uXkQJjqE8LBOMbKv7f8HCsZltXlg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.97.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.97.0.tgz",
+      "integrity": "sha512-y4So4eGcQoK2WVMAcDNZE9ofB/p5v1OlKvtc1F3uqHwrtifobT7q+ZnXk2mRkc8E84HKYSlAE9z6HXl2V0+ySQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.97.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tauri-apps/api": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
+    "@tanstack/react-query": "^5.97.0",
     "@tauri-apps/api": "^2.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { AppLayout } from "@/layouts/AppLayout";
 import {
   DownloadsView,
@@ -12,9 +13,11 @@ import {
   StatisticsView,
   SettingsView,
 } from "@/views";
+import { queryClient } from "@/api/client";
 
 export function App() {
   return (
+    <QueryClientProvider client={queryClient}>
     <BrowserRouter>
       <Routes>
         <Route element={<AppLayout />}>
@@ -33,5 +36,6 @@ export function App() {
         </Route>
       </Routes>
     </BrowserRouter>
+    </QueryClientProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,24 +18,24 @@ import { queryClient } from "@/api/client";
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
-    <BrowserRouter>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route index element={<Navigate to="/downloads" replace />} />
-          <Route path="downloads" element={<DownloadsView />} />
-          <Route path="link-grabber" element={<LinkGrabberView />} />
-          <Route path="packages" element={<PackagesView />} />
-          <Route path="accounts" element={<AccountsView />} />
-          <Route path="captcha" element={<CaptchaView />} />
-          <Route path="plugins" element={<PluginsView />} />
-          <Route path="scheduler" element={<SchedulerView />} />
-          <Route path="history" element={<HistoryView />} />
-          <Route path="statistics" element={<StatisticsView />} />
-          <Route path="settings" element={<SettingsView />} />
-          <Route path="*" element={<Navigate to="/downloads" replace />} />
-        </Route>
-      </Routes>
-    </BrowserRouter>
+      <BrowserRouter>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route index element={<Navigate to="/downloads" replace />} />
+            <Route path="downloads" element={<DownloadsView />} />
+            <Route path="link-grabber" element={<LinkGrabberView />} />
+            <Route path="packages" element={<PackagesView />} />
+            <Route path="accounts" element={<AccountsView />} />
+            <Route path="captcha" element={<CaptchaView />} />
+            <Route path="plugins" element={<PluginsView />} />
+            <Route path="scheduler" element={<SchedulerView />} />
+            <Route path="history" element={<HistoryView />} />
+            <Route path="statistics" element={<StatisticsView />} />
+            <Route path="settings" element={<SettingsView />} />
+            <Route path="*" element={<Navigate to="/downloads" replace />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
     </QueryClientProvider>
   );
 }

--- a/src/api/__tests__/client.test.ts
+++ b/src/api/__tests__/client.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from '@tauri-apps/api/core';
+import { tauriInvoke, queryClient } from '@/api/client';
+
+describe('tauriInvoke', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return typed data on success', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce({ id: '1', fileName: 'test.zip' });
+    const result = await tauriInvoke<{ id: string; fileName: string }>('get_download', { id: '1' });
+    expect(result).toEqual({ id: '1', fileName: 'test.zip' });
+    expect(invoke).toHaveBeenCalledWith('get_download', { id: '1' });
+  });
+
+  it('should propagate errors thrown by invoke', async () => {
+    vi.mocked(invoke).mockRejectedValueOnce(new Error('command not found'));
+    await expect(tauriInvoke('unknown_command')).rejects.toThrow('command not found');
+  });
+
+  it('should call invoke without args when none provided', async () => {
+    vi.mocked(invoke).mockResolvedValueOnce([]);
+    await tauriInvoke('list_downloads');
+    expect(invoke).toHaveBeenCalledWith('list_downloads', undefined);
+  });
+});
+
+describe('queryClient', () => {
+  it('should have staleTime of 5 minutes', () => {
+    const defaults = queryClient.getDefaultOptions();
+    expect(defaults.queries?.staleTime).toBe(5 * 60 * 1000);
+  });
+
+  it('should have gcTime of 10 minutes', () => {
+    const defaults = queryClient.getDefaultOptions();
+    expect(defaults.queries?.gcTime).toBe(10 * 60 * 1000);
+  });
+
+  it('should retry once', () => {
+    const defaults = queryClient.getDefaultOptions();
+    expect(defaults.queries?.retry).toBe(1);
+  });
+
+  it('should not refetch on window focus', () => {
+    const defaults = queryClient.getDefaultOptions();
+    expect(defaults.queries?.refetchOnWindowFocus).toBe(false);
+  });
+});

--- a/src/api/__tests__/hooks.test.ts
+++ b/src/api/__tests__/hooks.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+vi.mock('@/api/client', () => ({
+  tauriInvoke: vi.fn(),
+  queryClient: new QueryClient({ defaultOptions: { queries: { retry: false } } }),
+}));
+
+import { tauriInvoke } from '@/api/client';
+import { useTauriQuery, useTauriMutation } from '@/api/hooks';
+
+function makeWrapper() {
+  const testClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: testClient }, children);
+}
+
+describe('useTauriQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call tauriInvoke with command and args', async () => {
+    vi.mocked(tauriInvoke).mockResolvedValueOnce({ id: '1' });
+    const { result } = renderHook(
+      () => useTauriQuery('get_download', { id: '1' }),
+      { wrapper: makeWrapper() }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(tauriInvoke).toHaveBeenCalledWith('get_download', { id: '1' });
+  });
+
+  it('should return data on success', async () => {
+    vi.mocked(tauriInvoke).mockResolvedValueOnce({ id: '1', fileName: 'test.zip' });
+    const { result } = renderHook(
+      () => useTauriQuery<{ id: string; fileName: string }>('get_download', { id: '1' }),
+      { wrapper: makeWrapper() }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ id: '1', fileName: 'test.zip' });
+  });
+
+  it('should expose error on failure', async () => {
+    vi.mocked(tauriInvoke).mockRejectedValueOnce(new Error('not found'));
+    const { result } = renderHook(
+      () => useTauriQuery('get_download', { id: '99' }),
+      { wrapper: makeWrapper() }
+    );
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('not found');
+  });
+
+  it('should call tauriInvoke without args when none provided', async () => {
+    vi.mocked(tauriInvoke).mockResolvedValueOnce([]);
+    const { result } = renderHook(
+      () => useTauriQuery('list_downloads'),
+      { wrapper: makeWrapper() }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(tauriInvoke).toHaveBeenCalledWith('list_downloads', undefined);
+  });
+});
+
+describe('useTauriMutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should call tauriInvoke with command on mutate', async () => {
+    vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
+    const { result } = renderHook(
+      () => useTauriMutation('download_pause'),
+      { wrapper: makeWrapper() }
+    );
+    await act(async () => {
+      result.current.mutate({ id: '1' } as Record<string, unknown>);
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(tauriInvoke).toHaveBeenCalledWith('download_pause', { id: '1' });
+  });
+
+  it('should expose error when mutation fails', async () => {
+    vi.mocked(tauriInvoke).mockRejectedValueOnce(new Error('pause failed'));
+    const { result } = renderHook(
+      () => useTauriMutation('download_pause'),
+      { wrapper: makeWrapper() }
+    );
+    await act(async () => {
+      result.current.mutate({ id: '1' } as Record<string, unknown>);
+    });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('pause failed');
+  });
+});

--- a/src/api/__tests__/queries.test.ts
+++ b/src/api/__tests__/queries.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { downloadQueries, pluginQueries, historyQueries, statsQueries } from '@/api/queries';
+import type { DownloadFilter } from '@/types/download';
+
+describe('downloadQueries', () => {
+  it('should return base key for all()', () => {
+    expect(downloadQueries.all()).toEqual(['downloads']);
+  });
+
+  it('should return list key for lists()', () => {
+    expect(downloadQueries.lists()).toEqual(['downloads', 'list']);
+  });
+
+  it('should return list key with filters when provided', () => {
+    const filter: DownloadFilter = { filterState: 'Downloading' };
+    const key = downloadQueries.list(filter);
+    expect(key).toEqual(['downloads', 'list', filter]);
+  });
+
+  it('should return base lists key when no filter provided', () => {
+    const key = downloadQueries.list();
+    expect(key).toEqual(['downloads', 'list']);
+  });
+
+  it('should return detail base key for details()', () => {
+    expect(downloadQueries.details()).toEqual(['downloads', 'detail']);
+  });
+
+  it('should return detail key with id for detail()', () => {
+    expect(downloadQueries.detail('42')).toEqual(['downloads', 'detail', '42']);
+  });
+});
+
+describe('pluginQueries', () => {
+  it('should return base key for all()', () => {
+    expect(pluginQueries.all()).toEqual(['plugins']);
+  });
+
+  it('should return list key for lists()', () => {
+    expect(pluginQueries.lists()).toEqual(['plugins', 'list']);
+  });
+
+  it('should return list key for list()', () => {
+    expect(pluginQueries.list()).toEqual(['plugins', 'list']);
+  });
+});
+
+describe('historyQueries', () => {
+  it('should return base key for all()', () => {
+    expect(historyQueries.all()).toEqual(['history']);
+  });
+
+  it('should return list key for list()', () => {
+    expect(historyQueries.list()).toEqual(['history', 'list']);
+  });
+});
+
+describe('statsQueries', () => {
+  it('should return base key for all()', () => {
+    expect(statsQueries.all()).toEqual(['stats']);
+  });
+
+  it('should return overview key for overview()', () => {
+    expect(statsQueries.overview()).toEqual(['stats', 'overview']);
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,26 @@
+import { invoke } from '@tauri-apps/api/core';
+import { QueryClient } from '@tanstack/react-query';
+
+function toError(err: unknown): Error {
+  if (err instanceof Error) return err;
+  return new Error(typeof err === 'string' ? err : JSON.stringify(err));
+}
+
+export async function tauriInvoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  try {
+    return await invoke<T>(command, args);
+  } catch (err) {
+    throw toError(err);
+  }
+}
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5 * 60 * 1000,
+      gcTime: 10 * 60 * 1000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,0 +1,42 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { UseQueryOptions } from '@tanstack/react-query';
+import { tauriInvoke } from '@/api/client';
+
+export function useTauriQuery<T>(
+  command: string,
+  args?: Record<string, unknown>,
+  options?: Omit<UseQueryOptions<T, Error>, 'queryKey' | 'queryFn'>
+) {
+  return useQuery<T, Error>({
+    queryKey: args ? [command, args] : [command],
+    queryFn: () => tauriInvoke<T>(command, args),
+    ...options,
+  });
+}
+
+interface UseTauriMutationOptions<TData, TVariables> {
+  invalidateKeys?: readonly unknown[][];
+  onSuccess?: (data: TData, variables: TVariables, context: unknown) => void;
+  onError?: (error: Error, variables: TVariables, context: unknown) => void;
+}
+
+export function useTauriMutation<
+  TData = unknown,
+  TVariables extends Record<string, unknown> | void = Record<string, unknown>,
+>(command: string, options?: UseTauriMutationOptions<TData, TVariables>) {
+  const queryClientInstance = useQueryClient();
+
+  return useMutation<TData, Error, TVariables>({
+    mutationFn: (variables) =>
+      tauriInvoke<TData>(command, variables as Record<string, unknown> | undefined),
+    onSuccess: (data, variables, context) => {
+      if (options?.invalidateKeys) {
+        for (const key of options.invalidateKeys) {
+          queryClientInstance.invalidateQueries({ queryKey: key });
+        }
+      }
+      options?.onSuccess?.(data, variables, context);
+    },
+    onError: options?.onError,
+  });
+}

--- a/src/api/queries.ts
+++ b/src/api/queries.ts
@@ -1,0 +1,27 @@
+import type { DownloadFilter } from '@/types/download';
+
+export const downloadQueries = {
+  all: () => ['downloads'] as const,
+  lists: () => [...downloadQueries.all(), 'list'] as const,
+  list: (filters?: DownloadFilter) =>
+    filters ? ([...downloadQueries.lists(), filters] as const) : (downloadQueries.lists() as readonly unknown[]),
+  details: () => [...downloadQueries.all(), 'detail'] as const,
+  detail: (id: string) => [...downloadQueries.details(), id] as const,
+};
+
+export const pluginQueries = {
+  all: () => ['plugins'] as const,
+  lists: () => [...pluginQueries.all(), 'list'] as const,
+  list: () => pluginQueries.lists(),
+};
+
+export const historyQueries = {
+  all: () => ['history'] as const,
+  lists: () => [...historyQueries.all(), 'list'] as const,
+  list: () => historyQueries.lists(),
+};
+
+export const statsQueries = {
+  all: () => ['stats'] as const,
+  overview: () => [...statsQueries.all(), 'overview'] as const,
+};

--- a/src/hooks/__tests__/useDownloadEvents.test.ts
+++ b/src/hooks/__tests__/useDownloadEvents.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDownloadEvents } from '@/hooks/useDownloadEvents';
+
+vi.mock('@/hooks/useTauriEvent', () => ({
+  useTauriEvent: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  queryClient: {
+    invalidateQueries: vi.fn(),
+  },
+  tauriInvoke: vi.fn(),
+}));
+
+vi.mock('@/api/queries', () => ({
+  downloadQueries: {
+    lists: () => ['downloads', 'list'],
+  },
+}));
+
+import { useTauriEvent } from '@/hooks/useTauriEvent';
+import { queryClient } from '@/api/client';
+
+describe('useDownloadEvents', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should subscribe to all download lifecycle events', () => {
+    renderHook(() => useDownloadEvents());
+    const subscribedEvents = vi.mocked(useTauriEvent).mock.calls.map(([event]) => event);
+    expect(subscribedEvents).toContain('download-created');
+    expect(subscribedEvents).toContain('download-started');
+    expect(subscribedEvents).toContain('download-paused');
+    expect(subscribedEvents).toContain('download-resumed');
+    expect(subscribedEvents).toContain('download-completed');
+    expect(subscribedEvents).toContain('download-failed');
+    expect(subscribedEvents).toContain('download-cancelled');
+    expect(subscribedEvents).toContain('download-waiting');
+  });
+
+  it('should invalidate download list queries on download-created', () => {
+    vi.mocked(useTauriEvent).mockImplementation((event, callback) => {
+      if (event === 'download-created') callback({ id: 1 });
+    });
+    renderHook(() => useDownloadEvents());
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['downloads', 'list'],
+    });
+  });
+
+  it('should invalidate download list queries on download-completed', () => {
+    vi.mocked(useTauriEvent).mockImplementation((event, callback) => {
+      if (event === 'download-completed') callback({ id: 2 });
+    });
+    renderHook(() => useDownloadEvents());
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['downloads', 'list'],
+    });
+  });
+
+  it('should invalidate download list queries on download-failed', () => {
+    vi.mocked(useTauriEvent).mockImplementation((event, callback) => {
+      if (event === 'download-failed') callback({ id: 3, error: 'timeout' });
+    });
+    renderHook(() => useDownloadEvents());
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['downloads', 'list'],
+    });
+  });
+
+  it('should invalidate download list queries on download-cancelled', () => {
+    vi.mocked(useTauriEvent).mockImplementation((event, callback) => {
+      if (event === 'download-cancelled') callback({ id: 4 });
+    });
+    renderHook(() => useDownloadEvents());
+    expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['downloads', 'list'],
+    });
+  });
+
+  it('should subscribe to exactly 8 lifecycle events', () => {
+    renderHook(() => useDownloadEvents());
+    expect(useTauriEvent).toHaveBeenCalledTimes(8);
+  });
+});

--- a/src/hooks/__tests__/useDownloadProgress.test.ts
+++ b/src/hooks/__tests__/useDownloadProgress.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useDownloadProgress } from '@/hooks/useDownloadProgress';
+
+vi.mock('@/hooks/useTauriEvent', () => ({
+  useTauriEvent: vi.fn(),
+}));
+
+vi.mock('@/stores/downloadStore', () => ({
+  useDownloadStore: Object.assign(vi.fn(), {
+    getState: vi.fn(),
+  }),
+}));
+
+import { useTauriEvent } from '@/hooks/useTauriEvent';
+import { useDownloadStore } from '@/stores/downloadStore';
+
+describe('useDownloadProgress', () => {
+  const mockUpdateProgress = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useDownloadStore.getState).mockReturnValue({
+      updateProgress: mockUpdateProgress,
+      progressMap: {},
+      countByState: {},
+      removeProgress: vi.fn(),
+      updateCountByState: vi.fn(),
+      clearAllProgress: vi.fn(),
+    });
+  });
+
+  it('should subscribe to download-progress event', () => {
+    renderHook(() => useDownloadProgress());
+    expect(useTauriEvent).toHaveBeenCalledWith('download-progress', expect.any(Function));
+  });
+
+  it('should call updateProgress with string id and bytes when event fires', () => {
+    vi.mocked(useTauriEvent).mockImplementationOnce((_event, callback) => {
+      callback({ id: 42, downloadedBytes: 500, totalBytes: 1000 });
+    });
+    renderHook(() => useDownloadProgress());
+    expect(mockUpdateProgress).toHaveBeenCalledWith('42', 500, 1000);
+  });
+
+  it('should use getState() to avoid unnecessary re-renders', () => {
+    renderHook(() => useDownloadProgress());
+    const [, callback] = vi.mocked(useTauriEvent).mock.calls[0] as [string, (p: unknown) => void];
+    callback({ id: 1, downloadedBytes: 100, totalBytes: 200 });
+    expect(useDownloadStore.getState).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useDownloadEvents.ts
+++ b/src/hooks/useDownloadEvents.ts
@@ -1,0 +1,19 @@
+import { useTauriEvent } from '@/hooks/useTauriEvent';
+import { queryClient } from '@/api/client';
+import { downloadQueries } from '@/api/queries';
+import type { DownloadIdPayload, DownloadFailedPayload } from '@/types/events';
+
+export function useDownloadEvents(): void {
+  const invalidateDownloads = () => {
+    queryClient.invalidateQueries({ queryKey: downloadQueries.lists() });
+  };
+
+  useTauriEvent<DownloadIdPayload>('download-created', invalidateDownloads);
+  useTauriEvent<DownloadIdPayload>('download-started', invalidateDownloads);
+  useTauriEvent<DownloadIdPayload>('download-paused', invalidateDownloads);
+  useTauriEvent<DownloadIdPayload>('download-resumed', invalidateDownloads);
+  useTauriEvent<DownloadIdPayload>('download-completed', invalidateDownloads);
+  useTauriEvent<DownloadFailedPayload>('download-failed', invalidateDownloads);
+  useTauriEvent<DownloadIdPayload>('download-cancelled', invalidateDownloads);
+  useTauriEvent<DownloadIdPayload>('download-waiting', invalidateDownloads);
+}

--- a/src/hooks/useDownloadProgress.ts
+++ b/src/hooks/useDownloadProgress.ts
@@ -1,0 +1,13 @@
+import { useTauriEvent } from '@/hooks/useTauriEvent';
+import { useDownloadStore } from '@/stores/downloadStore';
+import type { DownloadProgressPayload } from '@/types/events';
+
+export function useDownloadProgress(): void {
+  useTauriEvent<DownloadProgressPayload>('download-progress', (payload) => {
+    useDownloadStore.getState().updateProgress(
+      String(payload.id),
+      payload.downloadedBytes,
+      payload.totalBytes,
+    );
+  });
+}

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -3,9 +3,13 @@ import { Outlet, useNavigate } from "react-router";
 import { Sidebar } from "./Sidebar";
 import { StatusBar } from "./StatusBar";
 import { ROUTES } from "@/types/layout";
+import { useDownloadProgress } from "@/hooks/useDownloadProgress";
+import { useDownloadEvents } from "@/hooks/useDownloadEvents";
 
 export function AppLayout() {
   const navigate = useNavigate();
+  useDownloadProgress();
+  useDownloadEvents();
 
   useEffect(() => {
     function handleKeydown(event: KeyboardEvent) {

--- a/src/layouts/StatusBar.tsx
+++ b/src/layouts/StatusBar.tsx
@@ -1,14 +1,15 @@
 import { useLayoutStore } from "@/stores/layout-store";
+import { useDownloadStore, selectTotalSpeed, selectActiveCount } from "@/stores/downloadStore";
 
 function Dot() {
   return <span className="text-[10px] text-border">·</span>;
 }
 
 export function StatusBar() {
-  const totalSpeed = useLayoutStore((state) => state.totalSpeed);
+  const totalSpeed = useDownloadStore(selectTotalSpeed);
+  const activeCount = useDownloadStore(selectActiveCount);
   const speedLimit = useLayoutStore((state) => state.speedLimit);
   const freeSpace = useLayoutStore((state) => state.freeSpace);
-  const totalConnections = useLayoutStore((state) => state.totalConnections);
   const appVersion = useLayoutStore((state) => state.appVersion);
 
   const limitLabel = speedLimit > 0 ? `${speedLimit} MB/s` : "unlimited";
@@ -29,7 +30,7 @@ export function StatusBar() {
         <Dot />
         <div className="flex items-center gap-1.5">
           <div className="h-[7px] w-[7px] rounded-full bg-success" />
-          <span className="text-text-dim">{totalConnections} connections</span>
+          <span className="text-text-dim">{activeCount} active</span>
         </div>
       </div>
     </footer>

--- a/src/layouts/__tests__/AppLayout.test.tsx
+++ b/src/layouts/__tests__/AppLayout.test.tsx
@@ -6,6 +6,14 @@ import { AppLayout } from "../AppLayout";
 const mockNavigate = vi.fn();
 const originalPlatform = navigator.platform;
 
+vi.mock("@/hooks/useDownloadProgress", () => ({
+  useDownloadProgress: vi.fn(),
+}));
+
+vi.mock("@/hooks/useDownloadEvents", () => ({
+  useDownloadEvents: vi.fn(),
+}));
+
 vi.mock("react-router", async () => {
   const actual = await vi.importActual("react-router");
   return {

--- a/src/layouts/__tests__/StatusBar.test.tsx
+++ b/src/layouts/__tests__/StatusBar.test.tsx
@@ -18,9 +18,9 @@ describe("StatusBar", () => {
     expect(screen.getByText(/-- GB/)).toBeInTheDocument();
   });
 
-  it("should render connection count", () => {
+  it("should render active download count", () => {
     render(<StatusBar />);
-    expect(screen.getByText(/0 connections/)).toBeInTheDocument();
+    expect(screen.getByText(/0 active/)).toBeInTheDocument();
   });
 
   it("should render app version", () => {

--- a/src/stores/__tests__/downloadStore.test.ts
+++ b/src/stores/__tests__/downloadStore.test.ts
@@ -8,11 +8,11 @@ beforeEach(() => {
 describe('useDownloadStore — updateProgress', () => {
   it('should add entry to progressMap', () => {
     useDownloadStore.getState().updateProgress('1', 500, 1000);
-    expect(useDownloadStore.getState().progressMap['1']).toEqual({
-      id: '1',
-      downloadedBytes: 500,
-      totalBytes: 1000,
-    });
+    const entry = useDownloadStore.getState().progressMap['1'];
+    expect(entry.id).toBe('1');
+    expect(entry.downloadedBytes).toBe(500);
+    expect(entry.totalBytes).toBe(1000);
+    expect(entry.speedBytesPerSec).toBe(0);
   });
 
   it('should update existing entry', () => {
@@ -76,7 +76,18 @@ describe('selectActiveCount', () => {
 });
 
 describe('selectTotalSpeed', () => {
-  it('should return 0', () => {
+  it('should return 0 when no progress entries', () => {
     expect(selectTotalSpeed(useDownloadStore.getState())).toBe(0);
+  });
+
+  it('should sum speed across progress entries', () => {
+    useDownloadStore.setState({
+      progressMap: {
+        '1': { id: '1', downloadedBytes: 500, totalBytes: 1000, speedBytesPerSec: 100, lastSampleBytes: 500, lastSampleTime: Date.now() },
+        '2': { id: '2', downloadedBytes: 300, totalBytes: 600, speedBytesPerSec: 200, lastSampleBytes: 300, lastSampleTime: Date.now() },
+      },
+      countByState: {},
+    });
+    expect(selectTotalSpeed(useDownloadStore.getState())).toBe(300);
   });
 });

--- a/src/stores/__tests__/downloadStore.test.ts
+++ b/src/stores/__tests__/downloadStore.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDownloadStore, selectActiveCount, selectTotalSpeed } from '@/stores/downloadStore';
+
+beforeEach(() => {
+  useDownloadStore.setState({ progressMap: {}, countByState: {} });
+});
+
+describe('useDownloadStore — updateProgress', () => {
+  it('should add entry to progressMap', () => {
+    useDownloadStore.getState().updateProgress('1', 500, 1000);
+    expect(useDownloadStore.getState().progressMap['1']).toEqual({
+      id: '1',
+      downloadedBytes: 500,
+      totalBytes: 1000,
+    });
+  });
+
+  it('should update existing entry', () => {
+    useDownloadStore.getState().updateProgress('1', 500, 1000);
+    useDownloadStore.getState().updateProgress('1', 800, 1000);
+    expect(useDownloadStore.getState().progressMap['1'].downloadedBytes).toBe(800);
+  });
+
+  it('should handle multiple entries independently', () => {
+    useDownloadStore.getState().updateProgress('1', 100, 200);
+    useDownloadStore.getState().updateProgress('2', 300, 400);
+    expect(Object.keys(useDownloadStore.getState().progressMap)).toHaveLength(2);
+  });
+});
+
+describe('useDownloadStore — removeProgress', () => {
+  it('should remove entry from progressMap', () => {
+    useDownloadStore.getState().updateProgress('1', 500, 1000);
+    useDownloadStore.getState().removeProgress('1');
+    expect(useDownloadStore.getState().progressMap['1']).toBeUndefined();
+  });
+
+  it('should not affect other entries when removing', () => {
+    useDownloadStore.getState().updateProgress('1', 100, 200);
+    useDownloadStore.getState().updateProgress('2', 300, 400);
+    useDownloadStore.getState().removeProgress('1');
+    expect(useDownloadStore.getState().progressMap['2']).toBeDefined();
+  });
+});
+
+describe('useDownloadStore — updateCountByState', () => {
+  it('should update countByState', () => {
+    useDownloadStore.getState().updateCountByState({ Downloading: 3, Paused: 1 });
+    expect(useDownloadStore.getState().countByState).toEqual({ Downloading: 3, Paused: 1 });
+  });
+
+  it('should replace previous counts', () => {
+    useDownloadStore.getState().updateCountByState({ Downloading: 3 });
+    useDownloadStore.getState().updateCountByState({ Paused: 2 });
+    expect(useDownloadStore.getState().countByState).toEqual({ Paused: 2 });
+  });
+});
+
+describe('useDownloadStore — clearAllProgress', () => {
+  it('should clear progressMap', () => {
+    useDownloadStore.getState().updateProgress('1', 100, 200);
+    useDownloadStore.getState().clearAllProgress();
+    expect(useDownloadStore.getState().progressMap).toEqual({});
+  });
+});
+
+describe('selectActiveCount', () => {
+  it('should return Downloading count', () => {
+    useDownloadStore.setState({ countByState: { Downloading: 5 }, progressMap: {} });
+    expect(selectActiveCount(useDownloadStore.getState())).toBe(5);
+  });
+
+  it('should return 0 when no Downloading entries', () => {
+    expect(selectActiveCount(useDownloadStore.getState())).toBe(0);
+  });
+});
+
+describe('selectTotalSpeed', () => {
+  it('should return 0', () => {
+    expect(selectTotalSpeed(useDownloadStore.getState())).toBe(0);
+  });
+});

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+vi.mock('@/api/client', () => ({
+  tauriInvoke: vi.fn(),
+  queryClient: {},
+}));
+
+import { tauriInvoke } from '@/api/client';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useSettingsStore.setState({ config: null, isLoading: false, error: null });
+});
+
+describe('useSettingsStore — setConfig', () => {
+  it('should set config', () => {
+    useSettingsStore.getState().setConfig({ theme: 'dark' });
+    expect(useSettingsStore.getState().config).toEqual({ theme: 'dark' });
+  });
+});
+
+describe('useSettingsStore — updateConfig', () => {
+  it('should call tauriInvoke with settings command', async () => {
+    vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
+    useSettingsStore.setState({ config: { theme: 'light' }, isLoading: false });
+    await useSettingsStore.getState().updateConfig({ theme: 'dark' });
+    expect(tauriInvoke).toHaveBeenCalledWith('settings_update', { theme: 'dark' });
+  });
+
+  it('should merge partial config on success', async () => {
+    vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
+    useSettingsStore.setState({ config: { theme: 'light', lang: 'fr' }, isLoading: false });
+    await useSettingsStore.getState().updateConfig({ theme: 'dark' });
+    expect(useSettingsStore.getState().config).toEqual({ theme: 'dark', lang: 'fr' });
+  });
+
+  it('should set config with partial when config was null', async () => {
+    vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
+    await useSettingsStore.getState().updateConfig({ theme: 'dark' });
+    expect(useSettingsStore.getState().config).toEqual({ theme: 'dark' });
+  });
+
+  it('should reset isLoading to false after success', async () => {
+    vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
+    await useSettingsStore.getState().updateConfig({ theme: 'dark' });
+    expect(useSettingsStore.getState().isLoading).toBe(false);
+  });
+
+  it('should set error and re-throw on failure', async () => {
+    vi.mocked(tauriInvoke).mockRejectedValueOnce(new Error('server error'));
+    await expect(useSettingsStore.getState().updateConfig({ theme: 'dark' })).rejects.toThrow('server error');
+    expect(useSettingsStore.getState().isLoading).toBe(false);
+    expect(useSettingsStore.getState().error).toBe('server error');
+  });
+
+  it('should clear error on next successful update', async () => {
+    useSettingsStore.setState({ error: 'previous error' });
+    vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
+    await useSettingsStore.getState().updateConfig({ theme: 'dark' });
+    expect(useSettingsStore.getState().error).toBeNull();
+  });
+});

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -8,6 +8,18 @@ vi.mock('@/api/client', () => ({
 
 import { tauriInvoke } from '@/api/client';
 
+const baseConfig = {
+  downloadDir: '/tmp',
+  maxConcurrentDownloads: 3,
+  maxSegmentsPerDownload: 8,
+  speedLimitBytesPerSec: null,
+  autoExtract: false,
+  theme: 'light',
+  locale: 'en',
+  clipboardMonitoring: true,
+  minimizeToTray: false,
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   useSettingsStore.setState({ config: null, isLoading: false, error: null });
@@ -15,54 +27,57 @@ beforeEach(() => {
 
 describe('useSettingsStore — setConfig', () => {
   it('should set config', () => {
-    useSettingsStore.getState().setConfig({ theme: 'dark' });
-    expect(useSettingsStore.getState().config).toEqual({ theme: 'dark' });
+    useSettingsStore.getState().setConfig({ ...baseConfig, theme: 'dark' });
+    expect(useSettingsStore.getState().config?.theme).toBe('dark');
   });
 });
 
 describe('useSettingsStore — updateConfig', () => {
   it('should call tauriInvoke with settings command', async () => {
     vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
-    useSettingsStore.setState({ config: { theme: 'light' }, isLoading: false });
+    useSettingsStore.setState({ config: baseConfig, isLoading: false });
     await useSettingsStore.getState().updateConfig({ theme: 'dark' });
     expect(tauriInvoke).toHaveBeenCalledWith('settings_update', { theme: 'dark' });
   });
 
   it('should merge partial config on success', async () => {
     vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
-    useSettingsStore.setState({ config: { theme: 'light', lang: 'fr' }, isLoading: false });
+    useSettingsStore.setState({ config: baseConfig, isLoading: false });
     await useSettingsStore.getState().updateConfig({ theme: 'dark' });
-    expect(useSettingsStore.getState().config).toEqual({ theme: 'dark', lang: 'fr' });
+    expect(useSettingsStore.getState().config?.theme).toBe('dark');
+    expect(useSettingsStore.getState().config?.locale).toBe('en');
   });
 
-  it('should set config with partial when config was null', async () => {
+  it('should not create config from partial when config is null', async () => {
     vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
     await useSettingsStore.getState().updateConfig({ theme: 'dark' });
-    expect(useSettingsStore.getState().config).toEqual({ theme: 'dark' });
+    expect(useSettingsStore.getState().config).toBeNull();
   });
 
   it('should reset isLoading to false after success', async () => {
     vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
+    useSettingsStore.setState({ config: baseConfig, isLoading: false });
     await useSettingsStore.getState().updateConfig({ theme: 'dark' });
     expect(useSettingsStore.getState().isLoading).toBe(false);
   });
 
   it('should apply config optimistically before IPC call', async () => {
     vi.mocked(tauriInvoke).mockRejectedValueOnce(new Error('unavailable'));
-    useSettingsStore.setState({ config: { theme: 'light' }, isLoading: false, error: null });
+    useSettingsStore.setState({ config: baseConfig, isLoading: false, error: null });
     await useSettingsStore.getState().updateConfig({ theme: 'dark' });
-    expect(useSettingsStore.getState().config).toEqual({ theme: 'dark' });
+    expect(useSettingsStore.getState().config?.theme).toBe('dark');
   });
 
   it('should set error but not throw on IPC failure', async () => {
     vi.mocked(tauriInvoke).mockRejectedValueOnce(new Error('server error'));
+    useSettingsStore.setState({ config: baseConfig, isLoading: false, error: null });
     await useSettingsStore.getState().updateConfig({ theme: 'dark' });
     expect(useSettingsStore.getState().isLoading).toBe(false);
     expect(useSettingsStore.getState().error).toBe('server error');
   });
 
   it('should clear error on next successful update', async () => {
-    useSettingsStore.setState({ error: 'previous error' });
+    useSettingsStore.setState({ config: baseConfig, error: 'previous error' });
     vi.mocked(tauriInvoke).mockResolvedValueOnce(null);
     await useSettingsStore.getState().updateConfig({ theme: 'dark' });
     expect(useSettingsStore.getState().error).toBeNull();

--- a/src/stores/__tests__/settingsStore.test.ts
+++ b/src/stores/__tests__/settingsStore.test.ts
@@ -47,9 +47,16 @@ describe('useSettingsStore — updateConfig', () => {
     expect(useSettingsStore.getState().isLoading).toBe(false);
   });
 
-  it('should set error and re-throw on failure', async () => {
+  it('should apply config optimistically before IPC call', async () => {
+    vi.mocked(tauriInvoke).mockRejectedValueOnce(new Error('unavailable'));
+    useSettingsStore.setState({ config: { theme: 'light' }, isLoading: false, error: null });
+    await useSettingsStore.getState().updateConfig({ theme: 'dark' });
+    expect(useSettingsStore.getState().config).toEqual({ theme: 'dark' });
+  });
+
+  it('should set error but not throw on IPC failure', async () => {
     vi.mocked(tauriInvoke).mockRejectedValueOnce(new Error('server error'));
-    await expect(useSettingsStore.getState().updateConfig({ theme: 'dark' })).rejects.toThrow('server error');
+    await useSettingsStore.getState().updateConfig({ theme: 'dark' });
     expect(useSettingsStore.getState().isLoading).toBe(false);
     expect(useSettingsStore.getState().error).toBe('server error');
   });

--- a/src/stores/__tests__/uiStore.test.ts
+++ b/src/stores/__tests__/uiStore.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useUiStore } from '@/stores/uiStore';
+
+beforeEach(() => {
+  useUiStore.setState({
+    selectedDownloadId: null,
+    detailsPanelOpen: false,
+    filterBarExpanded: false,
+  });
+});
+
+describe('useUiStore — selectDownload', () => {
+  it('should set selectedDownloadId', () => {
+    useUiStore.getState().selectDownload('42');
+    expect(useUiStore.getState().selectedDownloadId).toBe('42');
+  });
+
+  it('should clear selectedDownloadId when passed null', () => {
+    useUiStore.getState().selectDownload('42');
+    useUiStore.getState().selectDownload(null);
+    expect(useUiStore.getState().selectedDownloadId).toBeNull();
+  });
+});
+
+describe('useUiStore — setDetailsPanelOpen', () => {
+  it('should open details panel', () => {
+    useUiStore.getState().setDetailsPanelOpen(true);
+    expect(useUiStore.getState().detailsPanelOpen).toBe(true);
+  });
+
+  it('should close details panel', () => {
+    useUiStore.getState().setDetailsPanelOpen(true);
+    useUiStore.getState().setDetailsPanelOpen(false);
+    expect(useUiStore.getState().detailsPanelOpen).toBe(false);
+  });
+});
+
+describe('useUiStore — toggleFilterBar', () => {
+  it('should toggle filterBarExpanded from false to true', () => {
+    useUiStore.getState().toggleFilterBar();
+    expect(useUiStore.getState().filterBarExpanded).toBe(true);
+  });
+
+  it('should toggle filterBarExpanded from true to false', () => {
+    useUiStore.setState({ filterBarExpanded: true, selectedDownloadId: null, detailsPanelOpen: false });
+    useUiStore.getState().toggleFilterBar();
+    expect(useUiStore.getState().filterBarExpanded).toBe(false);
+  });
+});

--- a/src/stores/downloadStore.ts
+++ b/src/stores/downloadStore.ts
@@ -1,0 +1,45 @@
+import { create } from 'zustand';
+
+interface DownloadProgress {
+  id: string;
+  downloadedBytes: number;
+  totalBytes: number;
+}
+
+interface DownloadStoreState {
+  progressMap: Record<string, DownloadProgress>;
+  countByState: Record<string, number>;
+
+  updateProgress: (id: string, downloadedBytes: number, totalBytes: number) => void;
+  removeProgress: (id: string) => void;
+  updateCountByState: (counts: Record<string, number>) => void;
+  clearAllProgress: () => void;
+}
+
+export const selectTotalSpeed = (_state: DownloadStoreState): number => 0;
+
+export const selectActiveCount = (state: DownloadStoreState): number =>
+  state.countByState['Downloading'] ?? 0;
+
+export const useDownloadStore = create<DownloadStoreState>((set) => ({
+  progressMap: {},
+  countByState: {},
+
+  updateProgress: (id, downloadedBytes, totalBytes) =>
+    set((s) => ({
+      progressMap: {
+        ...s.progressMap,
+        [id]: { id, downloadedBytes, totalBytes },
+      },
+    })),
+
+  removeProgress: (id) =>
+    set((s) => {
+      const { [id]: _removed, ...rest } = s.progressMap;
+      return { progressMap: rest };
+    }),
+
+  updateCountByState: (counts) => set({ countByState: counts }),
+
+  clearAllProgress: () => set({ progressMap: {} }),
+}));

--- a/src/stores/downloadStore.ts
+++ b/src/stores/downloadStore.ts
@@ -4,6 +4,9 @@ interface DownloadProgress {
   id: string;
   downloadedBytes: number;
   totalBytes: number;
+  speedBytesPerSec: number;
+  lastSampleBytes: number;
+  lastSampleTime: number;
 }
 
 interface DownloadStoreState {
@@ -16,7 +19,8 @@ interface DownloadStoreState {
   clearAllProgress: () => void;
 }
 
-export const selectTotalSpeed = (_state: DownloadStoreState): number => 0;
+export const selectTotalSpeed = (state: DownloadStoreState): number =>
+  Object.values(state.progressMap).reduce((sum, p) => sum + p.speedBytesPerSec, 0);
 
 export const selectActiveCount = (state: DownloadStoreState): number =>
   state.countByState['Downloading'] ?? 0;
@@ -26,12 +30,33 @@ export const useDownloadStore = create<DownloadStoreState>((set) => ({
   countByState: {},
 
   updateProgress: (id, downloadedBytes, totalBytes) =>
-    set((s) => ({
-      progressMap: {
-        ...s.progressMap,
-        [id]: { id, downloadedBytes, totalBytes },
-      },
-    })),
+    set((s) => {
+      const prev = s.progressMap[id];
+      const now = Date.now();
+      let speedBytesPerSec = prev?.speedBytesPerSec ?? 0;
+
+      if (prev && now > prev.lastSampleTime) {
+        const deltaBytes = downloadedBytes - prev.lastSampleBytes;
+        const deltaSec = (now - prev.lastSampleTime) / 1000;
+        if (deltaSec > 0) {
+          speedBytesPerSec = deltaBytes / deltaSec;
+        }
+      }
+
+      return {
+        progressMap: {
+          ...s.progressMap,
+          [id]: {
+            id,
+            downloadedBytes,
+            totalBytes,
+            speedBytesPerSec,
+            lastSampleBytes: downloadedBytes,
+            lastSampleTime: now,
+          },
+        },
+      };
+    }),
 
   removeProgress: (id) =>
     set((s) => {

--- a/src/stores/downloadStore.ts
+++ b/src/stores/downloadStore.ts
@@ -39,7 +39,7 @@ export const useDownloadStore = create<DownloadStoreState>((set) => ({
         const deltaBytes = downloadedBytes - prev.lastSampleBytes;
         const deltaSec = (now - prev.lastSampleTime) / 1000;
         if (deltaSec > 0) {
-          speedBytesPerSec = deltaBytes / deltaSec;
+          speedBytesPerSec = Math.max(0, deltaBytes / deltaSec);
         }
       }
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,4 @@
+export { useDownloadStore, selectTotalSpeed, selectActiveCount } from './downloadStore';
+export { useUiStore } from './uiStore';
+export { useSettingsStore } from './settingsStore';
+export { useLayoutStore } from './layout-store';

--- a/src/stores/layout-store.ts
+++ b/src/stores/layout-store.ts
@@ -3,21 +3,15 @@ import { create } from 'zustand';
 interface LayoutState {
   sidebarCollapsed: boolean;
   toggleSidebar: () => void;
-  totalSpeed: number;
   speedLimit: number;
   freeSpace: string;
-  activeCount: number;
-  totalConnections: number;
   appVersion: string;
 }
 
 export const useLayoutStore = create<LayoutState>((set) => ({
   sidebarCollapsed: false,
   toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
-  totalSpeed: 0,
   speedLimit: 0,
   freeSpace: '-- GB',
-  activeCount: 0,
-  totalConnections: 0,
   appVersion: '0.1.0',
 }));

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+import { tauriInvoke } from '@/api/client';
+
+interface AppConfig {
+  [key: string]: unknown;
+}
+
+interface SettingsStoreState {
+  config: AppConfig | null;
+  isLoading: boolean;
+  error: string | null;
+  setConfig: (config: AppConfig) => void;
+  updateConfig: (partial: Partial<AppConfig>) => Promise<void>;
+  clearError: () => void;
+}
+
+// Note: 'settings_update' IPC command will be implemented in task 23.
+// Until then, updateConfig stores optimistically and logs a warning.
+export const useSettingsStore = create<SettingsStoreState>((set) => ({
+  config: null,
+  isLoading: false,
+  error: null,
+  setConfig: (config) => set({ config, error: null }),
+  clearError: () => set({ error: null }),
+  updateConfig: async (partial) => {
+    set({ isLoading: true, error: null });
+    try {
+      await tauriInvoke('settings_update', partial);
+      set((s) => ({
+        config: s.config ? { ...s.config, ...partial } : partial,
+      }));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      set({ error: message });
+      throw err;
+    } finally {
+      set({ isLoading: false });
+    }
+  },
+}));

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -2,20 +2,30 @@ import { create } from 'zustand';
 import { tauriInvoke } from '@/api/client';
 
 interface AppConfig {
-  [key: string]: unknown;
+  downloadDir: string | null;
+  maxConcurrentDownloads: number;
+  maxSegmentsPerDownload: number;
+  speedLimitBytesPerSec: number | null;
+  autoExtract: boolean;
+  theme: string;
+  locale: string;
+  clipboardMonitoring: boolean;
+  minimizeToTray: boolean;
 }
+
+type AppConfigPatch = Partial<AppConfig>;
 
 interface SettingsStoreState {
   config: AppConfig | null;
   isLoading: boolean;
   error: string | null;
   setConfig: (config: AppConfig) => void;
-  updateConfig: (partial: Partial<AppConfig>) => Promise<void>;
+  updateConfig: (partial: AppConfigPatch) => Promise<void>;
   clearError: () => void;
 }
 
-// Note: 'settings_update' IPC command will be implemented in task 23.
-// Until then, updateConfig applies the change optimistically without a backend call.
+// Note: 'settings_update' IPC command will be registered in task 23.
+// updateConfig applies optimistically, then attempts IPC; failure is logged, not thrown.
 export const useSettingsStore = create<SettingsStoreState>((set) => ({
   config: null,
   isLoading: false,
@@ -25,7 +35,7 @@ export const useSettingsStore = create<SettingsStoreState>((set) => ({
   updateConfig: async (partial) => {
     set({ isLoading: true, error: null });
     set((s) => ({
-      config: s.config ? { ...s.config, ...partial } : partial,
+      config: s.config ? { ...s.config, ...partial } : s.config,
     }));
     try {
       await tauriInvoke('settings_update', partial);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -15,7 +15,7 @@ interface SettingsStoreState {
 }
 
 // Note: 'settings_update' IPC command will be implemented in task 23.
-// Until then, updateConfig stores optimistically and logs a warning.
+// Until then, updateConfig applies the change optimistically without a backend call.
 export const useSettingsStore = create<SettingsStoreState>((set) => ({
   config: null,
   isLoading: false,
@@ -24,15 +24,14 @@ export const useSettingsStore = create<SettingsStoreState>((set) => ({
   clearError: () => set({ error: null }),
   updateConfig: async (partial) => {
     set({ isLoading: true, error: null });
+    set((s) => ({
+      config: s.config ? { ...s.config, ...partial } : partial,
+    }));
     try {
       await tauriInvoke('settings_update', partial);
-      set((s) => ({
-        config: s.config ? { ...s.config, ...partial } : partial,
-      }));
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       set({ error: message });
-      throw err;
     } finally {
       set({ isLoading: false });
     }

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+interface UiStoreState {
+  selectedDownloadId: string | null;
+  detailsPanelOpen: boolean;
+  filterBarExpanded: boolean;
+  selectDownload: (id: string | null) => void;
+  setDetailsPanelOpen: (open: boolean) => void;
+  toggleFilterBar: () => void;
+}
+
+export const useUiStore = create<UiStoreState>((set) => ({
+  selectedDownloadId: null,
+  detailsPanelOpen: false,
+  filterBarExpanded: false,
+  selectDownload: (id) => set({ selectedDownloadId: id }),
+  setDetailsPanelOpen: (open) => set({ detailsPanelOpen: open }),
+  toggleFilterBar: () => set((s) => ({ filterBarExpanded: !s.filterBarExpanded })),
+}));

--- a/src/types/download.ts
+++ b/src/types/download.ts
@@ -13,7 +13,7 @@ export type SortField = 'name' | 'filename' | 'size' | 'filesize' | 'progress' |
 export type SortDirection = 'asc' | 'ascending' | 'desc' | 'descending';
 
 export interface DownloadFilter {
-  filterState?: string;
+  filterState?: DownloadState;
   search?: string;
   sortField?: SortField;
   sortDirection?: SortDirection;

--- a/src/types/download.ts
+++ b/src/types/download.ts
@@ -1,0 +1,111 @@
+export type DownloadState =
+  | 'Queued'
+  | 'Downloading'
+  | 'Paused'
+  | 'Waiting'
+  | 'Retry'
+  | 'Error'
+  | 'Completed'
+  | 'Checking'
+  | 'Extracting';
+
+export type SortField = 'name' | 'filename' | 'size' | 'filesize' | 'progress' | 'speed' | 'state' | 'status';
+export type SortDirection = 'asc' | 'ascending' | 'desc' | 'descending';
+
+export interface DownloadFilter {
+  filterState?: string;
+  search?: string;
+  sortField?: SortField;
+  sortDirection?: SortDirection;
+  limit?: number;
+  offset?: number;
+}
+
+export interface SegmentView {
+  id: number;
+  startByte: number;
+  endByte: number;
+  downloadedBytes: number;
+  state: 'Pending' | 'Downloading' | 'Completed' | 'Error';
+}
+
+export interface DownloadView {
+  id: string;
+  fileName: string;
+  url: string;
+  state: DownloadState;
+  progressPercent: number;
+  speedBytesPerSec: number;
+  downloadedBytes: number;
+  totalBytes: number | null;
+  etaSeconds: number | null;
+  segmentsActive: number;
+  segmentsTotal: number;
+  moduleName: string | null;
+  accountName: string | null;
+  createdAt: number;
+}
+
+export interface DownloadDetailView {
+  id: string;
+  fileName: string;
+  url: string;
+  state: DownloadState;
+  progressPercent: number;
+  speedBytesPerSec: number;
+  downloadedBytes: number;
+  totalBytes: number | null;
+  etaSeconds: number | null;
+  segments: SegmentView[];
+  checksumExpected: string | null;
+  destinationPath: string;
+  moduleName: string | null;
+  accountName: string | null;
+  resumeSupported: boolean;
+  retryCount: number;
+  maxRetries: number;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface PluginView {
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+  category: string;
+  enabled: boolean;
+}
+
+export interface HistoryView {
+  downloadId: string;
+  fileName: string;
+  url: string;
+  totalBytes: number;
+  completedAt: number;
+  durationSeconds: number;
+  avgSpeed: number;
+  destinationPath: string;
+}
+
+export interface DailyVolume {
+  date: string;
+  bytes: number;
+  count: number;
+}
+
+export interface HostStats {
+  hostname: string;
+  totalBytes: number;
+  downloadCount: number;
+}
+
+export interface StatsView {
+  totalDownloadedBytes: number;
+  totalFiles: number;
+  avgSpeed: number;
+  peakSpeed: number;
+  successRate: number;
+  dailyVolumes: DailyVolume[];
+  topHosts: HostStats[];
+}

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,0 +1,68 @@
+export interface DownloadIdPayload {
+  id: number;
+}
+
+export interface DownloadFailedPayload {
+  id: number;
+  error: string;
+}
+
+export interface DownloadRetryingPayload {
+  id: number;
+  attempt: number;
+}
+
+export interface DownloadProgressPayload {
+  id: number;
+  downloadedBytes: number;
+  totalBytes: number;
+}
+
+export interface SegmentPayload {
+  downloadId: number;
+  segmentId: number;
+}
+
+export interface SegmentFailedPayload {
+  downloadId: number;
+  segmentId: number;
+  error: string;
+}
+
+export interface PluginLoadedPayload {
+  name: string;
+  version: string;
+}
+
+export interface PluginUnloadedPayload {
+  name: string;
+}
+
+export interface PackageCreatedPayload {
+  id: string;
+  name: string;
+}
+
+export type TauriEventMap = {
+  'download-created': DownloadIdPayload;
+  'download-started': DownloadIdPayload;
+  'download-paused': DownloadIdPayload;
+  'download-resumed': DownloadIdPayload;
+  'download-resumed-from-wait': DownloadIdPayload;
+  'download-completed': DownloadIdPayload;
+  'download-failed': DownloadFailedPayload;
+  'download-retrying': DownloadRetryingPayload;
+  'download-waiting': DownloadIdPayload;
+  'download-checking': DownloadIdPayload;
+  'download-cancelled': DownloadIdPayload;
+  'download-extracting': DownloadIdPayload;
+  'download-progress': DownloadProgressPayload;
+  'segment-started': SegmentPayload;
+  'segment-completed': SegmentPayload;
+  'segment-failed': SegmentFailedPayload;
+  'plugin-loaded': PluginLoadedPayload;
+  'plugin-unloaded': PluginUnloadedPayload;
+  'package-created': PackageCreatedPayload;
+};
+
+export type TauriEventName = keyof TauriEventMap;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,3 +1,6 @@
+/** Rust emits DownloadId.0 (u64) via serde_json. JavaScript receives it as number.
+ *  We type IDs as `number` to match the actual JSON wire format.
+ *  Consumers must use `String(payload.id)` when correlating with DTO IDs (which are string). */
 export interface DownloadIdPayload {
   id: number;
 }


### PR DESCRIPTION
## Summary

- Add typed `tauriInvoke<T>()` wrapper around Tauri v2 invoke API with proper error handling
- Add `useTauriQuery` and `useTauriMutation` generic hooks integrating TanStack Query v5 with Tauri IPC
- Add query key factories (`downloadQueries`, `pluginQueries`, `historyQueries`, `statsQueries`)
- Add Zustand stores: `downloadStore` (real-time progress), `uiStore` (selection/panels), `settingsStore` (config cache with error state)
- Add `useDownloadProgress` hook for high-frequency download-progress event subscription
- Add `useDownloadEvents` hook subscribing to 8 download lifecycle events with automatic query invalidation
- Add TypeScript types mirroring all Rust DTOs (camelCase) and 19 Tauri event payloads
- Wrap App with `QueryClientProvider` (staleTime 5min, gcTime 10min, retry 1, refetchOnWindowFocus false)
- Refactor `layout-store` to separate download concerns into `downloadStore`

## Test plan

- [x] TypeScript strict mode: 0 errors
- [x] oxlint: 0 warnings, 0 errors
- [x] vitest: 96/96 passing, 0 failures
- [x] Adversarial code review: 3 HIGH findings resolved (TQ v5 onSuccess signature, settings error handling, missing event listeners)
- [ ] Manual: open DevTools, verify TanStack Query panel shows queries
- [ ] Manual: trigger mutation, verify query invalidation + refetch
- [ ] Manual: verify Zustand store updates via download-progress events

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements a typed Tauri IPC data layer using React Query and Zustand for consistent fetching, caching, and real-time updates. Delivers the IPC data layer requested in Linear 17.

- **New Features**
  - Typed `tauriInvoke<T>()` wrapper for `@tauri-apps/api` v2 with error handling.
  - `useTauriQuery`/`useTauriMutation` powered by `@tanstack/react-query`; App wrapped with `QueryClientProvider` (5m staleTime, 10m gcTime, retry 1, no focus refetch).
  - Query key factories: `downloadQueries`, `pluginQueries`, `historyQueries`, `statsQueries`.
  - Zustand stores: `downloadStore` (progress + active count, total speed via delta sampling clamped to 0), `uiStore`, `settingsStore` (optimistic updates with IPC error state; no config creation from partial when null; stricter typed config).
  - Real-time updates via `useDownloadProgress` and `useDownloadEvents` (8 lifecycle events) with automatic cache invalidation; added TS types for Rust DTOs and 19 event payloads (IDs are numbers from Rust).

- **Refactors**
  - Moved download state out of `layout-store` into `downloadStore`; Status bar now shows total speed and “X active” from `downloadStore`.
  - Wired `useDownloadProgress` and `useDownloadEvents` in `AppLayout`; `DownloadFilter.filterState` now uses `DownloadState`.

<sup>Written for commit 2631f117b106f3a4a07113f7aaaef243d56a3b6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Updates**
  * Status bar now shows active download count instead of connection count.

* **New Features**
  * App-wide query provider added for consistent data fetching.
  * Real-time download event & progress hooks added to update UI and store state.

* **New Infrastructure**
  * Centralized download, UI and settings stores plus typed event/data models introduced.

* **Tests**
  * Extensive test coverage added for queries, hooks, stores, and event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->