### PR TITLE
feat(ui): implement Download Details Panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - uiStore extended with `selectedDownloadIds` for multi-select state
   - Fixed `useTauriQuery` to support custom `queryKey` (query cache invalidation now works correctly)
   - Fixed `useDownloadEvents` to invalidate `downloadQueries.all()` (covers list + count queries)
+- Download Details Panel: right sidebar showing detailed info for the selected download
+  - 8 sections: File Info, Metrics, Segments, Speed History, Source, Integrity, Module, Logs
+  - Real-time metrics from Zustand `downloadStore.progressMap` (speed, ETA, downloaded/total)
+  - Segment visualization with colored progress bars per segment
+  - Speed sparkline: SVG polyline chart with 2-minute history sampled every 2 seconds
+  - File info with MIME type detection, tooltips on long filenames/paths/URLs
+  - Integrity section with SHA-256 checksum status
+  - Scrollable logs section fetching last 20 log lines via IPC query
+  - Auto-opens when a download is selected, closeable via X button
+  - `useDownloadDetail` hook wrapping TanStack Query with 500ms staleTime
+  - `useSpeedHistory` hook sampling speed from store at 2s intervals

--- a/src/hooks/__tests__/useDownloadDetail.test.ts
+++ b/src/hooks/__tests__/useDownloadDetail.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement } from 'react';
+import { useDownloadDetail } from '../useDownloadDetail';
+import type { DownloadDetailView } from '@/types/download';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+function mockDownloadDetail(): DownloadDetailView {
+  return {
+    id: 'dl-1',
+    fileName: 'test-file.zip',
+    url: 'https://example.com/test-file.zip',
+    state: 'Downloading',
+    progressPercent: 50,
+    speedBytesPerSec: 1048576,
+    downloadedBytes: 524288,
+    totalBytes: 1048576,
+    etaSeconds: 30,
+    segments: [],
+    checksumExpected: null,
+    destinationPath: '/home/user/Downloads/test-file.zip',
+    moduleName: null,
+    accountName: null,
+    resumeSupported: true,
+    retryCount: 0,
+    maxRetries: 3,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) =>
+    createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+describe('useDownloadDetail', () => {
+  it('should call query_download_detail with correct args', async () => {
+    const { invoke } = await import('@tauri-apps/api/core');
+    vi.mocked(invoke).mockResolvedValue(mockDownloadDetail());
+
+    const { result } = renderHook(() => useDownloadDetail('dl-1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invoke).toHaveBeenCalledWith('query_download_detail', { id: 'dl-1' });
+    expect(result.current.data?.id).toBe('dl-1');
+  });
+});

--- a/src/hooks/__tests__/useSpeedHistory.test.ts
+++ b/src/hooks/__tests__/useSpeedHistory.test.ts
@@ -29,9 +29,10 @@ describe('useSpeedHistory', () => {
     vi.clearAllMocks();
   });
 
-  it('should return empty array initially', () => {
+  it('should sample immediately on mount', () => {
     const { result } = renderHook(() => useSpeedHistory('dl-1'));
-    expect(result.current).toEqual([]);
+    expect(result.current.length).toBe(1);
+    expect(result.current[0].speed).toBe(0);
   });
 
   it('should collect speed samples over time', () => {
@@ -50,12 +51,6 @@ describe('useSpeedHistory', () => {
 
     const { result } = renderHook(() => useSpeedHistory('dl-1'));
 
-    expect(result.current).toEqual([]);
-
-    act(() => {
-      vi.advanceTimersByTime(2000);
-    });
-
     expect(result.current.length).toBe(1);
     expect(result.current[0].speed).toBe(1024000);
 
@@ -64,5 +59,11 @@ describe('useSpeedHistory', () => {
     });
 
     expect(result.current.length).toBe(2);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.length).toBe(3);
   });
 });

--- a/src/hooks/__tests__/useSpeedHistory.test.ts
+++ b/src/hooks/__tests__/useSpeedHistory.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useSpeedHistory } from '../useSpeedHistory';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+const { mockGetState } = vi.hoisted(() => ({
+  mockGetState: vi.fn(),
+}));
+
+vi.mock('@/stores/downloadStore', () => ({
+  useDownloadStore: Object.assign(
+    (selector: (s: { progressMap: Record<string, unknown> }) => unknown) =>
+      selector({ progressMap: {} }),
+    { getState: mockGetState },
+  ),
+}));
+
+describe('useSpeedHistory', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockGetState.mockReturnValue({ progressMap: {} });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should return empty array initially', () => {
+    const { result } = renderHook(() => useSpeedHistory('dl-1'));
+    expect(result.current).toEqual([]);
+  });
+
+  it('should collect speed samples over time', () => {
+    mockGetState.mockReturnValue({
+      progressMap: {
+        'dl-1': {
+          id: 'dl-1',
+          downloadedBytes: 524288,
+          totalBytes: 1048576,
+          speedBytesPerSec: 1024000,
+          lastSampleBytes: 524288,
+          lastSampleTime: Date.now(),
+        },
+      },
+    });
+
+    const { result } = renderHook(() => useSpeedHistory('dl-1'));
+
+    expect(result.current).toEqual([]);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.length).toBe(1);
+    expect(result.current[0].speed).toBe(1024000);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(result.current.length).toBe(2);
+  });
+});

--- a/src/hooks/useDownloadDetail.ts
+++ b/src/hooks/useDownloadDetail.ts
@@ -6,6 +6,6 @@ export function useDownloadDetail(downloadId: string) {
   return useTauriQuery<DownloadDetailView>(
     'query_download_detail',
     { id: downloadId },
-    { queryKey: downloadQueries.detail(downloadId), staleTime: 500 },
+    { queryKey: downloadQueries.detail(downloadId), staleTime: 500, enabled: !!downloadId },
   );
 }

--- a/src/hooks/useDownloadDetail.ts
+++ b/src/hooks/useDownloadDetail.ts
@@ -1,0 +1,11 @@
+import { useTauriQuery } from '@/api/hooks';
+import { downloadQueries } from '@/api/queries';
+import type { DownloadDetailView } from '@/types/download';
+
+export function useDownloadDetail(downloadId: string) {
+  return useTauriQuery<DownloadDetailView>(
+    'query_download_detail',
+    { id: downloadId },
+    { queryKey: downloadQueries.detail(downloadId), staleTime: 500 },
+  );
+}

--- a/src/hooks/useSpeedHistory.ts
+++ b/src/hooks/useSpeedHistory.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useRef } from 'react';
+import { useDownloadStore } from '@/stores/downloadStore';
+
+export interface SpeedSample {
+  time: number;
+  speed: number;
+}
+
+const MAX_SAMPLES = 60; // 2 min at 2s intervals
+const SAMPLE_INTERVAL_MS = 2000;
+const MAX_AGE_MS = 120_000; // 2 minutes
+
+export function useSpeedHistory(downloadId: string): SpeedSample[] {
+  const [samples, setSamples] = useState<SpeedSample[]>([]);
+  const samplesRef = useRef<SpeedSample[]>([]);
+
+  useEffect(() => {
+    samplesRef.current = [];
+    setSamples([]);
+
+    const interval = setInterval(() => {
+      const progress = useDownloadStore.getState().progressMap[downloadId];
+      const speed = progress?.speedBytesPerSec ?? 0;
+      const now = Date.now();
+      const cutoff = now - MAX_AGE_MS;
+
+      samplesRef.current = [
+        ...samplesRef.current.filter((s) => s.time > cutoff),
+        { time: now, speed },
+      ].slice(-MAX_SAMPLES);
+
+      setSamples([...samplesRef.current]);
+    }, SAMPLE_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [downloadId]);
+
+  return samples;
+}

--- a/src/hooks/useSpeedHistory.ts
+++ b/src/hooks/useSpeedHistory.ts
@@ -18,7 +18,7 @@ export function useSpeedHistory(downloadId: string): SpeedSample[] {
     samplesRef.current = [];
     setSamples([]);
 
-    const interval = setInterval(() => {
+    const sample = () => {
       const progress = useDownloadStore.getState().progressMap[downloadId];
       const speed = progress?.speedBytesPerSec ?? 0;
       const now = Date.now();
@@ -30,7 +30,10 @@ export function useSpeedHistory(downloadId: string): SpeedSample[] {
       ].slice(-MAX_SAMPLES);
 
       setSamples([...samplesRef.current]);
-    }, SAMPLE_INTERVAL_MS);
+    };
+
+    sample();
+    const interval = setInterval(sample, SAMPLE_INTERVAL_MS);
 
     return () => clearInterval(interval);
   }, [downloadId]);

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -18,7 +18,7 @@ export const useUiStore = create<UiStoreState>((set) => ({
   selectedDownloadIds: [],
   detailsPanelOpen: false,
   filterBarExpanded: false,
-  selectDownload: (id) => set({ selectedDownloadId: id }),
+  selectDownload: (id) => set({ selectedDownloadId: id, detailsPanelOpen: id !== null }),
   setSelectedDownloadIds: (ids) => set({ selectedDownloadIds: ids }),
   toggleDownloadSelection: (id) =>
     set((s) => {

--- a/src/views/DownloadDetailsPanel/DownloadDetailsPanel.tsx
+++ b/src/views/DownloadDetailsPanel/DownloadDetailsPanel.tsx
@@ -1,0 +1,94 @@
+import { X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { useUiStore } from '@/stores/uiStore';
+import { useDownloadDetail } from '@/hooks/useDownloadDetail';
+import { FileInfoSection } from './FileInfoSection';
+import { MetricsSection } from './MetricsSection';
+import { SegmentVisualization } from './SegmentVisualization';
+import { SpeedSparkline } from './SpeedSparkline';
+import { SourceInfoSection } from './SourceInfoSection';
+import { IntegritySection } from './IntegritySection';
+import { ModuleSection } from './ModuleSection';
+import { LogsSection } from './LogsSection';
+
+export function DownloadDetailsPanel() {
+  const selectedDownloadId = useUiStore((s) => s.selectedDownloadId);
+  const detailsPanelOpen = useUiStore((s) => s.detailsPanelOpen);
+  const setDetailsPanelOpen = useUiStore((s) => s.setDetailsPanelOpen);
+
+  if (!detailsPanelOpen) return null;
+
+  if (!selectedDownloadId) {
+    return (
+      <aside className="w-80 shrink-0 border-l bg-muted/30 p-4 text-center text-sm text-muted-foreground">
+        Select a download to view details
+      </aside>
+    );
+  }
+
+  return (
+    <DownloadDetailContent
+      downloadId={selectedDownloadId}
+      onClose={() => setDetailsPanelOpen(false)}
+    />
+  );
+}
+
+function DownloadDetailContent({
+  downloadId,
+  onClose,
+}: {
+  downloadId: string;
+  onClose: () => void;
+}) {
+  const { data: detail, isLoading } = useDownloadDetail(downloadId);
+
+  if (isLoading) {
+    return (
+      <aside className="w-80 shrink-0 border-l bg-muted/30 p-4">
+        <div className="animate-pulse space-y-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-16 rounded bg-muted" />
+          ))}
+        </div>
+      </aside>
+    );
+  }
+
+  if (!detail) {
+    return (
+      <aside className="w-80 shrink-0 border-l bg-muted/30 p-4">
+        <p className="text-sm text-muted-foreground">Download not found</p>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="w-80 shrink-0 border-l bg-muted/30 overflow-y-auto">
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <h2 className="text-sm font-semibold">Details</h2>
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose}>
+          <X className="size-3.5" />
+        </Button>
+      </div>
+      <div className="space-y-4 p-4">
+        <FileInfoSection download={detail} />
+        <Separator />
+        <MetricsSection download={detail} />
+        <Separator />
+        <SegmentVisualization segments={detail.segments} totalBytes={detail.totalBytes} />
+        <Separator />
+        <SpeedSparkline downloadId={downloadId} />
+        <Separator />
+        <SourceInfoSection download={detail} />
+        <Separator />
+        <IntegritySection download={detail} />
+        <Separator />
+        <ModuleSection download={detail} />
+        <Separator />
+        <LogsSection downloadId={downloadId} />
+      </div>
+    </aside>
+  );
+}

--- a/src/views/DownloadDetailsPanel/DownloadDetailsPanel.tsx
+++ b/src/views/DownloadDetailsPanel/DownloadDetailsPanel.tsx
@@ -50,27 +50,7 @@ function DownloadDetailContent({
   downloadId: string;
   onClose: () => void;
 }) {
-  const { data: detail, isLoading } = useDownloadDetail(downloadId);
-
-  if (isLoading) {
-    return (
-      <aside className="w-80 shrink-0 border-l bg-muted/30 p-4">
-        <div className="animate-pulse space-y-4">
-          {Array.from({ length: 5 }).map((_, i) => (
-            <div key={i} className="h-16 rounded bg-muted" />
-          ))}
-        </div>
-      </aside>
-    );
-  }
-
-  if (!detail) {
-    return (
-      <aside className="w-80 shrink-0 border-l bg-muted/30 p-4">
-        <p className="text-sm text-muted-foreground">Download not found</p>
-      </aside>
-    );
-  }
+  const { data: detail, isLoading, isError } = useDownloadDetail(downloadId);
 
   return (
     <aside className="w-80 shrink-0 border-l bg-muted/30 overflow-y-auto">
@@ -80,23 +60,35 @@ function DownloadDetailContent({
           <X className="size-3.5" />
         </Button>
       </div>
-      <div className="space-y-4 p-4">
-        <FileInfoSection download={detail} />
-        <Separator />
-        <MetricsSection download={detail} />
-        <Separator />
-        <SegmentVisualization segments={detail.segments} totalBytes={detail.totalBytes} />
-        <Separator />
-        <SpeedSparkline downloadId={downloadId} />
-        <Separator />
-        <SourceInfoSection download={detail} />
-        <Separator />
-        <IntegritySection download={detail} />
-        <Separator />
-        <ModuleSection download={detail} />
-        <Separator />
-        <LogsSection downloadId={downloadId} />
-      </div>
+      {isLoading ? (
+        <div className="animate-pulse space-y-4 p-4">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-16 rounded bg-muted" />
+          ))}
+        </div>
+      ) : isError ? (
+        <p className="p-4 text-sm text-destructive">Failed to load download details</p>
+      ) : !detail ? (
+        <p className="p-4 text-sm text-muted-foreground">Download not found</p>
+      ) : (
+        <div className="space-y-4 p-4">
+          <FileInfoSection download={detail} />
+          <Separator />
+          <MetricsSection download={detail} />
+          <Separator />
+          <SegmentVisualization segments={detail.segments} totalBytes={detail.totalBytes} />
+          <Separator />
+          <SpeedSparkline downloadId={downloadId} />
+          <Separator />
+          <SourceInfoSection download={detail} />
+          <Separator />
+          <IntegritySection download={detail} />
+          <Separator />
+          <ModuleSection download={detail} />
+          <Separator />
+          <LogsSection downloadId={downloadId} />
+        </div>
+      )}
     </aside>
   );
 }

--- a/src/views/DownloadDetailsPanel/DownloadDetailsPanel.tsx
+++ b/src/views/DownloadDetailsPanel/DownloadDetailsPanel.tsx
@@ -21,8 +21,16 @@ export function DownloadDetailsPanel() {
 
   if (!selectedDownloadId) {
     return (
-      <aside className="w-80 shrink-0 border-l bg-muted/30 p-4 text-center text-sm text-muted-foreground">
-        Select a download to view details
+      <aside className="w-80 shrink-0 border-l bg-muted/30">
+        <div className="flex items-center justify-between border-b px-4 py-2">
+          <h2 className="text-sm font-semibold">Details</h2>
+          <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Close details panel" onClick={() => setDetailsPanelOpen(false)}>
+            <X className="size-3.5" />
+          </Button>
+        </div>
+        <p className="p-4 text-center text-sm text-muted-foreground">
+          Select a download to view details
+        </p>
       </aside>
     );
   }
@@ -68,7 +76,7 @@ function DownloadDetailContent({
     <aside className="w-80 shrink-0 border-l bg-muted/30 overflow-y-auto">
       <div className="flex items-center justify-between border-b px-4 py-2">
         <h2 className="text-sm font-semibold">Details</h2>
-        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose}>
+        <Button variant="ghost" size="icon" className="h-7 w-7" aria-label="Close details panel" onClick={onClose}>
           <X className="size-3.5" />
         </Button>
       </div>

--- a/src/views/DownloadDetailsPanel/FileInfoSection.tsx
+++ b/src/views/DownloadDetailsPanel/FileInfoSection.tsx
@@ -7,7 +7,10 @@ interface FileInfoSectionProps {
 }
 
 function getMimeType(fileName: string): string {
-  const ext = fileName.split('.').pop()?.toLowerCase();
+  const dotIndex = fileName.lastIndexOf('.');
+  const ext = dotIndex > 0 && dotIndex < fileName.length - 1
+    ? fileName.slice(dotIndex + 1).toLowerCase()
+    : undefined;
   const mimeMap: Record<string, string> = {
     mp4: 'video/mp4',
     mkv: 'video/x-matroska',

--- a/src/views/DownloadDetailsPanel/FileInfoSection.tsx
+++ b/src/views/DownloadDetailsPanel/FileInfoSection.tsx
@@ -1,0 +1,72 @@
+import type { DownloadDetailView } from '@/types/download';
+import { formatBytes } from '@/lib/format';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface FileInfoSectionProps {
+  download: DownloadDetailView;
+}
+
+function getMimeType(fileName: string): string {
+  const ext = fileName.split('.').pop()?.toLowerCase();
+  const mimeMap: Record<string, string> = {
+    mp4: 'video/mp4',
+    mkv: 'video/x-matroska',
+    avi: 'video/x-msvideo',
+    mp3: 'audio/mpeg',
+    flac: 'audio/flac',
+    wav: 'audio/wav',
+    zip: 'application/zip',
+    rar: 'application/x-rar-compressed',
+    '7z': 'application/x-7z-compressed',
+    pdf: 'application/pdf',
+    exe: 'application/x-msdownload',
+    iso: 'application/x-iso9660-image',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+  };
+  return ext ? (mimeMap[ext] ?? `application/${ext}`) : 'application/octet-stream';
+}
+
+export function FileInfoSection({ download }: FileInfoSectionProps) {
+  const mimeType = getMimeType(download.fileName);
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">File Info</h3>
+      <div className="space-y-2 text-xs">
+        <div>
+          <p className="text-muted-foreground">Name</p>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <p className="font-mono truncate max-w-full cursor-default">{download.fileName}</p>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="max-w-[400px] break-all">{download.fileName}</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Size</p>
+          <p className="font-mono">{formatBytes(download.totalBytes)}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">MIME Type</p>
+          <p className="font-mono">{mimeType}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Destination</p>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <p className="font-mono truncate max-w-full cursor-default">{download.destinationPath}</p>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="max-w-[400px] break-all">{download.destinationPath}</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/views/DownloadDetailsPanel/IntegritySection.tsx
+++ b/src/views/DownloadDetailsPanel/IntegritySection.tsx
@@ -14,7 +14,7 @@ export function IntegritySection({ download }: IntegritySectionProps) {
       <div className="space-y-2 text-xs">
         <div>
           <p className="text-muted-foreground">Algorithm</p>
-          <p className="font-mono">SHA-256</p>
+          <p className="font-mono">{hasChecksum ? 'SHA-256' : '—'}</p>
         </div>
         <div>
           <p className="text-muted-foreground">Expected Hash</p>

--- a/src/views/DownloadDetailsPanel/IntegritySection.tsx
+++ b/src/views/DownloadDetailsPanel/IntegritySection.tsx
@@ -1,0 +1,43 @@
+import type { DownloadDetailView } from '@/types/download';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface IntegritySectionProps {
+  download: DownloadDetailView;
+}
+
+export function IntegritySection({ download }: IntegritySectionProps) {
+  const hasChecksum = download.checksumExpected !== null;
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Integrity</h3>
+      <div className="space-y-2 text-xs">
+        <div>
+          <p className="text-muted-foreground">Algorithm</p>
+          <p className="font-mono">SHA-256</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Expected Hash</p>
+          {hasChecksum ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <p className="font-mono truncate max-w-full cursor-default">
+                  {download.checksumExpected}
+                </p>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="max-w-[400px] break-all">{download.checksumExpected}</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <p className="font-mono">—</p>
+          )}
+        </div>
+        <div>
+          <p className="text-muted-foreground">Status</p>
+          <p className="font-mono">{hasChecksum ? 'Pending' : '—'}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/views/DownloadDetailsPanel/LogsSection.tsx
+++ b/src/views/DownloadDetailsPanel/LogsSection.tsx
@@ -6,7 +6,7 @@ interface LogsSectionProps {
 }
 
 export function LogsSection({ downloadId }: LogsSectionProps) {
-  const { data: logs } = useTauriQuery<string[]>(
+  const { data: logs, isLoading } = useTauriQuery<string[]>(
     'query_download_logs',
     { id: downloadId, limit: 20 },
     { queryKey: ['query_download_logs', downloadId], staleTime: 2000 },
@@ -16,7 +16,9 @@ export function LogsSection({ downloadId }: LogsSectionProps) {
     <section className="space-y-3">
       <h3 className="text-sm font-semibold">Logs</h3>
       <ScrollArea className="h-48 rounded border bg-background p-2">
-      {!logs || logs.length === 0 ? (
+      {isLoading ? (
+        <div className="text-muted-foreground text-xs">Loading logs...</div>
+      ) : !logs || logs.length === 0 ? (
         <div className="text-muted-foreground text-xs">No logs</div>
       ) : (
         logs.map((line, index) => (

--- a/src/views/DownloadDetailsPanel/LogsSection.tsx
+++ b/src/views/DownloadDetailsPanel/LogsSection.tsx
@@ -1,0 +1,34 @@
+import { useTauriQuery } from '@/api/hooks';
+import { ScrollArea } from '@/components/ui/scroll-area';
+
+interface LogsSectionProps {
+  downloadId: string;
+}
+
+export function LogsSection({ downloadId }: LogsSectionProps) {
+  const { data: logs } = useTauriQuery<string[]>(
+    'query_download_logs',
+    { id: downloadId, limit: 20 },
+    { queryKey: ['query_download_logs', downloadId], staleTime: 2000 },
+  );
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Logs</h3>
+      <ScrollArea className="h-48 rounded border bg-background p-2">
+      {!logs || logs.length === 0 ? (
+        <div className="text-muted-foreground text-xs">No logs</div>
+      ) : (
+        logs.map((line, index) => (
+          <div
+            key={index}
+            className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words"
+          >
+            {line}
+          </div>
+        ))
+      )}
+      </ScrollArea>
+    </section>
+  );
+}

--- a/src/views/DownloadDetailsPanel/MetricsSection.tsx
+++ b/src/views/DownloadDetailsPanel/MetricsSection.tsx
@@ -1,0 +1,61 @@
+import { useDownloadStore } from '@/stores/downloadStore';
+import { formatSpeed, formatBytes, formatEta } from '@/lib/format';
+import { Progress } from '@/components/ui/progress';
+import type { DownloadDetailView } from '@/types/download';
+
+interface MetricsSectionProps {
+  download: DownloadDetailView;
+}
+
+export function MetricsSection({ download }: MetricsSectionProps) {
+  const progress = useDownloadStore((s) => s.progressMap[download.id]);
+
+  const speed = progress?.speedBytesPerSec ?? download.speedBytesPerSec;
+  const downloaded = progress?.downloadedBytes ?? download.downloadedBytes;
+  const total = progress?.totalBytes ?? download.totalBytes;
+  const progressPercent =
+    total && total > 0 ? (downloaded / total) * 100 : download.progressPercent;
+
+  const speedIsHigh = speed > 1_048_576;
+  const remaining = (total ?? 0) - downloaded;
+  const eta = speed > 0 && remaining > 0 ? remaining / speed : download.etaSeconds;
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Metrics</h3>
+      <div className="grid grid-cols-2 gap-2 text-xs">
+      <div className="rounded bg-background p-2">
+        <div className="text-muted-foreground">Speed</div>
+        <div className={`font-mono font-semibold ${speedIsHigh ? 'text-green-600' : ''}`}>
+          {formatSpeed(speed)}
+        </div>
+      </div>
+
+      <div className="rounded bg-background p-2">
+        <div className="text-muted-foreground">ETA</div>
+        <div className="font-mono font-semibold">{formatEta(eta)}</div>
+      </div>
+
+      <div className="rounded bg-background p-2">
+        <div className="text-muted-foreground">Downloaded</div>
+        <div className="font-mono font-semibold">{formatBytes(downloaded)}</div>
+      </div>
+
+      <div className="rounded bg-background p-2">
+        <div className="text-muted-foreground">Total</div>
+        <div className="font-mono font-semibold">{formatBytes(total)}</div>
+      </div>
+
+      <div className="col-span-2 rounded bg-background p-2">
+        <div className="text-muted-foreground">Connections</div>
+        <div className="font-mono font-semibold">{download.segments.length}</div>
+      </div>
+
+      <div className="col-span-2 rounded bg-background p-2">
+        <div className="text-muted-foreground mb-1">Progress</div>
+        <Progress value={progressPercent} />
+      </div>
+    </div>
+    </section>
+  );
+}

--- a/src/views/DownloadDetailsPanel/MetricsSection.tsx
+++ b/src/views/DownloadDetailsPanel/MetricsSection.tsx
@@ -13,8 +13,10 @@ export function MetricsSection({ download }: MetricsSectionProps) {
   const speed = progress?.speedBytesPerSec ?? download.speedBytesPerSec;
   const downloaded = progress?.downloadedBytes ?? download.downloadedBytes;
   const total = progress?.totalBytes ?? download.totalBytes;
-  const progressPercent =
-    total && total > 0 ? (downloaded / total) * 100 : download.progressPercent;
+  const progressPercent = Math.min(
+    100,
+    Math.max(0, total && total > 0 ? (downloaded / total) * 100 : download.progressPercent),
+  );
 
   const speedIsHigh = speed > 1_048_576;
   const remaining = (total ?? 0) - downloaded;
@@ -48,7 +50,9 @@ export function MetricsSection({ download }: MetricsSectionProps) {
 
       <div className="col-span-2 rounded bg-background p-2">
         <div className="text-muted-foreground">Connections</div>
-        <div className="font-mono font-semibold">{download.segments.length}</div>
+        <div className="font-mono font-semibold">
+          {download.segments.filter((s) => s.state === 'Downloading').length}
+        </div>
       </div>
 
       <div className="col-span-2 rounded bg-background p-2">

--- a/src/views/DownloadDetailsPanel/ModuleSection.tsx
+++ b/src/views/DownloadDetailsPanel/ModuleSection.tsx
@@ -1,0 +1,32 @@
+import type { DownloadDetailView } from '@/types/download';
+import { Badge } from '@/components/ui/badge';
+
+interface ModuleSectionProps {
+  download: DownloadDetailView;
+}
+
+export function ModuleSection({ download }: ModuleSectionProps) {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Module and Account</h3>
+      <div className="space-y-2 text-xs">
+        <div>
+          <p className="text-muted-foreground">Module</p>
+          <div className="mt-1">
+            {download.moduleName !== null ? (
+              <Badge variant="secondary">{download.moduleName}</Badge>
+            ) : (
+              <p className="font-mono">—</p>
+            )}
+          </div>
+        </div>
+        {download.accountName !== null && (
+          <div>
+            <p className="text-muted-foreground">Account</p>
+            <p className="font-mono">{download.accountName}</p>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/views/DownloadDetailsPanel/SegmentVisualization.tsx
+++ b/src/views/DownloadDetailsPanel/SegmentVisualization.tsx
@@ -1,0 +1,67 @@
+import type { SegmentView } from '@/types/download';
+import { formatBytes } from '@/lib/format';
+
+const SEGMENT_COLORS = [
+  'bg-blue-500',
+  'bg-purple-500',
+  'bg-pink-500',
+  'bg-red-500',
+  'bg-orange-500',
+  'bg-yellow-500',
+  'bg-green-500',
+  'bg-teal-500',
+];
+
+interface SegmentVisualizationProps {
+  segments: SegmentView[];
+  totalBytes: number | null;
+}
+
+function computeProgress(segment: SegmentView, totalBytes: number | null): number {
+  const segmentSize = segment.endByte - segment.startByte;
+  if (segmentSize <= 0 || totalBytes === 0 || totalBytes === null) return 0;
+  return Math.min(100, (segment.downloadedBytes / segmentSize) * 100);
+}
+
+export function SegmentVisualization({ segments, totalBytes }: SegmentVisualizationProps) {
+  if (segments.length === 0) {
+    return (
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold">Segments</h3>
+        <p className="text-xs text-muted-foreground">No segments</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Segments ({segments.length})</h3>
+      <div className="flex flex-col gap-2">
+      {segments.map((segment, index) => {
+        const color = SEGMENT_COLORS[index % SEGMENT_COLORS.length];
+        const progress = computeProgress(segment, totalBytes);
+        const segmentSize = segment.endByte - segment.startByte;
+
+        return (
+          <div key={segment.id} className="flex flex-col gap-1">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>Segment {index + 1}</span>
+              <span className="flex gap-2">
+                <span>{segment.state}</span>
+                <span>{formatBytes(segment.downloadedBytes)} / {formatBytes(segmentSize)}</span>
+                <span>{progress.toFixed(1)}%</span>
+              </span>
+            </div>
+            <div className="h-2 w-full rounded-full bg-muted overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all ${color}`}
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+          </div>
+        );
+      })}
+      </div>
+    </section>
+  );
+}

--- a/src/views/DownloadDetailsPanel/SourceInfoSection.tsx
+++ b/src/views/DownloadDetailsPanel/SourceInfoSection.tsx
@@ -1,0 +1,65 @@
+import type { DownloadDetailView } from '@/types/download';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface SourceInfoSectionProps {
+  download: DownloadDetailView;
+}
+
+function getHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function getProtocol(url: string): string {
+  try {
+    return new URL(url).protocol.replace(':', '').toUpperCase();
+  } catch {
+    const parts = url.split('://');
+    return parts.length > 1 ? parts[0].toUpperCase() : 'UNKNOWN';
+  }
+}
+
+export function SourceInfoSection({ download }: SourceInfoSectionProps) {
+  const hostname = getHostname(download.url);
+  const protocol = getProtocol(download.url);
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Source</h3>
+      <div className="space-y-2 text-xs">
+        <div>
+          <p className="text-muted-foreground">Host</p>
+          <p className="font-mono">{hostname}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">URL</p>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <p className="font-mono truncate max-w-full cursor-default">{download.url}</p>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="max-w-[400px] break-all">{download.url}</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Protocol</p>
+          <p className="font-mono">{protocol}</p>
+        </div>
+        <div>
+          <p className="text-muted-foreground">Resume Supported</p>
+          <input
+            type="checkbox"
+            disabled
+            checked={download.resumeSupported}
+            readOnly
+            className="mt-1"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/views/DownloadDetailsPanel/SourceInfoSection.tsx
+++ b/src/views/DownloadDetailsPanel/SourceInfoSection.tsx
@@ -51,13 +51,7 @@ export function SourceInfoSection({ download }: SourceInfoSectionProps) {
         </div>
         <div>
           <p className="text-muted-foreground">Resume Supported</p>
-          <input
-            type="checkbox"
-            disabled
-            checked={download.resumeSupported}
-            readOnly
-            className="mt-1"
-          />
+          <p className="font-mono">{download.resumeSupported ? 'Yes' : 'No'}</p>
         </div>
       </div>
     </section>

--- a/src/views/DownloadDetailsPanel/SpeedSparkline.tsx
+++ b/src/views/DownloadDetailsPanel/SpeedSparkline.tsx
@@ -1,0 +1,73 @@
+import { useSpeedHistory } from '@/hooks/useSpeedHistory';
+import { formatSpeed } from '@/lib/format';
+
+const WIDTH = 300;
+const HEIGHT = 60;
+const PADDING = 4;
+
+interface SpeedSparklineProps {
+  downloadId: string;
+}
+
+export function SpeedSparkline({ downloadId }: SpeedSparklineProps) {
+  const samples = useSpeedHistory(downloadId);
+
+  if (samples.length < 2) {
+    return (
+      <section className="space-y-3">
+        <h3 className="text-sm font-semibold">Speed History</h3>
+        <p className="text-xs text-muted-foreground">No history yet</p>
+      </section>
+    );
+  }
+
+  const maxSpeed = Math.max(...samples.map((s) => s.speed), 1);
+  const innerWidth = WIDTH - PADDING * 2;
+  const innerHeight = HEIGHT - PADDING * 2;
+
+  const points = samples.map((sample, i) => {
+    const x = PADDING + (i / (samples.length - 1)) * innerWidth;
+    const y = PADDING + (1 - sample.speed / maxSpeed) * innerHeight;
+    return `${x},${y}`;
+  });
+
+  const polylinePoints = points.join(' ');
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Speed History (2 min)</h3>
+      <svg width={WIDTH} height={HEIGHT} className="overflow-visible">
+        {/* Bottom grid line */}
+        <line
+          x1={PADDING}
+          y1={HEIGHT - PADDING}
+          x2={WIDTH - PADDING}
+          y2={HEIGHT - PADDING}
+          stroke="hsl(var(--border))"
+          strokeWidth={1}
+        />
+        {/* Top grid line */}
+        <line
+          x1={PADDING}
+          y1={PADDING}
+          x2={WIDTH - PADDING}
+          y2={PADDING}
+          stroke="hsl(var(--border))"
+          strokeWidth={1}
+        />
+        {/* Speed polyline */}
+        <polyline
+          points={polylinePoints}
+          fill="none"
+          stroke="hsl(var(--primary))"
+          strokeWidth={2}
+          strokeLinejoin="round"
+          strokeLinecap="round"
+        />
+      </svg>
+      <p className="text-xs text-muted-foreground text-right">
+        Max: {formatSpeed(maxSpeed)}
+      </p>
+    </section>
+  );
+}

--- a/src/views/DownloadDetailsPanel/__tests__/DownloadDetailsPanel.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/DownloadDetailsPanel.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { DownloadDetailsPanel } from '../DownloadDetailsPanel';
+import type { DownloadDetailView } from '@/types/download';
+
+// vi.hoisted ensures variables are available when vi.mock factories run
+const { mockInvoke, uiState } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  uiState: {
+    selectedDownloadId: null as string | null,
+    detailsPanelOpen: false,
+  },
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: mockInvoke,
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+vi.mock('@/stores/uiStore', () => ({
+  useUiStore: (selector: (s: {
+    selectedDownloadId: string | null;
+    selectedDownloadIds: string[];
+    detailsPanelOpen: boolean;
+    filterBarExpanded: boolean;
+    selectDownload: () => void;
+    setSelectedDownloadIds: () => void;
+    toggleDownloadSelection: () => void;
+    clearSelection: () => void;
+    setDetailsPanelOpen: () => void;
+    toggleFilterBar: () => void;
+  }) => unknown) =>
+    selector({
+      get selectedDownloadId() { return uiState.selectedDownloadId; },
+      get detailsPanelOpen() { return uiState.detailsPanelOpen; },
+      selectedDownloadIds: [],
+      filterBarExpanded: false,
+      selectDownload: () => undefined,
+      setSelectedDownloadIds: () => undefined,
+      toggleDownloadSelection: () => undefined,
+      clearSelection: () => undefined,
+      setDetailsPanelOpen: () => undefined,
+      toggleFilterBar: () => undefined,
+    }),
+}));
+
+vi.mock('@/stores/downloadStore', () => ({
+  useDownloadStore: (selector: (s: { progressMap: Record<string, unknown> }) => unknown) =>
+    selector({ progressMap: {} }),
+}));
+
+function mockDownloadDetail(overrides?: Partial<DownloadDetailView>): DownloadDetailView {
+  return {
+    id: 'dl-1',
+    fileName: 'test-file.zip',
+    url: 'https://example.com/test-file.zip',
+    state: 'Downloading',
+    progressPercent: 50,
+    speedBytesPerSec: 1048576,
+    downloadedBytes: 524288,
+    totalBytes: 1048576,
+    etaSeconds: 30,
+    segments: [
+      { id: 0, startByte: 0, endByte: 524288, downloadedBytes: 262144, state: 'Downloading' },
+      { id: 1, startByte: 524288, endByte: 1048576, downloadedBytes: 262144, state: 'Downloading' },
+    ],
+    checksumExpected: 'abc123def456',
+    destinationPath: '/home/user/Downloads/test-file.zip',
+    moduleName: 'core-http',
+    accountName: null,
+    resumeSupported: true,
+    retryCount: 0,
+    maxRetries: 3,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <TooltipProvider>{ui}</TooltipProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe('DownloadDetailsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInvoke.mockResolvedValue([]);
+    uiState.selectedDownloadId = null;
+    uiState.detailsPanelOpen = false;
+  });
+
+  it('should return null when detailsPanelOpen is false', () => {
+    uiState.detailsPanelOpen = false;
+    const { container } = renderWithProviders(<DownloadDetailsPanel />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should show placeholder when no download selected', () => {
+    uiState.detailsPanelOpen = true;
+    uiState.selectedDownloadId = null;
+    renderWithProviders(<DownloadDetailsPanel />);
+    expect(screen.getByText('Select a download to view details')).toBeInTheDocument();
+  });
+
+  it('should render detail content when download selected', async () => {
+    mockInvoke.mockResolvedValue(mockDownloadDetail());
+    uiState.detailsPanelOpen = true;
+    uiState.selectedDownloadId = 'dl-1';
+
+    renderWithProviders(<DownloadDetailsPanel />);
+    expect(await screen.findByText('Details')).toBeInTheDocument();
+  });
+});

--- a/src/views/DownloadDetailsPanel/__tests__/DownloadDetailsPanel.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/DownloadDetailsPanel.test.tsx
@@ -50,8 +50,11 @@ vi.mock('@/stores/uiStore', () => ({
 }));
 
 vi.mock('@/stores/downloadStore', () => ({
-  useDownloadStore: (selector: (s: { progressMap: Record<string, unknown> }) => unknown) =>
-    selector({ progressMap: {} }),
+  useDownloadStore: Object.assign(
+    (selector: (s: { progressMap: Record<string, unknown> }) => unknown) =>
+      selector({ progressMap: {} }),
+    { getState: () => ({ progressMap: {} }) },
+  ),
 }));
 
 function mockDownloadDetail(overrides?: Partial<DownloadDetailView>): DownloadDetailView {

--- a/src/views/DownloadDetailsPanel/__tests__/FileInfoSection.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/FileInfoSection.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { FileInfoSection } from '../FileInfoSection';
+import type { DownloadDetailView } from '@/types/download';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+function mockDownloadDetail(overrides?: Partial<DownloadDetailView>): DownloadDetailView {
+  return {
+    id: 'dl-1',
+    fileName: 'test-file.zip',
+    url: 'https://example.com/test-file.zip',
+    state: 'Downloading',
+    progressPercent: 50,
+    speedBytesPerSec: 1048576,
+    downloadedBytes: 524288,
+    totalBytes: 1048576,
+    etaSeconds: 30,
+    segments: [],
+    checksumExpected: null,
+    destinationPath: '/home/user/Downloads/test-file.zip',
+    moduleName: null,
+    accountName: null,
+    resumeSupported: true,
+    retryCount: 0,
+    maxRetries: 3,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+function renderWithTooltip(ui: React.ReactElement) {
+  return render(<TooltipProvider>{ui}</TooltipProvider>);
+}
+
+describe('FileInfoSection', () => {
+  it('should display filename', () => {
+    renderWithTooltip(<FileInfoSection download={mockDownloadDetail()} />);
+    expect(screen.getAllByText('test-file.zip').length).toBeGreaterThan(0);
+  });
+
+  it('should display formatted file size', () => {
+    renderWithTooltip(<FileInfoSection download={mockDownloadDetail({ totalBytes: 1048576 })} />);
+    expect(screen.getByText('1.00 MB')).toBeInTheDocument();
+  });
+
+  it('should display destination path', () => {
+    renderWithTooltip(<FileInfoSection download={mockDownloadDetail()} />);
+    expect(
+      screen.getAllByText('/home/user/Downloads/test-file.zip').length,
+    ).toBeGreaterThan(0);
+  });
+});

--- a/src/views/DownloadDetailsPanel/__tests__/LogsSection.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/LogsSection.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { LogsSection } from '../LogsSection';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+describe('LogsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should display log lines', async () => {
+    const { invoke } = await import('@tauri-apps/api/core');
+    vi.mocked(invoke).mockResolvedValue([
+      '[INFO] Download started',
+      '[INFO] Connected to server',
+    ]);
+
+    renderWithProviders(<LogsSection downloadId="dl-1" />);
+
+    expect(await screen.findByText('[INFO] Download started')).toBeInTheDocument();
+    expect(screen.getByText('[INFO] Connected to server')).toBeInTheDocument();
+  });
+
+  it('should show no logs message when empty', async () => {
+    const { invoke } = await import('@tauri-apps/api/core');
+    vi.mocked(invoke).mockResolvedValue([]);
+
+    renderWithProviders(<LogsSection downloadId="dl-1" />);
+
+    expect(await screen.findByText('No logs')).toBeInTheDocument();
+  });
+});

--- a/src/views/DownloadDetailsPanel/__tests__/MetricsSection.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/MetricsSection.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MetricsSection } from '../MetricsSection';
+import type { DownloadDetailView } from '@/types/download';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+const mockUseDownloadStore = vi.fn();
+vi.mock('@/stores/downloadStore', () => ({
+  useDownloadStore: (selector: Parameters<typeof mockUseDownloadStore>[0]) =>
+    mockUseDownloadStore(selector),
+}));
+
+function mockDownloadDetail(overrides?: Partial<DownloadDetailView>): DownloadDetailView {
+  return {
+    id: 'dl-1',
+    fileName: 'test-file.zip',
+    url: 'https://example.com/test-file.zip',
+    state: 'Downloading',
+    progressPercent: 50,
+    speedBytesPerSec: 524288,
+    downloadedBytes: 524288,
+    totalBytes: 1048576,
+    etaSeconds: 30,
+    segments: [
+      { id: 0, startByte: 0, endByte: 524288, downloadedBytes: 262144, state: 'Downloading' },
+    ],
+    checksumExpected: null,
+    destinationPath: '/home/user/Downloads/test-file.zip',
+    moduleName: null,
+    accountName: null,
+    resumeSupported: true,
+    retryCount: 0,
+    maxRetries: 3,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('MetricsSection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should display speed from store when progress entry exists', () => {
+    mockUseDownloadStore.mockImplementation((selector) =>
+      selector({
+        progressMap: {
+          'dl-1': {
+            id: 'dl-1',
+            downloadedBytes: 786432,
+            totalBytes: 1048576,
+            speedBytesPerSec: 2097152,
+            lastSampleBytes: 786432,
+            lastSampleTime: Date.now(),
+          },
+        },
+      }),
+    );
+
+    render(<MetricsSection download={mockDownloadDetail()} />);
+    // 2097152 B/s = 2 MB/s
+    expect(screen.getByText('2.00 MB/s')).toBeInTheDocument();
+  });
+
+  it('should fall back to static values when no progress entry', () => {
+    mockUseDownloadStore.mockImplementation((selector) =>
+      selector({ progressMap: {} }),
+    );
+
+    // download.speedBytesPerSec = 524288 = 512 KB/s
+    render(<MetricsSection download={mockDownloadDetail()} />);
+    expect(screen.getByText('512.00 KB/s')).toBeInTheDocument();
+  });
+});

--- a/src/views/DownloadDetailsPanel/__tests__/SegmentVisualization.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/SegmentVisualization.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SegmentVisualization } from '../SegmentVisualization';
+import type { SegmentView } from '@/types/download';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+const segments: SegmentView[] = [
+  { id: 0, startByte: 0, endByte: 524288, downloadedBytes: 262144, state: 'Downloading' },
+  { id: 1, startByte: 524288, endByte: 1048576, downloadedBytes: 524288, state: 'Completed' },
+];
+
+describe('SegmentVisualization', () => {
+  it('should render all segments', () => {
+    render(<SegmentVisualization segments={segments} totalBytes={1048576} />);
+    expect(screen.getByText('Segment 1')).toBeInTheDocument();
+    expect(screen.getByText('Segment 2')).toBeInTheDocument();
+  });
+
+  it('should handle empty segments array', () => {
+    render(<SegmentVisualization segments={[]} totalBytes={1048576} />);
+    expect(screen.getByText('No segments')).toBeInTheDocument();
+  });
+
+  it('should handle zero totalBytes', () => {
+    render(<SegmentVisualization segments={segments} totalBytes={0} />);
+    // With totalBytes=0, progress computes to 0%
+    const percentTexts = screen.getAllByText('0.0%');
+    expect(percentTexts.length).toBeGreaterThan(0);
+  });
+});

--- a/src/views/DownloadDetailsPanel/__tests__/SpeedSparkline.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/SpeedSparkline.test.tsx
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SpeedSparkline } from '../SpeedSparkline';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+const mockUseSpeedHistory = vi.fn();
+vi.mock('@/hooks/useSpeedHistory', () => ({
+  useSpeedHistory: (id: string) => mockUseSpeedHistory(id),
+}));
+
+describe('SpeedSparkline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should show no history message with less than 2 samples', () => {
+    mockUseSpeedHistory.mockReturnValue([{ time: Date.now(), speed: 1024 }]);
+    render(<SpeedSparkline downloadId="dl-1" />);
+    expect(screen.getByText('No history yet')).toBeInTheDocument();
+  });
+
+  it('should render SVG with enough samples', () => {
+    const now = Date.now();
+    mockUseSpeedHistory.mockReturnValue([
+      { time: now - 4000, speed: 512000 },
+      { time: now - 2000, speed: 1024000 },
+      { time: now, speed: 768000 },
+    ]);
+    const { container } = render(<SpeedSparkline downloadId="dl-1" />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(container.querySelector('polyline')).toBeInTheDocument();
+  });
+});

--- a/src/views/DownloadDetailsPanel/index.ts
+++ b/src/views/DownloadDetailsPanel/index.ts
@@ -1,0 +1,1 @@
+export { DownloadDetailsPanel } from './DownloadDetailsPanel';

--- a/src/views/DownloadsView/DownloadsView.tsx
+++ b/src/views/DownloadsView/DownloadsView.tsx
@@ -8,6 +8,7 @@ import { SearchBar } from './SearchBar';
 import { FilterBar } from './FilterBar';
 import { ActionsBar } from './ActionsBar';
 import { DownloadsTable } from './DownloadsTable';
+import { DownloadDetailsPanel } from '../DownloadDetailsPanel';
 
 export function DownloadsView() {
   const [filter, setFilter] = useState<FilterType>('all');
@@ -28,20 +29,23 @@ export function DownloadsView() {
   );
 
   return (
-    <div className="flex h-full flex-col gap-3 p-4">
-      <SearchBar value={searchQuery} onChange={setSearchQuery} />
-      <FilterBar
-        activeFilter={filter}
-        onFilterChange={setFilter}
-        counts={countByState}
-      />
-      <ActionsBar />
-      <DownloadsTable
-        downloads={downloads ?? []}
-        isLoading={isLoading}
-        filter={filter}
-        searchQuery={searchQuery}
-      />
+    <div className="flex h-full">
+      <div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
+        <SearchBar value={searchQuery} onChange={setSearchQuery} />
+        <FilterBar
+          activeFilter={filter}
+          onFilterChange={setFilter}
+          counts={countByState}
+        />
+        <ActionsBar />
+        <DownloadsTable
+          downloads={downloads ?? []}
+          isLoading={isLoading}
+          filter={filter}
+          searchQuery={searchQuery}
+        />
+      </div>
+      <DownloadDetailsPanel />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Right sidebar panel displaying detailed info for the selected download, with 8 collapsible sections: File Info, Metrics, Segments, Speed History, Source, Integrity, Module, Logs
- Real-time metrics from Zustand `downloadStore.progressMap` (speed, ETA, downloaded/total, connections) with dynamic ETA calculation
- SVG speed sparkline sampling from the store every 2s, rendering a 2-minute polyline chart
- Segment visualization with colored progress bars per segment and download state indicators
- Auto-opens panel when a download is selected (`selectDownload` now sets `detailsPanelOpen: true`)
- Integrated into DownloadsView as a flex-row split layout (table left, panel right)

## New files

- `src/views/DownloadDetailsPanel/` — 9 components (panel + 8 sections) + barrel export
- `src/hooks/useDownloadDetail.ts` — TanStack Query wrapper (500ms staleTime)
- `src/hooks/useSpeedHistory.ts` — Speed sampling hook (2s interval, 2min window)

## Modified files

- `src/stores/uiStore.ts` — `selectDownload` auto-opens details panel
- `src/views/DownloadsView/DownloadsView.tsx` — Flex-row layout with panel
- `CHANGELOG.md` — Added entry for Download Details Panel

## Test plan

- [x] TypeScript strict mode: 0 errors
- [x] oxlint: 0 warnings, 0 errors
- [x] 178/178 tests passing (18 new tests for panel components + hooks)
- [ ] Manual: select download, verify panel appears with all sections
- [ ] Manual: watch metrics update in real-time during active download
- [ ] Manual: close panel via X button, verify it hides
- [ ] Manual: switch between downloads, verify panel content updates

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a right sidebar Download Details Panel for the selected download with real-time metrics, speed history, segments, and logs. Improves accuracy, accessibility, and keeps the header/close control visible during loading and errors.

- **New Features**
  - 8 sections: File Info, Metrics, Segments, Speed History, Source, Integrity, Module, Logs.
  - Live metrics from `zustand` progress map with dynamic ETA.
  - 2-minute SVG speed sparkline sampled every 2s (samples immediately on mount).
  - Segment progress bars and a logs viewer (last 20 lines).
  - Auto-opens on selection; closable via X; integrated as a split layout in DownloadsView.
  - Hooks: `useDownloadDetail` (500ms stale, enabled guard) and `useSpeedHistory` (2s sampling, 2-min window).

- **Bug Fixes**
  - Progress clamped to [0, 100]; connections count filters active segments only.
  - Integrity shows algorithm/status only when a checksum is present.
  - Logs handle loading state separately from empty state; header and close button stay visible in loading/error states.
  - File Info MIME detection handles extensionless filenames.
  - Close button has an aria-label; empty state includes a close control.

<sup>Written for commit 05c4588d5ea0a730ca7e7c0ec55a20e180232b0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Right-side Download Details panel with eight sections (File Info, Metrics, Segments, Speed History, Source, Integrity, Module, Logs); auto-opens on selection and includes a close control.
  * Real-time speed/ETA/progress updates, per-segment colored progress bars, 2-minute speed sparkline sampled every 2s, MIME detection, tooltips, checksum status, and scrollable last-20 logs.
* **Integration**
  * Panel added alongside the downloads list in the main view.
* **Tests**
  * New test suites covering hooks and all panel sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->