### PR TITLE
feat(ui): implement Media Grabber dialog for media download options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,5 +121,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - SizeEstimate: real-time download size estimation based on quality and duration
   - MediaPreview: thumbnail + title display with broken image fallback
   - `useMediaMetadata` hook fetching metadata via Tauri IPC
-  - Integration in LinkGrabberView via clickable media badge in LinkRow
+  - Integration in LinkGrabberView via clickable media button in LinkRow
   - shadcn/ui Dialog, Card, Skeleton components added to UI library

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,3 +103,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Auto-opens when a download is selected, closeable via X button
   - `useDownloadDetail` hook wrapping TanStack Query with 500ms staleTime
   - `useSpeedHistory` hook sampling speed from store at 2s intervals
+- Link Grabber View: paste zone, URL validation, link analysis pipeline, package grouping
+  - PasteZone with textarea + drag-and-drop URL input
+  - FilterBar: All | Online | Offline | Media filter tabs
+  - PackageGrouping: group by hostname, extension, or type
+  - ActionsBar: Select All, Start Selected, Start All Online, Clear
+  - LinkRow with status icons, filename/URL display, media badge
+  - ResolvedLinksSection with grouping, multi-select, and group toggle
+  - URL validation for http/https/ftp/magnet protocols (case-insensitive)
+  - `useTauriMutation` for `link_resolve` and `download_start` commands
+- Media Grabber UI: modal dialog for media download options (Task 21)
+  - MediaGrabberDialog: orchestrates quality/format/audio/subtitle/playlist selection
+  - QualitySelector: grid of video qualities (360p-4K) with resolution, fps, bitrate
+  - AudioOnlySection: toggle + audio format selection (M4A, MP3, OGG, WAV, OPUS)
+  - SubtitleSelector: multi-select checkbox list of available languages
+  - PlaylistSection: scrollable list with individual/bulk select for playlist items
+  - SizeEstimate: real-time download size estimation based on quality and duration
+  - MediaPreview: thumbnail + title display with broken image fallback
+  - `useMediaMetadata` hook fetching metadata via Tauri IPC
+  - Integration in LinkGrabberView via clickable media badge in LinkRow
+  - shadcn/ui Dialog, Card, Skeleton components added to UI library

--- a/src/components/MediaPreview.tsx
+++ b/src/components/MediaPreview.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+
+interface MediaPreviewProps {
+  title: string;
+  thumbnail: string;
+}
+
+export function MediaPreview({ title, thumbnail }: MediaPreviewProps) {
+  const [imgError, setImgError] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      {imgError ? (
+        <div className="flex w-full items-center justify-center rounded bg-muted aspect-video">
+          <span className="text-sm text-muted-foreground">No preview available</span>
+        </div>
+      ) : (
+        <img
+          src={thumbnail}
+          alt={title}
+          className="w-full rounded object-cover aspect-video"
+          onError={() => setImgError(true)}
+        />
+      )}
+      <p className="text-sm font-semibold">{title}</p>
+    </div>
+  );
+}

--- a/src/components/MediaPreview.tsx
+++ b/src/components/MediaPreview.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface MediaPreviewProps {
   title: string;
@@ -7,6 +7,10 @@ interface MediaPreviewProps {
 
 export function MediaPreview({ title, thumbnail }: MediaPreviewProps) {
   const [imgError, setImgError] = useState(false);
+
+  useEffect(() => {
+    setImgError(false);
+  }, [thumbnail]);
 
   return (
     <div className="space-y-2">

--- a/src/components/__tests__/MediaPreview.test.tsx
+++ b/src/components/__tests__/MediaPreview.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MediaPreview } from "../MediaPreview";
+
+describe("MediaPreview", () => {
+  it("should display the title", () => {
+    render(
+      <MediaPreview title="Test Video" thumbnail="https://img.test/thumb.jpg" />,
+    );
+    expect(screen.getByText("Test Video")).toBeInTheDocument();
+  });
+
+  it("should render thumbnail image", () => {
+    render(
+      <MediaPreview title="Test Video" thumbnail="https://img.test/thumb.jpg" />,
+    );
+    const img = screen.getByRole("img", { name: "Test Video" });
+    expect(img).toHaveAttribute("src", "https://img.test/thumb.jpg");
+  });
+
+  it("should show fallback when image fails to load", () => {
+    render(
+      <MediaPreview title="Test Video" thumbnail="https://broken-url/nope.jpg" />,
+    );
+    const img = screen.getByRole("img", { name: "Test Video" });
+    fireEvent.error(img);
+    expect(screen.getByText("No preview available")).toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "flex flex-col gap-6 rounded-xl border bg-card py-6 text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-2 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,156 @@
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-accent", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -1,0 +1,38 @@
+export interface QualityOption {
+  quality: string;
+  height: number;
+  width: number;
+  fps: number;
+  bitrateKbps: number;
+}
+
+export interface SubtitleLanguage {
+  code: string;
+  name: string;
+}
+
+export interface PlaylistItem {
+  id: string;
+  title: string;
+  durationSeconds: number;
+}
+
+export interface MediaMetadata {
+  title: string;
+  thumbnailUrl: string;
+  durationSeconds: number;
+  isPlaylist: boolean;
+  availableQualities: QualityOption[];
+  availableFormats: string[];
+  availableAudioFormats: string[];
+  availableSubtitles: SubtitleLanguage[];
+  playlistItems?: PlaylistItem[];
+}
+
+export interface MediaGrabberOptions {
+  quality: string;
+  format: string;
+  subtitles: string[];
+  audioOnly: boolean;
+  playlistItems: string[];
+}

--- a/src/views/LinkGrabberView/LinkGrabberView.tsx
+++ b/src/views/LinkGrabberView/LinkGrabberView.tsx
@@ -8,13 +8,18 @@ import { FilterBar } from "./FilterBar";
 import { PackageGrouping } from "./PackageGrouping";
 import { ActionsBar } from "./ActionsBar";
 import { ResolvedLinksSection } from "./ResolvedLinksSection";
+import { MediaGrabberDialog } from "./MediaGrabberDialog";
 import type { ResolvedLink, FilterType, GroupingMode } from "./types";
+import type { MediaGrabberOptions } from "@/types/media";
 
 export function LinkGrabberView() {
   const [resolvedLinks, setResolvedLinks] = useState<ResolvedLink[]>([]);
   const [filter, setFilter] = useState<FilterType>("all");
   const [selectedLinkIds, setSelectedLinkIds] = useState<string[]>([]);
   const [groupingMode, setGroupingMode] = useState<GroupingMode>("hostname");
+  const [selectedMediaLink, setSelectedMediaLink] =
+    useState<ResolvedLink | null>(null);
+  const [mediaGrabberOpen, setMediaGrabberOpen] = useState(false);
 
   const clipboardMonitoringEnabled = useSettingsStore(
     (s) => s.config?.clipboardMonitoring ?? false,
@@ -33,6 +38,11 @@ export function LinkGrabberView() {
   const { mutate: startDownload } = useTauriMutation<unknown, { url: string }>(
     "download_start",
   );
+
+  const { mutate: startMediaDownload } = useTauriMutation<
+    unknown,
+    { url: string; mediaOptions: MediaGrabberOptions }
+  >("download_start");
 
   const handlePasteUrls = (urls: string[]) => {
     // TODO: container: entries need a dedicated backend command for decryption
@@ -62,6 +72,20 @@ export function LinkGrabberView() {
       if (link.status === "online" && link.resolvedUrl) {
         startDownload({ url: link.resolvedUrl });
       }
+    }
+  };
+
+  const handleMediaClick = (link: ResolvedLink) => {
+    setSelectedMediaLink(link);
+    setMediaGrabberOpen(true);
+  };
+
+  const handleMediaGrabberConfirm = (options: MediaGrabberOptions) => {
+    if (selectedMediaLink?.originalUrl) {
+      startMediaDownload({
+        url: selectedMediaLink.originalUrl,
+        mediaOptions: options,
+      });
     }
   };
 
@@ -111,8 +135,17 @@ export function LinkGrabberView() {
             groupingMode={groupingMode}
             selectedIds={selectedLinkIds}
             onSelectIds={setSelectedLinkIds}
+            onMediaClick={handleMediaClick}
           />
         </>
+      )}
+      {selectedMediaLink && (
+        <MediaGrabberDialog
+          link={selectedMediaLink}
+          open={mediaGrabberOpen}
+          onOpenChange={setMediaGrabberOpen}
+          onConfirm={handleMediaGrabberConfirm}
+        />
       )}
     </div>
   );

--- a/src/views/LinkGrabberView/LinkGrabberView.tsx
+++ b/src/views/LinkGrabberView/LinkGrabberView.tsx
@@ -143,7 +143,10 @@ export function LinkGrabberView() {
         <MediaGrabberDialog
           link={selectedMediaLink}
           open={mediaGrabberOpen}
-          onOpenChange={setMediaGrabberOpen}
+          onOpenChange={(open) => {
+            setMediaGrabberOpen(open);
+            if (!open) setSelectedMediaLink(null);
+          }}
           onConfirm={handleMediaGrabberConfirm}
         />
       )}

--- a/src/views/LinkGrabberView/LinkRow.tsx
+++ b/src/views/LinkGrabberView/LinkRow.tsx
@@ -1,25 +1,19 @@
 import { Loader2, Check, X, AlertCircle } from "lucide-react";
 import { Checkbox } from "@/components/ui/checkbox";
-import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { formatBytes } from "@/lib/format";
 import type { ResolvedLink } from "./types";
 
 interface LinkRowProps {
   link: ResolvedLink;
   selected: boolean;
   onSelect: () => void;
-}
-
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  if (bytes < 1024 * 1024 * 1024)
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
+  onMediaClick?: (link: ResolvedLink) => void;
 }
 
 const statusIconMap = {
@@ -29,7 +23,7 @@ const statusIconMap = {
   error: <AlertCircle className="h-4 w-4 text-yellow-500" />,
 };
 
-export function LinkRow({ link, selected, onSelect }: LinkRowProps) {
+export function LinkRow({ link, selected, onSelect, onMediaClick }: LinkRowProps) {
   return (
     <div
       className={`flex items-center gap-3 rounded p-2 transition-colors hover:bg-muted ${
@@ -62,7 +56,17 @@ export function LinkRow({ link, selected, onSelect }: LinkRowProps) {
         </span>
       )}
       {link.isMedia && (
-        <Badge variant="outline">{link.mediaType ?? "Media"}</Badge>
+        <Button
+          variant="outline"
+          size="sm"
+          className="h-6 px-2 text-xs"
+          onClick={(e) => {
+            e.stopPropagation();
+            onMediaClick?.(link);
+          }}
+        >
+          {link.mediaType ?? "Media"}
+        </Button>
       )}
     </div>
   );

--- a/src/views/LinkGrabberView/MediaGrabberDialog/AudioOnlySection.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/AudioOnlySection.tsx
@@ -1,0 +1,59 @@
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+
+interface AudioOnlySectionProps {
+  enabled: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+  audioFormats: string[];
+  selectedFormat: string;
+  onSelectFormat: (format: string) => void;
+}
+
+export function AudioOnlySection({
+  enabled,
+  onEnabledChange,
+  audioFormats,
+  selectedFormat,
+  onSelectFormat,
+}: AudioOnlySectionProps) {
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Switch
+          id="audio-only"
+          checked={enabled}
+          onCheckedChange={onEnabledChange}
+        />
+        <label
+          htmlFor="audio-only"
+          className="cursor-pointer text-sm font-semibold"
+        >
+          Audio Only
+        </label>
+      </div>
+
+      {enabled && (
+        <div className="space-y-2">
+          <label className="text-sm font-semibold">Audio Format</label>
+          <div className="grid grid-cols-3 gap-2">
+            {audioFormats.map((fmt) => (
+              <Button
+                key={fmt}
+                variant={selectedFormat === fmt ? "default" : "outline"}
+                size="sm"
+                onClick={() => onSelectFormat(fmt)}
+                className="uppercase"
+              >
+                {fmt}
+              </Button>
+            ))}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            Popular formats: MP3 (wide compatibility), M4A (iTunes), OPUS
+            (quality)
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/views/LinkGrabberView/MediaGrabberDialog/AudioOnlySection.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/AudioOnlySection.tsx
@@ -34,14 +34,15 @@ export function AudioOnlySection({
 
       {enabled && (
         <div className="space-y-2">
-          <label className="text-sm font-semibold">Audio Format</label>
-          <div className="grid grid-cols-3 gap-2">
+          <span className="text-sm font-semibold" id="audio-format-label">Audio Format</span>
+          <div className="grid grid-cols-3 gap-2" role="group" aria-labelledby="audio-format-label">
             {audioFormats.map((fmt) => (
               <Button
                 key={fmt}
                 variant={selectedFormat === fmt ? "default" : "outline"}
                 size="sm"
                 onClick={() => onSelectFormat(fmt)}
+                aria-pressed={selectedFormat === fmt}
                 className="uppercase"
               >
                 {fmt}

--- a/src/views/LinkGrabberView/MediaGrabberDialog/MediaGrabberDialog.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/MediaGrabberDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -47,6 +47,23 @@ export function MediaGrabberDialog({
     refetch,
   } = useMediaMetadata(link.originalUrl, open);
 
+  useEffect(() => {
+    if (!open) return;
+    setAudioOnly(false);
+    setSelectedSubtitles([]);
+    setSelectedPlaylistItems([]);
+  }, [open, link.originalUrl]);
+
+  useEffect(() => {
+    if (!metadata) return;
+    const firstQuality = metadata.availableQualities[0]?.quality ?? "1080p";
+    const firstFormat = metadata.availableFormats[0] ?? "mp4";
+    const firstAudioFormat = metadata.availableAudioFormats[0] ?? "m4a";
+    setQualitySelection(firstQuality);
+    setFormatSelection(firstFormat);
+    setAudioFormat(firstAudioFormat);
+  }, [metadata]);
+
   const handleConfirm = () => {
     onConfirm({
       quality: audioOnly ? "audio_only" : qualitySelection,
@@ -74,7 +91,7 @@ export function MediaGrabberDialog({
               thumbnail={metadata.thumbnailUrl}
             />
 
-            {metadata.isPlaylist && metadata.playlistItems && (
+            {metadata.isPlaylist && metadata.playlistItems && metadata.playlistItems.length > 0 && (
               <PlaylistSection
                 items={metadata.playlistItems}
                 selectedItems={selectedPlaylistItems}
@@ -115,6 +132,7 @@ export function MediaGrabberDialog({
               quality={audioOnly ? "audio_only" : qualitySelection}
               format={audioOnly ? audioFormat : formatSelection}
               duration={metadata.durationSeconds}
+              qualities={metadata.availableQualities}
             />
           </div>
         ) : (

--- a/src/views/LinkGrabberView/MediaGrabberDialog/MediaGrabberDialog.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/MediaGrabberDialog.tsx
@@ -1,0 +1,146 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { MediaPreview } from "@/components/MediaPreview";
+import { QualitySelector } from "./QualitySelector";
+import { AudioOnlySection } from "./AudioOnlySection";
+import { SubtitleSelector } from "./SubtitleSelector";
+import { PlaylistSection } from "./PlaylistSection";
+import { SizeEstimate } from "./SizeEstimate";
+import { useMediaMetadata } from "./useMediaMetadata";
+import type { ResolvedLink } from "../types";
+import type { MediaGrabberOptions } from "@/types/media";
+
+interface MediaGrabberDialogProps {
+  link: ResolvedLink;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (options: MediaGrabberOptions) => void;
+}
+
+export function MediaGrabberDialog({
+  link,
+  open,
+  onOpenChange,
+  onConfirm,
+}: MediaGrabberDialogProps) {
+  const [qualitySelection, setQualitySelection] = useState("1080p");
+  const [formatSelection, setFormatSelection] = useState("mp4");
+  const [audioOnly, setAudioOnly] = useState(false);
+  const [audioFormat, setAudioFormat] = useState("m4a");
+  const [selectedSubtitles, setSelectedSubtitles] = useState<string[]>([]);
+  const [selectedPlaylistItems, setSelectedPlaylistItems] = useState<string[]>(
+    [],
+  );
+
+  const {
+    data: metadata,
+    isLoading,
+    isError,
+    refetch,
+  } = useMediaMetadata(link.originalUrl, open);
+
+  const handleConfirm = () => {
+    onConfirm({
+      quality: audioOnly ? "audio_only" : qualitySelection,
+      format: audioOnly ? audioFormat : formatSelection,
+      subtitles: selectedSubtitles,
+      audioOnly,
+      playlistItems: selectedPlaylistItems,
+    });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[80vh] max-w-2xl overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Media Grabber Options</DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <Skeleton className="h-64" />
+        ) : metadata ? (
+          <div className="space-y-6">
+            <MediaPreview
+              title={metadata.title}
+              thumbnail={metadata.thumbnailUrl}
+            />
+
+            {metadata.isPlaylist && metadata.playlistItems && (
+              <PlaylistSection
+                items={metadata.playlistItems}
+                selectedItems={selectedPlaylistItems}
+                onSelectItems={setSelectedPlaylistItems}
+              />
+            )}
+
+            <div className="space-y-4 border-t pt-6">
+              {!audioOnly && metadata.availableQualities.length > 0 && (
+                <QualitySelector
+                  qualities={metadata.availableQualities}
+                  formats={metadata.availableFormats}
+                  selected={qualitySelection}
+                  selectedFormat={formatSelection}
+                  onSelectQuality={setQualitySelection}
+                  onSelectFormat={setFormatSelection}
+                />
+              )}
+
+              <AudioOnlySection
+                enabled={audioOnly}
+                onEnabledChange={setAudioOnly}
+                audioFormats={metadata.availableAudioFormats}
+                selectedFormat={audioFormat}
+                onSelectFormat={setAudioFormat}
+              />
+
+              {metadata.availableSubtitles.length > 0 && (
+                <SubtitleSelector
+                  languages={metadata.availableSubtitles}
+                  selected={selectedSubtitles}
+                  onSelect={setSelectedSubtitles}
+                />
+              )}
+            </div>
+
+            <SizeEstimate
+              quality={audioOnly ? "audio_only" : qualitySelection}
+              format={audioOnly ? audioFormat : formatSelection}
+              duration={metadata.durationSeconds}
+            />
+          </div>
+        ) : (
+          <div className="space-y-3 text-center">
+            <p className="text-sm text-muted-foreground">
+              {isError
+                ? "Failed to load media metadata"
+                : "No metadata available for this link"}
+            </p>
+            {isError && (
+              <Button variant="outline" size="sm" onClick={() => refetch()}>
+                Retry
+              </Button>
+            )}
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={handleConfirm} disabled={isLoading || !metadata}>
+            Download
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/views/LinkGrabberView/MediaGrabberDialog/PlaylistSection.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/PlaylistSection.tsx
@@ -1,0 +1,75 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { PlaylistItem } from "@/types/media";
+
+interface PlaylistSectionProps {
+  items: PlaylistItem[];
+  selectedItems: string[];
+  onSelectItems: (ids: string[]) => void;
+}
+
+export function PlaylistSection({
+  items,
+  selectedItems,
+  onSelectItems,
+}: PlaylistSectionProps) {
+  const allSelected = items.length > 0 && selectedItems.length === items.length;
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-sm font-semibold">
+          Playlist ({items.length} items)
+        </h3>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            if (allSelected) {
+              onSelectItems([]);
+            } else {
+              onSelectItems(items.map((i) => i.id));
+            }
+          }}
+        >
+          {allSelected ? "Deselect All" : "Select All"}
+        </Button>
+      </div>
+
+      <ScrollArea className="h-40 rounded border">
+        <div className="space-y-1 p-2">
+          {items.map((item, idx) => (
+            <div
+              key={item.id}
+              className="flex items-center gap-2 rounded p-2 hover:bg-muted"
+            >
+              <Checkbox
+                checked={selectedItems.includes(item.id)}
+                onCheckedChange={(checked) => {
+                  if (checked) {
+                    onSelectItems([...selectedItems, item.id]);
+                  } else {
+                    onSelectItems(
+                      selectedItems.filter((id) => id !== item.id),
+                    );
+                  }
+                }}
+              />
+              <div className="min-w-0 flex-1">
+                <span className="text-xs font-semibold text-muted-foreground">
+                  #{idx + 1}
+                </span>
+                <p className="truncate text-sm">{item.title}</p>
+                <p className="text-xs text-muted-foreground">
+                  {Math.floor(item.durationSeconds / 60)}m{" "}
+                  {item.durationSeconds % 60}s
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </ScrollArea>
+    </section>
+  );
+}

--- a/src/views/LinkGrabberView/MediaGrabberDialog/PlaylistSection.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/PlaylistSection.tsx
@@ -45,6 +45,7 @@ export function PlaylistSection({
               className="flex items-center gap-2 rounded p-2 hover:bg-muted"
             >
               <Checkbox
+                aria-label={`#${idx + 1} ${item.title}`}
                 checked={selectedItems.includes(item.id)}
                 onCheckedChange={(checked) => {
                   if (checked) {

--- a/src/views/LinkGrabberView/MediaGrabberDialog/QualitySelector.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/QualitySelector.tsx
@@ -29,7 +29,7 @@ export function QualitySelector({
             key={q.quality}
             role="radio"
             aria-checked={selected === q.quality}
-            tabIndex={0}
+            tabIndex={selected === q.quality ? 0 : -1}
             className={`cursor-pointer p-3 transition-colors ${
               selected === q.quality
                 ? "ring-2 ring-accent bg-accent/10"
@@ -55,14 +55,15 @@ export function QualitySelector({
       </div>
 
       <div className="space-y-2">
-        <label className="text-sm font-semibold">Container Format</label>
-        <div className="flex gap-2">
+        <span className="text-sm font-semibold" id="container-format-label">Container Format</span>
+        <div className="flex gap-2" role="group" aria-labelledby="container-format-label">
           {formats.map((fmt) => (
             <Button
               key={fmt}
               variant={selectedFormat === fmt ? "default" : "outline"}
               size="sm"
               onClick={() => onSelectFormat(fmt)}
+              aria-pressed={selectedFormat === fmt}
               className="uppercase"
             >
               {fmt}

--- a/src/views/LinkGrabberView/MediaGrabberDialog/QualitySelector.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/QualitySelector.tsx
@@ -1,0 +1,75 @@
+import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import type { QualityOption } from "@/types/media";
+
+interface QualitySelectorProps {
+  qualities: QualityOption[];
+  formats: string[];
+  selected: string;
+  selectedFormat: string;
+  onSelectQuality: (quality: string) => void;
+  onSelectFormat: (format: string) => void;
+}
+
+export function QualitySelector({
+  qualities,
+  formats,
+  selected,
+  selectedFormat,
+  onSelectQuality,
+  onSelectFormat,
+}: QualitySelectorProps) {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Video Quality</h3>
+
+      <div className="grid grid-cols-3 gap-2" role="radiogroup" aria-label="Video quality">
+        {qualities.map((q) => (
+          <Card
+            key={q.quality}
+            role="radio"
+            aria-checked={selected === q.quality}
+            tabIndex={0}
+            className={`cursor-pointer p-3 transition-colors ${
+              selected === q.quality
+                ? "ring-2 ring-accent bg-accent/10"
+                : "hover:bg-muted"
+            }`}
+            onClick={() => onSelectQuality(q.quality)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelectQuality(q.quality);
+              }
+            }}
+          >
+            <div className="text-sm font-semibold">{q.quality}</div>
+            <div className="text-xs text-muted-foreground">
+              {q.width}&times;{q.height} @ {q.fps}fps
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {(q.bitrateKbps / 1000).toFixed(1)} Mbps
+            </div>
+          </Card>
+        ))}
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-semibold">Container Format</label>
+        <div className="flex gap-2">
+          {formats.map((fmt) => (
+            <Button
+              key={fmt}
+              variant={selectedFormat === fmt ? "default" : "outline"}
+              size="sm"
+              onClick={() => onSelectFormat(fmt)}
+              className="uppercase"
+            >
+              {fmt}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/views/LinkGrabberView/MediaGrabberDialog/SizeEstimate.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/SizeEstimate.tsx
@@ -1,0 +1,34 @@
+import { formatBytes } from "@/lib/format";
+
+interface SizeEstimateProps {
+  quality: string;
+  format: string;
+  duration: number;
+}
+
+const BITRATE_MAP: Record<string, number> = {
+  "360p": 500,
+  "480p": 1000,
+  "720p": 2500,
+  "1080p": 5000,
+  "1440p": 8000,
+  "4k": 15000,
+  audio_only: 192,
+};
+
+export function SizeEstimate({ quality, format, duration }: SizeEstimateProps) {
+  const bitrateKbps = BITRATE_MAP[quality] ?? 2500;
+  const fileSizeBytes = ((bitrateKbps * 1000) * duration) / 8;
+
+  return (
+    <div className="rounded bg-muted p-3">
+      <p className="text-sm font-semibold">
+        Estimated Size: {formatBytes(fileSizeBytes)}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        {quality} {format.toUpperCase()} &bull; {Math.round(duration / 60)}m
+        video
+      </p>
+    </div>
+  );
+}

--- a/src/views/LinkGrabberView/MediaGrabberDialog/SizeEstimate.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/SizeEstimate.tsx
@@ -1,12 +1,14 @@
 import { formatBytes } from "@/lib/format";
+import type { QualityOption } from "@/types/media";
 
 interface SizeEstimateProps {
   quality: string;
   format: string;
   duration: number;
+  qualities?: QualityOption[];
 }
 
-const BITRATE_MAP: Record<string, number> = {
+const FALLBACK_BITRATE_MAP: Record<string, number> = {
   "360p": 500,
   "480p": 1000,
   "720p": 2500,
@@ -16,9 +18,16 @@ const BITRATE_MAP: Record<string, number> = {
   audio_only: 192,
 };
 
-export function SizeEstimate({ quality, format, duration }: SizeEstimateProps) {
-  const bitrateKbps = BITRATE_MAP[quality] ?? 2500;
+export function SizeEstimate({
+  quality,
+  format,
+  duration,
+  qualities,
+}: SizeEstimateProps) {
+  const actualBitrate = qualities?.find((q) => q.quality === quality)?.bitrateKbps;
+  const bitrateKbps = actualBitrate ?? FALLBACK_BITRATE_MAP[quality] ?? 2500;
   const fileSizeBytes = ((bitrateKbps * 1000) * duration) / 8;
+  const isAudio = quality === "audio_only";
 
   return (
     <div className="rounded bg-muted p-3">
@@ -26,8 +35,8 @@ export function SizeEstimate({ quality, format, duration }: SizeEstimateProps) {
         Estimated Size: {formatBytes(fileSizeBytes)}
       </p>
       <p className="text-xs text-muted-foreground">
-        {quality} {format.toUpperCase()} &bull; {Math.round(duration / 60)}m
-        video
+        {quality} {format.toUpperCase()} &bull; {Math.round(duration / 60)}m{" "}
+        {isAudio ? "audio" : "video"}
       </p>
     </div>
   );

--- a/src/views/LinkGrabberView/MediaGrabberDialog/SubtitleSelector.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/SubtitleSelector.tsx
@@ -1,0 +1,46 @@
+import { Checkbox } from "@/components/ui/checkbox";
+import type { SubtitleLanguage } from "@/types/media";
+
+interface SubtitleSelectorProps {
+  languages: SubtitleLanguage[];
+  selected: string[];
+  onSelect: (codes: string[]) => void;
+}
+
+export function SubtitleSelector({
+  languages,
+  selected,
+  onSelect,
+}: SubtitleSelectorProps) {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold">Subtitles</h3>
+      <p className="text-xs text-muted-foreground">
+        Select languages to download (if available)
+      </p>
+      <div className="grid max-h-48 grid-cols-2 gap-2 overflow-y-auto">
+        {languages.map((lang) => (
+          <div key={lang.code} className="flex items-center gap-2">
+            <Checkbox
+              id={`subtitle-${lang.code}`}
+              checked={selected.includes(lang.code)}
+              onCheckedChange={(checked) => {
+                if (checked) {
+                  onSelect([...selected, lang.code]);
+                } else {
+                  onSelect(selected.filter((c) => c !== lang.code));
+                }
+              }}
+            />
+            <label
+              htmlFor={`subtitle-${lang.code}`}
+              className="cursor-pointer text-sm"
+            >
+              {lang.name} ({lang.code})
+            </label>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/views/LinkGrabberView/MediaGrabberDialog/SubtitleSelector.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/SubtitleSelector.tsx
@@ -25,11 +25,10 @@ export function SubtitleSelector({
               id={`subtitle-${lang.code}`}
               checked={selected.includes(lang.code)}
               onCheckedChange={(checked) => {
-                if (checked) {
-                  onSelect([...selected, lang.code]);
-                } else {
-                  onSelect(selected.filter((c) => c !== lang.code));
-                }
+                const next = new Set(selected);
+                if (checked === true) next.add(lang.code);
+                else next.delete(lang.code);
+                onSelect([...next]);
               }}
             />
             <label

--- a/src/views/LinkGrabberView/MediaGrabberDialog/index.ts
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/index.ts
@@ -1,0 +1,1 @@
+export { MediaGrabberDialog } from "./MediaGrabberDialog";

--- a/src/views/LinkGrabberView/MediaGrabberDialog/useMediaMetadata.ts
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/useMediaMetadata.ts
@@ -1,0 +1,9 @@
+import { useTauriQuery } from "@/api/hooks";
+import type { MediaMetadata } from "@/types/media";
+
+export function useMediaMetadata(url: string, enabled: boolean) {
+  return useTauriQuery<MediaMetadata>("command_get_media_metadata", { url }, {
+    enabled,
+    queryKey: ["command_get_media_metadata", { url }],
+  });
+}

--- a/src/views/LinkGrabberView/ResolvedLinksSection.tsx
+++ b/src/views/LinkGrabberView/ResolvedLinksSection.tsx
@@ -8,6 +8,7 @@ interface ResolvedLinksSectionProps {
   groupingMode: GroupingMode;
   selectedIds: string[];
   onSelectIds: (ids: string[]) => void;
+  onMediaClick?: (link: ResolvedLink) => void;
 }
 
 function getGroupKey(link: ResolvedLink, mode: GroupingMode): string {
@@ -67,6 +68,7 @@ export function ResolvedLinksSection({
   groupingMode,
   selectedIds,
   onSelectIds,
+  onMediaClick,
 }: ResolvedLinksSectionProps) {
   const filtered = applyFilter(links, filter);
   const grouped = groupLinks(filtered, groupingMode);
@@ -118,6 +120,7 @@ export function ResolvedLinksSection({
                   link={link}
                   selected={selectedIds.includes(link.id)}
                   onSelect={() => handleLinkToggle(link.id)}
+                  onMediaClick={onMediaClick}
                 />
               ))}
             </div>

--- a/src/views/LinkGrabberView/__tests__/MediaGrabberDialog.test.tsx
+++ b/src/views/LinkGrabberView/__tests__/MediaGrabberDialog.test.tsx
@@ -359,3 +359,95 @@ describe("MediaGrabberDialog - Playlist", () => {
     expect(screen.queryByText(/Playlist/)).not.toBeInTheDocument();
   });
 });
+
+describe("MediaGrabberDialog - State Reset", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  it("should reset selections when dialog reopens with new link", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    const user = userEvent.setup();
+
+    const altLink: ResolvedLink = {
+      ...mockMediaLink,
+      id: "media-2",
+      originalUrl: "https://youtube.com/watch?v=alt456",
+    };
+
+    const altMetadata: MediaMetadata = {
+      ...mockMetadata,
+      title: "Alt Video",
+      availableQualities: [
+        { quality: "720p", height: 720, width: 1280, fps: 60, bitrateKbps: 3000 },
+      ],
+      availableFormats: ["webm"],
+      availableAudioFormats: ["opus"],
+    };
+
+    const { onConfirm, rerender } = (() => {
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: { retry: false },
+          mutations: { retry: false },
+        },
+      });
+      const onConfirmFn = vi.fn();
+      const result = render(
+        <QueryClientProvider client={queryClient}>
+          <MediaGrabberDialog
+            link={mockMediaLink}
+            open={true}
+            onOpenChange={vi.fn()}
+            onConfirm={onConfirmFn}
+          />
+        </QueryClientProvider>,
+      );
+      return { onConfirm: onConfirmFn, ...result };
+    })();
+
+    // Wait for first metadata
+    await screen.findByText("Test Video Title");
+
+    // Toggle audio only
+    await user.click(screen.getByRole("switch"));
+
+    // Now rerender with new link and new metadata
+    mockInvoke.mockResolvedValue(altMetadata);
+
+    rerender(
+      <QueryClientProvider
+        client={
+          new QueryClient({
+            defaultOptions: {
+              queries: { retry: false },
+              mutations: { retry: false },
+            },
+          })
+        }
+      >
+        <MediaGrabberDialog
+          link={altLink}
+          open={true}
+          onOpenChange={vi.fn()}
+          onConfirm={onConfirm}
+        />
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Alt Video");
+
+    // Audio only should be reset
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quality: "720p",
+        format: "webm",
+        audioOnly: false,
+        subtitles: [],
+        playlistItems: [],
+      }),
+    );
+  });
+});

--- a/src/views/LinkGrabberView/__tests__/MediaGrabberDialog.test.tsx
+++ b/src/views/LinkGrabberView/__tests__/MediaGrabberDialog.test.tsx
@@ -1,0 +1,361 @@
+import { beforeAll, beforeEach, describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
+import { MediaGrabberDialog } from "../MediaGrabberDialog";
+import type { ResolvedLink } from "../types";
+import type { MediaMetadata } from "@/types/media";
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+const mockInvoke = vi.mocked(invoke);
+
+const mockMediaLink: ResolvedLink = {
+  id: "media-1",
+  originalUrl: "https://youtube.com/watch?v=test123",
+  resolvedUrl: "https://youtube.com/watch?v=test123",
+  filename: "Test Video.mp4",
+  sizeBytes: null,
+  status: "online",
+  moduleName: "youtube",
+  isMedia: true,
+  mediaType: "video",
+};
+
+const mockMetadata: MediaMetadata = {
+  title: "Test Video Title",
+  thumbnailUrl: "https://img.youtube.com/test.jpg",
+  durationSeconds: 600,
+  isPlaylist: false,
+  availableQualities: [
+    { quality: "1080p", height: 1080, width: 1920, fps: 30, bitrateKbps: 5000 },
+    { quality: "720p", height: 720, width: 1280, fps: 30, bitrateKbps: 2500 },
+    { quality: "480p", height: 480, width: 854, fps: 30, bitrateKbps: 1000 },
+  ],
+  availableFormats: ["mp4", "webm"],
+  availableAudioFormats: ["m4a", "mp3", "opus"],
+  availableSubtitles: [
+    { code: "en", name: "English" },
+    { code: "fr", name: "Français" },
+  ],
+};
+
+const mockPlaylistMetadata: MediaMetadata = {
+  ...mockMetadata,
+  isPlaylist: true,
+  playlistItems: [
+    { id: "v1", title: "Video 1", durationSeconds: 120 },
+    { id: "v2", title: "Video 2", durationSeconds: 240 },
+    { id: "v3", title: "Video 3", durationSeconds: 180 },
+  ],
+};
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+
+  global.ResizeObserver = class {
+    observe = vi.fn();
+    unobserve = vi.fn();
+    disconnect = vi.fn();
+  } as unknown as typeof ResizeObserver;
+});
+
+function renderDialog(
+  props: Partial<React.ComponentProps<typeof MediaGrabberDialog>> = {},
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const defaultProps = {
+    link: mockMediaLink,
+    open: true,
+    onOpenChange: vi.fn(),
+    onConfirm: vi.fn(),
+    ...props,
+  };
+
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <MediaGrabberDialog {...defaultProps} />
+      </QueryClientProvider>,
+    ),
+    onConfirm: defaultProps.onConfirm,
+    onOpenChange: defaultProps.onOpenChange,
+  };
+}
+
+describe("MediaGrabberDialog", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  it("should show loading skeleton while fetching metadata", () => {
+    mockInvoke.mockReturnValue(new Promise(() => {}));
+    renderDialog();
+    expect(screen.getByText("Media Grabber Options")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Download" })).toBeDisabled();
+  });
+
+  it("should display metadata when loaded", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    renderDialog();
+
+    expect(
+      await screen.findByText("Test Video Title"),
+    ).toBeInTheDocument();
+  });
+
+  it("should show no-metadata message when metadata is null", async () => {
+    mockInvoke.mockResolvedValue(null);
+    renderDialog();
+
+    expect(
+      await screen.findByText("No metadata available for this link"),
+    ).toBeInTheDocument();
+  });
+
+  it("should show error message with retry when metadata fetch fails", async () => {
+    mockInvoke.mockRejectedValue(new Error("Network error"));
+    renderDialog();
+
+    expect(
+      await screen.findByText("Failed to load media metadata"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Retry" }),
+    ).toBeInTheDocument();
+  });
+
+  it("should show quality selector with available qualities", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    renderDialog();
+
+    expect(await screen.findByText("1080p")).toBeInTheDocument();
+    expect(screen.getByText("720p")).toBeInTheDocument();
+    expect(screen.getByText("480p")).toBeInTheDocument();
+  });
+
+  it("should show format selector buttons", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+    expect(screen.getByRole("button", { name: /mp4/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /webm/i })).toBeInTheDocument();
+  });
+
+  it("should toggle audio only mode and show audio formats", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+
+    const audioSwitch = screen.getByRole("switch");
+    await user.click(audioSwitch);
+
+    expect(screen.getByRole("button", { name: /m4a/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /mp3/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /opus/i })).toBeInTheDocument();
+  });
+
+  it("should hide video quality when audio only is enabled", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+    expect(screen.getByText("Video Quality")).toBeInTheDocument();
+
+    const audioSwitch = screen.getByRole("switch");
+    await user.click(audioSwitch);
+
+    expect(screen.queryByText("Video Quality")).not.toBeInTheDocument();
+  });
+
+  it("should show subtitle selector with available languages", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+    expect(screen.getByText("Subtitles")).toBeInTheDocument();
+    expect(screen.getByText("English (en)")).toBeInTheDocument();
+    expect(screen.getByText("Français (fr)")).toBeInTheDocument();
+  });
+
+  it("should allow multi-select of subtitles", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+
+    const enCheckbox = screen.getByRole("checkbox", {
+      name: "English (en)",
+    });
+    const frCheckbox = screen.getByRole("checkbox", {
+      name: "Français (fr)",
+    });
+
+    await user.click(enCheckbox);
+    await user.click(frCheckbox);
+
+    expect(enCheckbox).toBeChecked();
+    expect(frCheckbox).toBeChecked();
+  });
+
+  it("should hide subtitle selector when no subtitles available", async () => {
+    mockInvoke.mockResolvedValue({
+      ...mockMetadata,
+      availableSubtitles: [],
+    });
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+    expect(screen.queryByText("Subtitles")).not.toBeInTheDocument();
+  });
+
+  it("should show size estimate", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+    expect(screen.getByText(/Estimated Size:/)).toBeInTheDocument();
+  });
+
+  it("should call onConfirm with correct options on Download click", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    const user = userEvent.setup();
+    const { onConfirm, onOpenChange } = renderDialog();
+
+    await screen.findByText("Test Video Title");
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      quality: "1080p",
+      format: "mp4",
+      subtitles: [],
+      audioOnly: false,
+      playlistItems: [],
+    });
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("should call onConfirm with audio_only quality when audio mode is on", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    const user = userEvent.setup();
+    const { onConfirm } = renderDialog();
+
+    await screen.findByText("Test Video Title");
+
+    await user.click(screen.getByRole("switch"));
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quality: "audio_only",
+        format: "m4a",
+        audioOnly: true,
+      }),
+    );
+  });
+
+  it("should close dialog on Cancel click", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await screen.findByText("Test Video Title");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("MediaGrabberDialog - Playlist", () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+  });
+
+  it("should show playlist section for playlist content", async () => {
+    mockInvoke.mockResolvedValue(mockPlaylistMetadata);
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+    expect(screen.getByText("Playlist (3 items)")).toBeInTheDocument();
+    expect(screen.getByText("Video 1")).toBeInTheDocument();
+    expect(screen.getByText("Video 2")).toBeInTheDocument();
+    expect(screen.getByText("Video 3")).toBeInTheDocument();
+  });
+
+  it("should select all playlist items with Select All button", async () => {
+    mockInvoke.mockResolvedValue(mockPlaylistMetadata);
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+    await user.click(screen.getByRole("button", { name: "Select All" }));
+
+    const playlistSection = screen.getByText("Playlist (3 items)").closest("section");
+    const checkboxes = within(playlistSection!).getAllByRole("checkbox");
+    for (const checkbox of checkboxes) {
+      expect(checkbox).toBeChecked();
+    }
+  });
+
+  it("should toggle individual playlist items", async () => {
+    mockInvoke.mockResolvedValue(mockPlaylistMetadata);
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+
+    const playlistSection = screen.getByText("Playlist (3 items)").closest("section");
+    const checkboxes = within(playlistSection!).getAllByRole("checkbox");
+    await user.click(checkboxes[0]);
+
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
+  it("should deselect all after selecting all", async () => {
+    mockInvoke.mockResolvedValue(mockPlaylistMetadata);
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+
+    await user.click(screen.getByRole("button", { name: "Select All" }));
+    await user.click(screen.getByRole("button", { name: "Deselect All" }));
+
+    const playlistSection = screen.getByText("Playlist (3 items)").closest("section");
+    const checkboxes = within(playlistSection!).getAllByRole("checkbox");
+    for (const checkbox of checkboxes) {
+      expect(checkbox).not.toBeChecked();
+    }
+  });
+
+  it("should not show playlist section for non-playlist content", async () => {
+    mockInvoke.mockResolvedValue(mockMetadata);
+    renderDialog();
+
+    await screen.findByText("Test Video Title");
+    expect(screen.queryByText(/Playlist/)).not.toBeInTheDocument();
+  });
+});

--- a/src/views/LinkGrabberView/__tests__/SizeEstimate.test.tsx
+++ b/src/views/LinkGrabberView/__tests__/SizeEstimate.test.tsx
@@ -13,12 +13,24 @@ describe("SizeEstimate", () => {
     render(<SizeEstimate quality="audio_only" format="m4a" duration={600} />);
     // 192 kbps * 1000 * 600 / 8 = 14_400_000 bytes ≈ 13.73 MB
     expect(screen.getByText(/Estimated Size: 13\.73 MB/)).toBeInTheDocument();
+    expect(screen.getByText(/10m audio/)).toBeInTheDocument();
   });
 
   it("should show quality and format info", () => {
     render(<SizeEstimate quality="720p" format="webm" duration={300} />);
     expect(screen.getByText(/720p WEBM/)).toBeInTheDocument();
     expect(screen.getByText(/5m video/)).toBeInTheDocument();
+  });
+
+  it("should use actual bitrate from qualities when provided", () => {
+    const qualities = [
+      { quality: "720p", height: 720, width: 1280, fps: 30, bitrateKbps: 3000 },
+    ];
+    render(
+      <SizeEstimate quality="720p" format="mp4" duration={60} qualities={qualities} />,
+    );
+    // 3000 kbps * 1000 * 60 / 8 = 22_500_000 bytes ≈ 21.46 MB
+    expect(screen.getByText(/Estimated Size: 21\.46 MB/)).toBeInTheDocument();
   });
 
   it("should use fallback bitrate for unknown quality", () => {

--- a/src/views/LinkGrabberView/__tests__/SizeEstimate.test.tsx
+++ b/src/views/LinkGrabberView/__tests__/SizeEstimate.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SizeEstimate } from "../MediaGrabberDialog/SizeEstimate";
+
+describe("SizeEstimate", () => {
+  it("should calculate correct size for 1080p 10-minute video", () => {
+    render(<SizeEstimate quality="1080p" format="mp4" duration={600} />);
+    // 5000 kbps * 1000 * 600 / 8 = 375_000_000 bytes ≈ 357.63 MB
+    expect(screen.getByText(/Estimated Size: 357\.63 MB/)).toBeInTheDocument();
+  });
+
+  it("should calculate correct size for audio_only", () => {
+    render(<SizeEstimate quality="audio_only" format="m4a" duration={600} />);
+    // 192 kbps * 1000 * 600 / 8 = 14_400_000 bytes ≈ 13.73 MB
+    expect(screen.getByText(/Estimated Size: 13\.73 MB/)).toBeInTheDocument();
+  });
+
+  it("should show quality and format info", () => {
+    render(<SizeEstimate quality="720p" format="webm" duration={300} />);
+    expect(screen.getByText(/720p WEBM/)).toBeInTheDocument();
+    expect(screen.getByText(/5m video/)).toBeInTheDocument();
+  });
+
+  it("should use fallback bitrate for unknown quality", () => {
+    render(<SizeEstimate quality="unknown" format="mp4" duration={60} />);
+    // 2500 kbps fallback * 1000 * 60 / 8 = 18_750_000 bytes ≈ 17.88 MB
+    expect(screen.getByText(/Estimated Size: 17\.88 MB/)).toBeInTheDocument();
+  });
+
+  it("should update when quality changes", () => {
+    const { rerender } = render(
+      <SizeEstimate quality="480p" format="mp4" duration={600} />,
+    );
+    expect(screen.getByText(/480p MP4/)).toBeInTheDocument();
+
+    rerender(<SizeEstimate quality="4k" format="mp4" duration={600} />);
+    expect(screen.getByText(/4k MP4/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- Add `MediaGrabberDialog` modal that opens when clicking a media link badge in Link Grabber
- Quality selector grid (360p-4K) with resolution, fps, and bitrate display
- Audio-only toggle with format selection (M4A, MP3, OGG, WAV, OPUS)
- Subtitle selector with multi-select language checkboxes
- Playlist section with individual/bulk selection and scroll area
- Real-time size estimation based on quality and duration
- Media preview with thumbnail + broken image fallback
- `useMediaMetadata` hook fetching metadata via Tauri IPC
- Install shadcn/ui components: Dialog, Card, Skeleton
- Integration in LinkGrabberView via `onMediaClick` prop chain

## Adversarial review fixes

- Type-safe `startMediaDownload` mutation (no `as` cast)
- Centralized `formatBytes` import (removed duplicate from LinkRow)
- Keyboard-accessible quality cards (`role="radio"`, `tabIndex`, `onKeyDown`)
- Accessible media button (Button instead of Badge div)
- Empty playlist guard (`allSelected` when `items.length === 0`)
- Error state with retry button on metadata fetch failure
- Redundant `queryKey` kept (required by `useTauriQuery` type signature)

## Test plan

- [x] 27 new tests covering all components and edge cases
- [x] 242 total tests passing, 0 failures
- [x] TypeScript strict mode clean (`tsc --noEmit`)
- [x] oxlint: 0 warnings, 0 errors
- [x] Pre-commit hooks pass (no-secrets, ts-lint)
- [ ] Manual: paste YouTube URL, verify dialog opens on media badge click
- [ ] Manual: verify quality/format/audio/subtitle/playlist selection
- [ ] Manual: verify Download button sends correct options to backend

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Media Grabber dialog to configure media downloads (quality, format, audio-only, subtitles, playlist items) with preview and more accurate size estimates. Opens from the media button in Link Grabber and starts downloads with the chosen options. Implements Linear Task 21.

- **New Features**
  - Quality grid + container format; audio-only with M4A/MP3/OGG/WAV/OPUS; subtitle multi-select; playlist item selection.
  - Media preview with thumbnail fallback; size estimate uses actual bitrates when available.
  - Metadata via Tauri IPC with `useMediaMetadata`; adds `Dialog`, `Card`, `Skeleton` from `shadcn/ui`.

- **Bug Fixes**
  - Reset selections on reopen/link change; defaults derived from metadata; clear selected link on close; preview error resets on thumbnail change.
  - Accessibility: keyboard radio cards with correct tab order; `role="group"` + `aria-pressed` on format buttons; labeled playlist checkboxes; media button replaces badge.
  - Guard playlist section when no items; error state with Retry; centralized `formatBytes`; type-safe download mutation.

<sup>Written for commit 51c6ce99d5bee939c91149f52d9b198c38d0f541. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Link Grabber View: paste/drag-and-drop input, multi-protocol validation, grouped resolved-links with multi-select and per-row media badge.
  * Media Grabber dialog: quality/format/audio-only/subtitle/playlist controls, media preview, playlist bulk/individual selection, and real-time size estimation.
  * UI primitives: dialog, card, and skeleton components added.

* **Tests**
  * Added comprehensive tests for media preview, size estimation, and the media grabber dialog behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->