### PR TITLE
fix(core): wire AppState via .manage() — all 22 IPC commands now work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,3 +216,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `contrib/icons/README.md` — icon generation instructions via `npx tauri icon`
   - `contrib/winget/Vortex.yaml` — Winget manifest template (TODO placeholders for future submission)
   - `contrib/homebrew/vortex.rb` — Homebrew cask template (TODO placeholders for future submission)
+
+### Fixed
+- **CRITICAL**: All 22 IPC commands now work — `AppState` is constructed and registered via `.manage()` in the Tauri setup closure (#27)
+  - Database connection (SQLite WAL mode) with migrations run at startup
+  - All driven adapters wired: event bus, file storage, HTTP client, config store, clipboard observer, plugin loader, download engine, archive extractor
+  - CQRS buses (CommandBus + QueryBus) assembled from 15 driven ports
+  - Event bridges (Tauri webview + desktop notifications) connected to domain event bus
+  - Plugin hot-reload watcher started with tracing on failure
+  - Shared `reqwest::Client` between HTTP metadata port and download engine
+  - `NoopCredentialStore` stub until keyring-rs integration
+  - `InMemoryStatsRepository` stub until SQLite implementation (with `saturating_add` for overflow safety)

--- a/src-tauri/src/adapters/driven/credential/mod.rs
+++ b/src-tauri/src/adapters/driven/credential/mod.rs
@@ -1,0 +1,3 @@
+mod noop_credential_store;
+
+pub use noop_credential_store::NoopCredentialStore;

--- a/src-tauri/src/adapters/driven/credential/noop_credential_store.rs
+++ b/src-tauri/src/adapters/driven/credential/noop_credential_store.rs
@@ -1,0 +1,34 @@
+//! No-op credential store stub.
+//!
+//! A placeholder implementation that returns `Ok(None)` for reads
+//! and no-ops for writes/deletes. Used during development until
+//! the keyring-rs integration is fully implemented.
+
+use crate::domain::error::DomainError;
+use crate::domain::model::credential::Credential;
+use crate::domain::ports::driven::credential_store::CredentialStore;
+
+/// Stub credential store that performs no operations.
+///
+/// Credentials are not persisted. This adapter is intended as a temporary
+/// placeholder until the full keyring-rs backend is integrated.
+#[derive(Debug, Clone)]
+pub struct NoopCredentialStore;
+
+impl CredentialStore for NoopCredentialStore {
+    fn get(&self, service: &str) -> Result<Option<Credential>, DomainError> {
+        tracing::warn!(
+            service,
+            "credential requested but keyring store is not yet implemented"
+        );
+        Ok(None)
+    }
+
+    fn store(&self, _service: &str, _credential: &Credential) -> Result<(), DomainError> {
+        Ok(())
+    }
+
+    fn delete(&self, _service: &str) -> Result<(), DomainError> {
+        Ok(())
+    }
+}

--- a/src-tauri/src/adapters/driven/credential/noop_credential_store.rs
+++ b/src-tauri/src/adapters/driven/credential/noop_credential_store.rs
@@ -24,11 +24,19 @@ impl CredentialStore for NoopCredentialStore {
         Ok(None)
     }
 
-    fn store(&self, _service: &str, _credential: &Credential) -> Result<(), DomainError> {
+    fn store(&self, service: &str, _credential: &Credential) -> Result<(), DomainError> {
+        tracing::warn!(
+            service,
+            "credential write ignored: keyring store is not yet implemented"
+        );
         Ok(())
     }
 
-    fn delete(&self, _service: &str) -> Result<(), DomainError> {
+    fn delete(&self, service: &str) -> Result<(), DomainError> {
+        tracing::warn!(
+            service,
+            "credential delete ignored: keyring store is not yet implemented"
+        );
         Ok(())
     }
 }

--- a/src-tauri/src/adapters/driven/mod.rs
+++ b/src-tauri/src/adapters/driven/mod.rs
@@ -2,6 +2,7 @@
 
 pub mod clipboard;
 pub mod config;
+pub mod credential;
 pub mod event;
 pub mod extractor;
 pub mod filesystem;
@@ -9,4 +10,5 @@ pub mod network;
 pub mod notification;
 pub mod plugin;
 pub mod sqlite;
+pub mod stats;
 pub mod tray;

--- a/src-tauri/src/adapters/driven/sqlite/connection.rs
+++ b/src-tauri/src/adapters/driven/sqlite/connection.rs
@@ -10,13 +10,11 @@ use sea_orm_migration::MigratorTrait;
 use super::migrations::Migrator;
 
 pub async fn establish_connection(db_path: &Path) -> Result<DatabaseConnection, sea_orm::DbErr> {
-    let db_str = db_path
-        .to_str()
-        .ok_or_else(|| sea_orm::DbErr::Custom("database path is not valid UTF-8".to_string()))?;
-    // Per-connection PRAGMA via SqliteConnectOptions ensures every pool
-    // connection enforces FK constraints, not just the first one.
-    let sqlite_opts = SqliteConnectOptions::from_str(&format!("sqlite://{}?mode=rwc", db_str))
-        .map_err(|e| sea_orm::DbErr::Conn(sea_orm::RuntimeErr::Internal(e.to_string())))?
+    // Use filename() instead of URL interpolation — handles Windows paths,
+    // non-UTF-8 paths, and URI-reserved characters safely.
+    let sqlite_opts = SqliteConnectOptions::new()
+        .filename(db_path)
+        .create_if_missing(true)
         .pragma("foreign_keys", "ON");
 
     let pool = SqlitePoolOptions::new()

--- a/src-tauri/src/adapters/driven/sqlite/connection.rs
+++ b/src-tauri/src/adapters/driven/sqlite/connection.rs
@@ -1,16 +1,21 @@
+use std::path::Path;
+use std::str::FromStr;
+use std::time::Duration;
+
 use sea_orm::SqlxSqliteConnector;
 use sea_orm::sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sea_orm::{ConnectionTrait, DatabaseConnection, Statement};
 use sea_orm_migration::MigratorTrait;
-use std::str::FromStr;
-use std::time::Duration;
 
 use super::migrations::Migrator;
 
-pub async fn establish_connection(db_path: &str) -> Result<DatabaseConnection, sea_orm::DbErr> {
+pub async fn establish_connection(db_path: &Path) -> Result<DatabaseConnection, sea_orm::DbErr> {
+    let db_str = db_path
+        .to_str()
+        .ok_or_else(|| sea_orm::DbErr::Custom("database path is not valid UTF-8".to_string()))?;
     // Per-connection PRAGMA via SqliteConnectOptions ensures every pool
     // connection enforces FK constraints, not just the first one.
-    let sqlite_opts = SqliteConnectOptions::from_str(&format!("sqlite://{}?mode=rwc", db_path))
+    let sqlite_opts = SqliteConnectOptions::from_str(&format!("sqlite://{}?mode=rwc", db_str))
         .map_err(|e| sea_orm::DbErr::Conn(sea_orm::RuntimeErr::Internal(e.to_string())))?
         .pragma("foreign_keys", "ON");
 
@@ -93,9 +98,7 @@ mod tests {
         let db_path = dir.join("test.db");
         let _ = std::fs::remove_file(&db_path);
 
-        let db = establish_connection(db_path.to_str().unwrap())
-            .await
-            .unwrap();
+        let db = establish_connection(&db_path).await.unwrap();
 
         let result = db
             .query_one(Statement::from_string(

--- a/src-tauri/src/adapters/driven/stats/in_memory_stats_repo.rs
+++ b/src-tauri/src/adapters/driven/stats/in_memory_stats_repo.rs
@@ -1,0 +1,84 @@
+//! In-memory statistics repository stub.
+//!
+//! This is a simple accumulator-based implementation for testing and early development.
+//! In production, statistics are typically computed from history data via SQLite aggregations.
+
+use std::sync::Mutex;
+
+use crate::domain::error::DomainError;
+use crate::domain::model::views::StatsView;
+use crate::domain::ports::driven::stats_repository::StatsRepository;
+
+struct StatsAccumulator {
+    total_bytes: u64,
+    total_files: u64,
+    total_speed_sum: u64,
+    peak_speed: u64,
+}
+
+/// In-memory repository for aggregated download statistics.
+///
+/// Accumulates total bytes, file count, and speed metrics without persistence.
+/// Useful for testing command handlers and services without SQLite.
+pub struct InMemoryStatsRepository {
+    accumulator: Mutex<StatsAccumulator>,
+}
+
+impl InMemoryStatsRepository {
+    /// Create a new empty in-memory statistics repository.
+    pub fn new() -> Self {
+        Self {
+            accumulator: Mutex::new(StatsAccumulator {
+                total_bytes: 0,
+                total_files: 0,
+                total_speed_sum: 0,
+                peak_speed: 0,
+            }),
+        }
+    }
+}
+
+impl Default for InMemoryStatsRepository {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StatsRepository for InMemoryStatsRepository {
+    fn record_completed(&self, bytes: u64, avg_speed: u64) -> Result<(), DomainError> {
+        let mut accumulator = match self.accumulator.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        accumulator.total_bytes = accumulator.total_bytes.saturating_add(bytes);
+        accumulator.total_files = accumulator.total_files.saturating_add(1);
+        accumulator.total_speed_sum = accumulator.total_speed_sum.saturating_add(avg_speed);
+        accumulator.peak_speed = accumulator.peak_speed.max(avg_speed);
+
+        Ok(())
+    }
+
+    fn get_stats(&self) -> Result<StatsView, DomainError> {
+        let accumulator = match self.accumulator.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        let avg_speed = if accumulator.total_files > 0 {
+            accumulator.total_speed_sum / accumulator.total_files
+        } else {
+            0
+        };
+
+        Ok(StatsView {
+            total_downloaded_bytes: accumulator.total_bytes,
+            total_files: accumulator.total_files,
+            avg_speed,
+            peak_speed: accumulator.peak_speed,
+            success_rate: 100.0,
+            daily_volumes: vec![],
+            top_hosts: vec![],
+        })
+    }
+}

--- a/src-tauri/src/adapters/driven/stats/in_memory_stats_repo.rs
+++ b/src-tauri/src/adapters/driven/stats/in_memory_stats_repo.rs
@@ -76,8 +76,13 @@ impl StatsRepository for InMemoryStatsRepository {
             total_files: accumulator.total_files,
             avg_speed,
             peak_speed: accumulator.peak_speed,
-            // TODO: track failures to compute a real 0.0–1.0 fraction
-            success_rate: 0.0,
+            // Only completed downloads are recorded, so success_rate is 1.0
+            // when any exist. TODO: track failures to compute a real fraction.
+            success_rate: if accumulator.total_files > 0 {
+                1.0
+            } else {
+                0.0
+            },
             daily_volumes: vec![],
             top_hosts: vec![],
         })

--- a/src-tauri/src/adapters/driven/stats/in_memory_stats_repo.rs
+++ b/src-tauri/src/adapters/driven/stats/in_memory_stats_repo.rs
@@ -76,7 +76,8 @@ impl StatsRepository for InMemoryStatsRepository {
             total_files: accumulator.total_files,
             avg_speed,
             peak_speed: accumulator.peak_speed,
-            success_rate: 100.0,
+            // TODO: track failures to compute a real 0.0–1.0 fraction
+            success_rate: 0.0,
             daily_volumes: vec![],
             top_hosts: vec![],
         })

--- a/src-tauri/src/adapters/driven/stats/mod.rs
+++ b/src-tauri/src/adapters/driven/stats/mod.rs
@@ -1,0 +1,3 @@
+mod in_memory_stats_repo;
+
+pub use in_memory_stats_repo::InMemoryStatsRepository;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,13 +82,9 @@ pub fn run() {
             // event bus subscribers).
             let (db, rt_handle) = tauri::async_runtime::block_on(async {
                 let handle = tokio::runtime::Handle::current();
-                let db = connection::establish_connection(
-                    db_path
-                        .to_str()
-                        .ok_or_else(|| "non-UTF-8 database path".to_string())?,
-                )
-                .await
-                .map_err(|e| e.to_string())?;
+                let db = connection::establish_connection(&db_path)
+                    .await
+                    .map_err(|e| e.to_string())?;
                 connection::run_migrations(&db)
                     .await
                     .map_err(|e| e.to_string())?;
@@ -107,6 +103,7 @@ pub fn run() {
             let http_client: Arc<dyn HttpClient> =
                 Arc::new(ReqwestHttpClient::with_client(reqwest_client.clone()));
             let config_store: Arc<dyn ConfigStore> = Arc::new(TomlConfigStore::new(config_path));
+            // TODO: replace with keyring-rs CredentialStore once implemented
             let credential_store: Arc<dyn CredentialStore> = Arc::new(NoopCredentialStore);
             let clipboard_observer: Arc<dyn ClipboardObserver> =
                 Arc::new(TauriClipboardObserver::new(app_handle.clone()));
@@ -138,6 +135,15 @@ pub fn run() {
                 file_storage.clone(),
                 event_bus.clone(),
                 4,
+            ));
+
+            // ── Queue manager ──────────────────────────────────────
+            // Listens to domain events and auto-schedules queued downloads.
+            let queue_manager = Arc::new(QueueManager::new(
+                download_repo.clone(),
+                download_engine.clone(),
+                event_bus.clone(),
+                4, // TODO: read max_concurrent from config
             ));
 
             // ── CQRS buses ──────────────────────────────────────────
@@ -176,6 +182,10 @@ pub fn run() {
             // ── Event bridges (domain events → frontend + desktop) ──
             spawn_tauri_event_bridge(app_handle.clone(), event_bus.as_ref());
             spawn_notification_bridge(app_handle, event_bus.as_ref());
+
+            // ── Queue manager event listener ────────────────────────
+            queue_manager.clone().start_listening();
+            app.manage(queue_manager);
 
             // ── Plugin hot-reload watcher ────────────────────────────
             // Kept alive by moving into a managed resource; dropped on app exit.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,17 +2,35 @@ mod adapters;
 mod application;
 pub mod domain;
 
+use std::sync::Arc;
+
+use tauri::Manager;
+
+use domain::ports::driven::{
+    ArchiveExtractor, ClipboardObserver, ConfigStore, CredentialStore, DownloadEngine,
+    DownloadReadRepository, DownloadRepository, EventBus, FileStorage, HistoryRepository,
+    HttpClient, PluginLoader, PluginReadRepository, StatsRepository,
+};
+
 // Public API — concrete types for app wiring (main.rs, Tauri setup, integration tests)
+pub use adapters::driven::clipboard::TauriClipboardObserver;
+pub use adapters::driven::config::TomlConfigStore;
+pub use adapters::driven::credential::NoopCredentialStore;
 pub use adapters::driven::event::TokioEventBus;
 pub use adapters::driven::event::spawn_tauri_event_bridge;
+pub use adapters::driven::extractor::VortexArchiveExtractor;
 pub use adapters::driven::filesystem::FsFileStorage;
 pub use adapters::driven::network::ReqwestHttpClient;
 pub use adapters::driven::network::SegmentedDownloadEngine;
 pub use adapters::driven::notification::spawn_notification_bridge;
+pub use adapters::driven::plugin::builtin::HttpModule;
+pub use adapters::driven::plugin::capabilities::SharedHostResources;
+pub use adapters::driven::plugin::{ExtismPluginLoader, PluginRegistry, PluginWatcher};
 pub use adapters::driven::sqlite::connection;
 pub use adapters::driven::sqlite::download_read_repo::SqliteDownloadReadRepo;
 pub use adapters::driven::sqlite::download_repo::SqliteDownloadRepo;
 pub use adapters::driven::sqlite::history_repo::SqliteHistoryRepo;
+pub use adapters::driven::stats::InMemoryStatsRepository;
 pub use adapters::driven::tray::setup_system_tray;
 pub use application::command_bus::CommandBus;
 pub use application::error::AppError;
@@ -25,12 +43,8 @@ pub use application::read_models::{
     stats_view::{DailyVolumeDto, HostStatsDto, StatsViewDto},
 };
 pub use application::services::QueueManager;
+pub use domain::model::ExtractionConfig;
 
-pub use adapters::driven::clipboard::TauriClipboardObserver;
-pub use adapters::driven::config::TomlConfigStore;
-pub use adapters::driven::plugin::builtin::HttpModule;
-pub use adapters::driven::plugin::capabilities::SharedHostResources;
-pub use adapters::driven::plugin::{ExtismPluginLoader, PluginRegistry, PluginWatcher};
 pub use adapters::driving::tauri_ipc::{
     self, AppState, clipboard_state, clipboard_toggle, download_cancel, download_count_by_state,
     download_detail, download_list, download_pause, download_pause_all, download_remove,
@@ -51,17 +65,126 @@ pub fn run() {
     }
     builder
         .setup(|app| {
-            // System tray — default to clipboard_enabled=false since the
-            // observer starts disabled and AppState isn't wired yet.
-            // TODO(task-16): read clipboard_monitoring from persisted config.
+            let app_handle = app.handle().clone();
+
+            // ── Paths ───────────────────────────────────────────────
+            let app_data_dir = app.path().app_data_dir()?;
+            std::fs::create_dir_all(&app_data_dir)?;
+            let db_path = app_data_dir.join("vortex.db");
+            let config_path = app_data_dir.join("config.toml");
+            let plugins_dir = app_data_dir.join("plugins");
+            std::fs::create_dir_all(&plugins_dir)?;
+
+            // ── Database ────────────────────────────────────────────
+            // SAFETY: block_on is safe here because Tauri's tokio runtime is
+            // already running when setup() executes, and the inner future does
+            // not block back on this thread.
+            let db = tauri::async_runtime::block_on(async {
+                let db = connection::establish_connection(
+                    db_path
+                        .to_str()
+                        .ok_or_else(|| "non-UTF-8 database path".to_string())?,
+                )
+                .await
+                .map_err(|e| e.to_string())?;
+                connection::run_migrations(&db)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                Ok::<_, String>(db)
+            })?;
+
+            // ── Driven adapters ─────────────────────────────────────
+            let event_bus: Arc<dyn EventBus> = Arc::new(TokioEventBus::new(256));
+            let file_storage: Arc<dyn FileStorage> = Arc::new(FsFileStorage::new());
+            let reqwest_client = reqwest::Client::builder()
+                .user_agent("Vortex/0.1")
+                .connect_timeout(std::time::Duration::from_secs(30))
+                .build()
+                .map_err(|e| e.to_string())?;
+            let http_client: Arc<dyn HttpClient> =
+                Arc::new(ReqwestHttpClient::with_client(reqwest_client.clone()));
+            let config_store: Arc<dyn ConfigStore> = Arc::new(TomlConfigStore::new(config_path));
+            let credential_store: Arc<dyn CredentialStore> = Arc::new(NoopCredentialStore);
+            let clipboard_observer: Arc<dyn ClipboardObserver> =
+                Arc::new(TauriClipboardObserver::new(app_handle.clone()));
+            let archive_extractor: Arc<dyn ArchiveExtractor> =
+                Arc::new(VortexArchiveExtractor::new(ExtractionConfig::default()));
+
+            // ── SQLite repositories ─────────────────────────────────
+            let download_repo: Arc<dyn DownloadRepository> =
+                Arc::new(SqliteDownloadRepo::new(db.clone()));
+            let download_read_repo: Arc<dyn DownloadReadRepository> =
+                Arc::new(SqliteDownloadReadRepo::new(db.clone()));
+            let history_repo: Arc<dyn HistoryRepository> = Arc::new(SqliteHistoryRepo::new(db));
+            // TODO: replace with SqliteStatsRepo once implemented
+            let stats_repo: Arc<dyn StatsRepository> = Arc::new(InMemoryStatsRepository::new());
+
+            // ── Plugin system ───────────────────────────────────────
+            let shared_resources = Arc::new(SharedHostResources::new());
+            let plugin_loader_impl = Arc::new(
+                ExtismPluginLoader::new(plugins_dir.clone(), shared_resources)
+                    .map_err(|e| e.to_string())?,
+            );
+            let plugin_read_repo: Arc<dyn PluginReadRepository> =
+                plugin_loader_impl.registry().clone();
+            let plugin_loader: Arc<dyn PluginLoader> = plugin_loader_impl.clone();
+
+            // ── Download engine ─────────────────────────────────────
+            let download_engine: Arc<dyn DownloadEngine> = Arc::new(SegmentedDownloadEngine::new(
+                reqwest_client,
+                file_storage.clone(),
+                event_bus.clone(),
+                4,
+            ));
+
+            // ── CQRS buses ──────────────────────────────────────────
+            let command_bus = Arc::new(CommandBus::new(
+                download_repo,
+                download_engine,
+                event_bus.clone(),
+                file_storage,
+                http_client,
+                plugin_loader,
+                config_store,
+                credential_store,
+                clipboard_observer,
+                archive_extractor.clone(),
+            ));
+
+            let query_bus = Arc::new(QueryBus::new(
+                download_read_repo,
+                history_repo,
+                stats_repo,
+                plugin_read_repo,
+                archive_extractor,
+            ));
+
+            // ── Register AppState ───────────────────────────────────
+            app.manage(AppState {
+                command_bus,
+                query_bus,
+            });
+
+            // ── System tray ─────────────────────────────────────────
             if let Err(e) = setup_system_tray(app, false) {
                 tracing::error!("Failed to setup system tray: {e}");
             }
 
-            // TODO(task-16): construct AppState from real adapters and call
-            // app.manage(state). IPC handlers (including clipboard_toggle,
-            // clipboard_state) require State<'_, AppState>; until wired,
-            // the app starts but IPC calls will fail.
+            // ── Event bridges (domain events → frontend + desktop) ──
+            spawn_tauri_event_bridge(app_handle.clone(), event_bus.as_ref());
+            spawn_notification_bridge(app_handle, event_bus.as_ref());
+
+            // ── Plugin hot-reload watcher ────────────────────────────
+            // Kept alive by moving into a managed resource; dropped on app exit.
+            match PluginWatcher::start(plugins_dir, plugin_loader_impl) {
+                Ok(watcher) => {
+                    app.manage(watcher);
+                }
+                Err(e) => {
+                    tracing::warn!("Plugin watcher failed to start: {e}");
+                }
+            }
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -76,10 +76,12 @@ pub fn run() {
             std::fs::create_dir_all(&plugins_dir)?;
 
             // ── Database ────────────────────────────────────────────
-            // SAFETY: block_on is safe here because Tauri's tokio runtime is
-            // already running when setup() executes, and the inner future does
-            // not block back on this thread.
-            let db = tauri::async_runtime::block_on(async {
+            // block_on enters the Tauri tokio runtime for async DB setup.
+            // We also capture the Handle so we can keep the runtime context
+            // active for the rest of setup (needed by tokio::spawn in
+            // event bus subscribers).
+            let (db, rt_handle) = tauri::async_runtime::block_on(async {
+                let handle = tokio::runtime::Handle::current();
                 let db = connection::establish_connection(
                     db_path
                         .to_str()
@@ -90,8 +92,9 @@ pub fn run() {
                 connection::run_migrations(&db)
                     .await
                     .map_err(|e| e.to_string())?;
-                Ok::<_, String>(db)
+                Ok::<_, String>((db, handle))
             })?;
+            let _rt_guard = rt_handle.enter();
 
             // ── Driven adapters ─────────────────────────────────────
             let event_bus: Arc<dyn EventBus> = Arc::new(TokioEventBus::new(256));

--- a/src-tauri/tests/app_state_wiring.rs
+++ b/src-tauri/tests/app_state_wiring.rs
@@ -1,0 +1,132 @@
+//! Integration test verifying that all adapters can be constructed and wired
+//! into CommandBus + QueryBus without a running Tauri app.
+
+use std::sync::Arc;
+
+use vortex_lib::domain::ports::driven::{
+    ArchiveExtractor, ClipboardObserver, ConfigStore, CredentialStore, DownloadEngine,
+    DownloadReadRepository, DownloadRepository, EventBus, FileStorage, HistoryRepository,
+    HttpClient, PluginLoader, PluginReadRepository, StatsRepository,
+};
+use vortex_lib::{
+    CommandBus, ExtismPluginLoader, ExtractionConfig, FsFileStorage, InMemoryStatsRepository,
+    NoopCredentialStore, QueryBus, ReqwestHttpClient, SegmentedDownloadEngine, SharedHostResources,
+    SqliteDownloadReadRepo, SqliteDownloadRepo, SqliteHistoryRepo, TokioEventBus, TomlConfigStore,
+    VortexArchiveExtractor, connection,
+};
+
+/// Verifies that all driven adapters satisfy their port traits and that
+/// CommandBus + QueryBus can be constructed end-to-end.
+///
+/// Uses a sync test with an explicit runtime to avoid "Cannot drop a runtime
+/// in a context where blocking is not allowed" panics from adapters that
+/// internally use `block_on`.
+#[test]
+fn test_appstate_wiring_with_in_memory_db() {
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let _guard = rt.enter();
+
+    // Database (only async step)
+    let db = rt
+        .block_on(connection::setup_test_db())
+        .expect("in-memory DB setup");
+
+    // Driven adapters
+    let event_bus: Arc<dyn EventBus> = Arc::new(TokioEventBus::new(64));
+    let file_storage: Arc<dyn FileStorage> = Arc::new(FsFileStorage::new());
+    let reqwest_client = reqwest::Client::builder()
+        .user_agent("Vortex-Test/0.1")
+        .build()
+        .expect("reqwest client");
+    let http_client: Arc<dyn HttpClient> =
+        Arc::new(ReqwestHttpClient::with_client(reqwest_client.clone()));
+    let config_dir = tempfile::tempdir().expect("temp dir");
+    let config_store: Arc<dyn ConfigStore> =
+        Arc::new(TomlConfigStore::new(config_dir.path().join("config.toml")));
+    let credential_store: Arc<dyn CredentialStore> = Arc::new(NoopCredentialStore);
+    let archive_extractor: Arc<dyn ArchiveExtractor> =
+        Arc::new(VortexArchiveExtractor::new(ExtractionConfig::default()));
+
+    // SQLite repos
+    let download_repo: Arc<dyn DownloadRepository> = Arc::new(SqliteDownloadRepo::new(db.clone()));
+    let download_read_repo: Arc<dyn DownloadReadRepository> =
+        Arc::new(SqliteDownloadReadRepo::new(db.clone()));
+    let history_repo: Arc<dyn HistoryRepository> = Arc::new(SqliteHistoryRepo::new(db));
+    let stats_repo: Arc<dyn StatsRepository> = Arc::new(InMemoryStatsRepository::new());
+
+    // Plugin system
+    let plugins_dir = tempfile::tempdir().expect("plugins dir");
+    let shared_resources = Arc::new(SharedHostResources::new());
+    let plugin_loader_impl = Arc::new(
+        ExtismPluginLoader::new(plugins_dir.path().to_path_buf(), shared_resources)
+            .expect("plugin loader"),
+    );
+    let plugin_read_repo: Arc<dyn PluginReadRepository> = plugin_loader_impl.registry().clone();
+    let plugin_loader: Arc<dyn PluginLoader> = plugin_loader_impl;
+
+    // Download engine
+    let download_engine: Arc<dyn DownloadEngine> = Arc::new(SegmentedDownloadEngine::new(
+        reqwest_client,
+        file_storage.clone(),
+        event_bus.clone(),
+        4,
+    ));
+
+    // Clipboard stub (no Tauri AppHandle in tests)
+    let clipboard_observer: Arc<dyn ClipboardObserver> = Arc::new(StubClipboardObserver);
+
+    // CQRS buses
+    let command_bus = Arc::new(CommandBus::new(
+        download_repo,
+        download_engine,
+        event_bus,
+        file_storage,
+        http_client,
+        plugin_loader,
+        config_store,
+        credential_store,
+        clipboard_observer,
+        archive_extractor.clone(),
+    ));
+
+    let query_bus = Arc::new(QueryBus::new(
+        download_read_repo,
+        history_repo,
+        stats_repo,
+        plugin_read_repo,
+        archive_extractor,
+    ));
+
+    // Verify buses are accessible
+    assert!(Arc::strong_count(&command_bus) >= 1);
+    assert!(Arc::strong_count(&query_bus) >= 1);
+
+    // Verify query bus can execute a read query (empty DB → empty results)
+    let downloads = query_bus
+        .download_read_repo()
+        .find_downloads(None, None, Some(10), None)
+        .expect("download list query");
+    assert!(downloads.is_empty());
+
+    // Verify stats repo returns zero-state
+    let stats = query_bus.stats_repo().get_stats().expect("stats query");
+    assert_eq!(stats.total_files, 0);
+    assert_eq!(stats.total_downloaded_bytes, 0);
+}
+
+/// Minimal clipboard observer stub for tests without a Tauri runtime.
+struct StubClipboardObserver;
+
+impl ClipboardObserver for StubClipboardObserver {
+    fn start(&self) -> Result<(), vortex_lib::domain::error::DomainError> {
+        Ok(())
+    }
+
+    fn stop(&self) -> Result<(), vortex_lib::domain::error::DomainError> {
+        Ok(())
+    }
+
+    fn get_urls(&self) -> Result<Vec<String>, vortex_lib::domain::error::DomainError> {
+        Ok(vec![])
+    }
+}

--- a/src-tauri/tests/app_state_wiring.rs
+++ b/src-tauri/tests/app_state_wiring.rs
@@ -97,9 +97,11 @@ fn test_appstate_wiring_with_in_memory_db() {
         archive_extractor,
     ));
 
-    // Verify buses are accessible
-    assert!(Arc::strong_count(&command_bus) >= 1);
-    assert!(Arc::strong_count(&query_bus) >= 1);
+    // Verify command bus is wired (exercise a read through it)
+    let _config = command_bus
+        .config_store()
+        .get_config()
+        .expect("config load");
 
     // Verify query bus can execute a read query (empty DB → empty results)
     let downloads = query_bus


### PR DESCRIPTION
## Summary

- **Fixes #27** — All 22 Tauri IPC commands were failing with "state not managed" because `AppState` was never constructed or registered via `.manage()` in the setup closure
- Constructs all 12 driven adapters, assembles CommandBus + QueryBus, and registers `AppState` in the Tauri setup closure
- Adds `NoopCredentialStore` and `InMemoryStatsRepository` stub adapters for the two ports without production implementations yet
- Adds integration test validating end-to-end wiring with in-memory SQLite

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/lib.rs` | Main fix: complete setup closure with DB init, adapter construction, bus assembly, `.manage()`, event bridges, plugin watcher |
| `src-tauri/src/adapters/driven/credential/` | New `NoopCredentialStore` stub (returns `Ok(None)`, logs warning on access) |
| `src-tauri/src/adapters/driven/stats/` | New `InMemoryStatsRepository` stub (accumulates in-memory with `saturating_add`) |
| `src-tauri/src/adapters/driven/mod.rs` | Register new `credential` and `stats` modules |
| `src-tauri/tests/app_state_wiring.rs` | Integration test: full adapter wiring + query execution on in-memory DB |
| `CHANGELOG.md` | Document fix in Unreleased section |

## Test plan

- [x] `cargo build` passes (0 errors, 0 warnings)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — 433 passed, 0 failed (includes new integration test)
- [x] `npx vitest run` — 297 passed, 0 failed (frontend unaffected)
- [x] Adversarial code review: 3 HIGH findings fixed (silent watcher failure, duplicate reqwest client, integer overflow)
- [ ] Manual: launch app in dev mode, verify IPC commands respond (settings_get, download_list)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores all 22 IPC commands by constructing and registering `AppState` during Tauri setup and entering the `tokio` runtime; queued downloads now auto-start via the wired `QueueManager`. Also initializes the DB, wires adapters with a shared `reqwest::Client`, and adds credential and stats stubs.

- **Bug Fixes**
  - Initialize SQLite (WAL) and run migrations at startup
  - Wire driven adapters and assemble `CommandBus`/`QueryBus`; share a single `reqwest::Client`
  - Register `AppState` with `.manage()` and enter the runtime so subscribers can `tokio::spawn` (Fixes #27)
  - Start `QueueManager.start_listening()` to execute queued downloads
  - Bridge domain events to the webview and desktop notifications; start plugin hot-reload watcher with failure logging
  - Add stubs: `NoopCredentialStore` (warns on get/store/delete) and `InMemoryStatsRepository` (overflow-safe; `success_rate` is 1.0 when any completed downloads exist, else 0.0)

- **Refactors**
  - `sqlite::connection::establish_connection` now accepts `&Path` and uses `SqliteConnectOptions::filename()` for cross-platform, non-UTF-8-safe paths

<sup>Written for commit aff77120be3c3933c40ca41b473f4f02bcbadd78. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * All Tauri IPC commands are now operational; startup runs DB migrations, initializes adapters, and wires event bridges for reliable behavior.

* **New Features**
  * Plugin hot-reload starts at launch and logs failures instead of failing silently.
  * In-memory stats provide consistent metrics with overflow-safe aggregation.
  * A no-op credential store is available as a development stub (no persistent credential writes).
  * Shared HTTP client used for metadata and downloads to reduce duplication.

* **Tests**
  * Added an integration test validating full app wiring with in-memory storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->