### PR TITLE
feat(credential): implement KeyringCredentialStore (OS keychain)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,5 +230,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Event bridges (Tauri webview + desktop notifications) connected to domain event bus
   - Plugin hot-reload watcher started with tracing on failure
   - Shared `reqwest::Client` between HTTP metadata port and download engine
-  - `NoopCredentialStore` stub until keyring-rs integration
+  - `NoopCredentialStore` stub for tests (replaced by `KeyringCredentialStore` as default in #35)
   - `InMemoryStatsRepository` stub until SQLite implementation (with `saturating_add` for overflow safety)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `contrib/winget/Vortex.yaml` — Winget manifest template (TODO placeholders for future submission)
   - `contrib/homebrew/vortex.rb` — Homebrew cask template (TODO placeholders for future submission)
 
+### Changed
+- `KeyringCredentialStore` replaces `NoopCredentialStore` as the default credential adapter (#35)
+  - Credentials now persist in the OS keychain (macOS Keychain, Linux Secret Service/keyutils, Windows Credential Manager)
+  - `NoopCredentialStore` remains available for tests
+
 ### Fixed
 - **CRITICAL**: All 22 IPC commands now work — `AppState` is constructed and registered via `.manage()` in the Tauri setup closure (#27)
   - Database connection (SQLite WAL mode) with migrations run at startup

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3301,6 +3301,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7807,6 +7817,7 @@ dependencies = [
  "extism",
  "flate2",
  "futures-util",
+ "keyring",
  "notify",
  "regex",
  "reqwest",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -47,6 +47,7 @@ zstd = "0.13.3"
 sevenz-rust2 = "0.20.2"
 unrar = "0.5.8"
 tauri-plugin-updater = "2.10.1"
+keyring = "3.6.3"
 
 [target.'cfg(unix)'.dependencies]
 tauri-plugin-pilot = { git = "https://github.com/mpiton/tauri-pilot", version = "0.3.0" }

--- a/src-tauri/src/adapters/driven/credential/keyring_credential_store.rs
+++ b/src-tauri/src/adapters/driven/credential/keyring_credential_store.rs
@@ -1,0 +1,215 @@
+//! Credential store backed by the OS keychain via `keyring-rs`.
+//!
+//! Stores credentials in the platform-native secret store:
+//! macOS Keychain, Linux Secret Service / keyutils, Windows Credential Manager.
+//! Each credential is stored as two keyring entries (username + password)
+//! under the service name `vortex-{service}`.
+
+use crate::domain::error::DomainError;
+use crate::domain::model::credential::Credential;
+use crate::domain::ports::driven::credential_store::CredentialStore;
+
+/// Credential store backed by the OS keychain.
+///
+/// Uses [`keyring::Entry`] to persist credentials securely.
+/// Two entries are created per service — one for the username, one for the
+/// password — so that a full [`Credential`] can be reconstructed on retrieval
+/// without any serialization format dependency.
+///
+/// # Concurrency
+///
+/// The two reads in [`get`](CredentialStore::get) (username then password) are
+/// not atomic at the keychain level. A concurrent [`store`](CredentialStore::store)
+/// or [`delete`](CredentialStore::delete) between the two reads can produce a
+/// mismatched `Credential`. Callers that require strong consistency must
+/// serialize access externally (e.g. wrap in a `Mutex`).
+#[derive(Debug, Clone)]
+pub struct KeyringCredentialStore;
+
+impl KeyringCredentialStore {
+    fn username_entry(service: &str) -> Result<keyring::Entry, DomainError> {
+        let svc = format!("vortex-{service}");
+        keyring::Entry::new(&svc, "vortex-username")
+            .map_err(|e| DomainError::StorageError(sanitize_keyring_error(service, "entry", &e)))
+    }
+
+    fn password_entry(service: &str) -> Result<keyring::Entry, DomainError> {
+        let svc = format!("vortex-{service}");
+        keyring::Entry::new(&svc, "vortex-password")
+            .map_err(|e| DomainError::StorageError(sanitize_keyring_error(service, "entry", &e)))
+    }
+}
+
+/// Map a keyring error to a safe, opaque message that never leaks stored secrets.
+///
+/// `keyring::Error::Ambiguous` wraps platform `Credential` objects whose `Debug`
+/// impl can print raw secret values. `BadEncoding` contains a raw `Vec<u8>` dump.
+/// Neither should ever appear in a `DomainError` that can propagate to logs or UI.
+fn sanitize_keyring_error(service: &str, operation: &str, err: &keyring::Error) -> String {
+    match err {
+        keyring::Error::Ambiguous(_) => {
+            format!(
+                "keyring {operation} error for service '{service}': ambiguous (multiple entries matched)"
+            )
+        }
+        keyring::Error::BadEncoding(_) => {
+            format!(
+                "keyring {operation} error for service '{service}': stored value is not valid UTF-8"
+            )
+        }
+        other => format!("keyring {operation} error for service '{service}': {other}"),
+    }
+}
+
+impl CredentialStore for KeyringCredentialStore {
+    fn get(&self, service: &str) -> Result<Option<Credential>, DomainError> {
+        let user_entry = Self::username_entry(service)?;
+        let pass_entry = Self::password_entry(service)?;
+
+        let username = match user_entry.get_password() {
+            Ok(val) => val,
+            Err(keyring::Error::NoEntry) => return Ok(None),
+            Err(e) => {
+                return Err(DomainError::StorageError(sanitize_keyring_error(
+                    service, "read", &e,
+                )));
+            }
+        };
+
+        let password = match pass_entry.get_password() {
+            Ok(val) => val,
+            Err(keyring::Error::NoEntry) => return Ok(None),
+            Err(e) => {
+                return Err(DomainError::StorageError(sanitize_keyring_error(
+                    service, "read", &e,
+                )));
+            }
+        };
+
+        Ok(Some(Credential::new(username, password)))
+    }
+
+    fn store(&self, service: &str, credential: &Credential) -> Result<(), DomainError> {
+        let user_entry = Self::username_entry(service)?;
+        let pass_entry = Self::password_entry(service)?;
+
+        user_entry
+            .set_password(credential.username())
+            .map_err(|e| DomainError::StorageError(sanitize_keyring_error(service, "write", &e)))?;
+
+        pass_entry
+            .set_password(credential.password())
+            .map_err(|e| {
+                if let Err(cleanup_err) = user_entry.delete_credential() {
+                    tracing::warn!(
+                        service = service,
+                        error = %cleanup_err,
+                        "password write failed and username cleanup also failed — \
+                         orphaned username entry may remain in keychain"
+                    );
+                }
+                DomainError::StorageError(sanitize_keyring_error(service, "write", &e))
+            })?;
+
+        Ok(())
+    }
+
+    fn delete(&self, service: &str) -> Result<(), DomainError> {
+        let user_entry = Self::username_entry(service)?;
+        let pass_entry = Self::password_entry(service)?;
+
+        // Delete both entries; ignore NoEntry (already absent is fine).
+        if let Err(e) = user_entry.delete_credential()
+            && !matches!(e, keyring::Error::NoEntry)
+        {
+            return Err(DomainError::StorageError(sanitize_keyring_error(
+                service, "delete", &e,
+            )));
+        }
+
+        if let Err(e) = pass_entry.delete_credential()
+            && !matches!(e, keyring::Error::NoEntry)
+        {
+            return Err(DomainError::StorageError(sanitize_keyring_error(
+                service, "delete", &e,
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests require a running OS keychain backend and are skipped in CI.
+    // Run locally with: cargo test -- --ignored keyring
+
+    #[test]
+    #[ignore = "requires OS keychain backend"]
+    fn test_store_get_delete_cycle() {
+        let store = KeyringCredentialStore;
+        let service = "test-integration-cycle";
+        let cred = Credential::new("alice", "s3cret");
+
+        // Clean slate
+        let _ = store.delete(service);
+
+        // Store
+        store.store(service, &cred).expect("store credential");
+
+        // Get
+        let retrieved = store.get(service).expect("get credential");
+        let retrieved = retrieved.expect("credential should exist");
+        assert_eq!(retrieved.username(), "alice");
+        assert_eq!(retrieved.password(), "s3cret");
+
+        // Delete
+        store.delete(service).expect("delete credential");
+
+        // Verify gone
+        let after_delete = store.get(service).expect("get after delete");
+        assert!(after_delete.is_none());
+    }
+
+    #[test]
+    #[ignore = "requires OS keychain backend"]
+    fn test_get_returns_none_when_absent() {
+        let store = KeyringCredentialStore;
+        let result = store
+            .get("test-nonexistent-service")
+            .expect("get nonexistent");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    #[ignore = "requires OS keychain backend"]
+    fn test_delete_absent_is_ok() {
+        let store = KeyringCredentialStore;
+        store
+            .delete("test-nonexistent-delete")
+            .expect("delete nonexistent should succeed");
+    }
+
+    #[test]
+    #[ignore = "requires OS keychain backend"]
+    fn test_store_overwrites_existing() {
+        let store = KeyringCredentialStore;
+        let service = "test-overwrite";
+
+        let _ = store.delete(service);
+
+        let cred1 = Credential::new("bob", "pass1");
+        store.store(service, &cred1).expect("store first");
+
+        let cred2 = Credential::new("charlie", "pass2");
+        store.store(service, &cred2).expect("store second");
+
+        let retrieved = store.get(service).expect("get").expect("should exist");
+        assert_eq!(retrieved.username(), "charlie");
+        assert_eq!(retrieved.password(), "pass2");
+
+        let _ = store.delete(service);
+    }
+}

--- a/src-tauri/src/adapters/driven/credential/keyring_credential_store.rs
+++ b/src-tauri/src/adapters/driven/credential/keyring_credential_store.rs
@@ -103,7 +103,7 @@ impl CredentialStore for KeyringCredentialStore {
                 if let Err(cleanup_err) = user_entry.delete_credential() {
                     tracing::warn!(
                         service = service,
-                        error = %cleanup_err,
+                        error = sanitize_keyring_error(service, "cleanup", &cleanup_err),
                         "password write failed and username cleanup also failed — \
                          orphaned username entry may remain in keychain"
                     );
@@ -118,18 +118,17 @@ impl CredentialStore for KeyringCredentialStore {
         let user_entry = Self::username_entry(service)?;
         let pass_entry = Self::password_entry(service)?;
 
-        // Delete both entries; ignore NoEntry (already absent is fine).
-        if let Err(e) = user_entry.delete_credential()
-            && !matches!(e, keyring::Error::NoEntry)
-        {
-            return Err(DomainError::StorageError(sanitize_keyring_error(
-                service, "delete", &e,
-            )));
+        // Attempt both deletions before returning; ignore NoEntry (already absent).
+        let mut first_err: Option<keyring::Error> = None;
+        for entry in [&user_entry, &pass_entry] {
+            if let Err(e) = entry.delete_credential()
+                && !matches!(e, keyring::Error::NoEntry)
+                && first_err.is_none()
+            {
+                first_err = Some(e);
+            }
         }
-
-        if let Err(e) = pass_entry.delete_credential()
-            && !matches!(e, keyring::Error::NoEntry)
-        {
+        if let Some(e) = first_err {
             return Err(DomainError::StorageError(sanitize_keyring_error(
                 service, "delete", &e,
             )));
@@ -143,7 +142,48 @@ impl CredentialStore for KeyringCredentialStore {
 mod tests {
     use super::*;
 
-    // These tests require a running OS keychain backend and are skipped in CI.
+    #[test]
+    fn test_sanitize_ambiguous_hides_secrets() {
+        let fake_creds: Vec<Box<keyring::Credential>> = vec![];
+        let err = keyring::Error::Ambiguous(fake_creds);
+        let msg = sanitize_keyring_error("mega", "read", &err);
+        assert!(msg.contains("ambiguous"));
+        assert!(!msg.contains("secret"));
+        assert!(msg.contains("mega"));
+    }
+
+    #[test]
+    fn test_sanitize_bad_encoding_hides_raw_bytes() {
+        let err = keyring::Error::BadEncoding(vec![0xFF, 0xFE]);
+        let msg = sanitize_keyring_error("mega", "read", &err);
+        assert!(msg.contains("not valid UTF-8"));
+        assert!(!msg.contains("0xFF"));
+        assert!(!msg.contains("255"));
+    }
+
+    #[test]
+    fn test_sanitize_no_entry_passes_through() {
+        let err = keyring::Error::NoEntry;
+        let msg = sanitize_keyring_error("mega", "delete", &err);
+        assert!(msg.contains("No matching entry"));
+        assert!(msg.contains("mega"));
+    }
+
+    #[test]
+    fn test_sanitize_includes_service_and_operation() {
+        let err = keyring::Error::NoEntry;
+        let msg = sanitize_keyring_error("my-svc", "write", &err);
+        assert!(msg.contains("my-svc"));
+        assert!(msg.contains("write"));
+    }
+
+    // The CredentialStore trait contract (get/store/delete cycle) is tested in:
+    //   - domain/ports/driven/tests.rs with InMemoryCredentialStore (runs in CI)
+    //   - tests/app_state_wiring.rs with NoopCredentialStore (runs in CI)
+    //
+    // The tests below exercise the real OS keychain integration and are skipped
+    // in CI. keyring::mock has EntryOnly persistence (no cross-Entry storage),
+    // so it cannot be used for store→get flows that recreate entries.
     // Run locally with: cargo test -- --ignored keyring
 
     #[test]
@@ -153,43 +193,19 @@ mod tests {
         let service = "test-integration-cycle";
         let cred = Credential::new("alice", "s3cret");
 
-        // Clean slate
         let _ = store.delete(service);
 
-        // Store
         store.store(service, &cred).expect("store credential");
 
-        // Get
         let retrieved = store.get(service).expect("get credential");
         let retrieved = retrieved.expect("credential should exist");
         assert_eq!(retrieved.username(), "alice");
         assert_eq!(retrieved.password(), "s3cret");
 
-        // Delete
         store.delete(service).expect("delete credential");
 
-        // Verify gone
         let after_delete = store.get(service).expect("get after delete");
         assert!(after_delete.is_none());
-    }
-
-    #[test]
-    #[ignore = "requires OS keychain backend"]
-    fn test_get_returns_none_when_absent() {
-        let store = KeyringCredentialStore;
-        let result = store
-            .get("test-nonexistent-service")
-            .expect("get nonexistent");
-        assert!(result.is_none());
-    }
-
-    #[test]
-    #[ignore = "requires OS keychain backend"]
-    fn test_delete_absent_is_ok() {
-        let store = KeyringCredentialStore;
-        store
-            .delete("test-nonexistent-delete")
-            .expect("delete nonexistent should succeed");
     }
 
     #[test]

--- a/src-tauri/src/adapters/driven/credential/keyring_credential_store.rs
+++ b/src-tauri/src/adapters/driven/credential/keyring_credential_store.rs
@@ -100,13 +100,19 @@ impl CredentialStore for KeyringCredentialStore {
         pass_entry
             .set_password(credential.password())
             .map_err(|e| {
-                if let Err(cleanup_err) = user_entry.delete_credential() {
-                    tracing::warn!(
-                        service = service,
-                        error = sanitize_keyring_error(service, "cleanup", &cleanup_err),
-                        "password write failed and username cleanup also failed — \
-                         orphaned username entry may remain in keychain"
-                    );
+                // Best-effort rollback: delete both entries to avoid leaving
+                // stale data (e.g. old password) when overwriting a credential.
+                for (entry_name, entry) in [("username", &user_entry), ("password", &pass_entry)] {
+                    if let Err(cleanup_err) = entry.delete_credential()
+                        && !matches!(cleanup_err, keyring::Error::NoEntry)
+                    {
+                        tracing::warn!(
+                            service = service,
+                            entry = entry_name,
+                            error = sanitize_keyring_error(service, "cleanup", &cleanup_err),
+                            "password write failed and credential cleanup also failed"
+                        );
+                    }
                 }
                 DomainError::StorageError(sanitize_keyring_error(service, "write", &e))
             })?;

--- a/src-tauri/src/adapters/driven/credential/mod.rs
+++ b/src-tauri/src/adapters/driven/credential/mod.rs
@@ -1,3 +1,5 @@
+mod keyring_credential_store;
 mod noop_credential_store;
 
+pub use keyring_credential_store::KeyringCredentialStore;
 pub use noop_credential_store::NoopCredentialStore;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ use domain::ports::driven::{
 // Public API — concrete types for app wiring (main.rs, Tauri setup, integration tests)
 pub use adapters::driven::clipboard::TauriClipboardObserver;
 pub use adapters::driven::config::TomlConfigStore;
+pub use adapters::driven::credential::KeyringCredentialStore;
 pub use adapters::driven::credential::NoopCredentialStore;
 pub use adapters::driven::event::TokioEventBus;
 pub use adapters::driven::event::spawn_tauri_event_bridge;
@@ -103,8 +104,7 @@ pub fn run() {
             let http_client: Arc<dyn HttpClient> =
                 Arc::new(ReqwestHttpClient::with_client(reqwest_client.clone()));
             let config_store: Arc<dyn ConfigStore> = Arc::new(TomlConfigStore::new(config_path));
-            // TODO: replace with keyring-rs CredentialStore once implemented
-            let credential_store: Arc<dyn CredentialStore> = Arc::new(NoopCredentialStore);
+            let credential_store: Arc<dyn CredentialStore> = Arc::new(KeyringCredentialStore);
             let clipboard_observer: Arc<dyn ClipboardObserver> =
                 Arc::new(TauriClipboardObserver::new(app_handle.clone()));
             let archive_extractor: Arc<dyn ArchiveExtractor> =


### PR DESCRIPTION
## Summary

- Implement `KeyringCredentialStore` adapter using `keyring-rs` v3.6.3 to persist credentials in the OS keychain (macOS Keychain, Linux Secret Service/keyutils, Windows Credential Manager)
- Replace `NoopCredentialStore` with `KeyringCredentialStore` as the default adapter in `lib.rs`
- Sanitize keyring error messages to prevent leaking stored secrets through `Ambiguous`/`BadEncoding` variants

## Design decisions

**Two entries per service**: Each credential is stored as two separate keyring entries (`vortex-{service}` with user keys `vortex-username` and `vortex-password`). This avoids serialization format dependencies in the adapter layer.

**Graceful absence handling**: `keyring::Error::NoEntry` maps to `Ok(None)` on get and is silently ignored on delete — an absent credential is a normal state, not an error.

**Best-effort cleanup**: If the password write fails after a successful username write, the adapter attempts to clean up the orphaned username entry and logs a warning if cleanup also fails.

**NoopCredentialStore preserved**: Remains available for integration tests where a real OS keychain backend is not desirable.

## Test plan

- [x] `cargo clippy --workspace -- -D warnings` passes (zero warnings)
- [x] `cargo fmt --check` passes
- [x] `cargo test --workspace` passes (433 passed, 8 ignored)
- [x] 4 unit tests for keyring operations (store/get/delete cycle, absent returns None, delete absent OK, overwrite) — marked `#[ignore]` as they need a real OS keychain
- [x] Existing `app_state_wiring` integration test still passes with `NoopCredentialStore`

Closes #35

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `KeyringCredentialStore` to persist credentials in the OS keychain and makes it the default adapter. Secures storage on macOS, Linux, and Windows, with sanitized errors and logs to avoid leaking secrets.

- **New Features**
  - Implemented `KeyringCredentialStore` using `keyring` v3.6.3 (Keychain, Secret Service/keyutils, Credential Manager).
  - Set as the default credential adapter; `NoopCredentialStore` remains for tests.
  - Stores username and password as two entries under `vortex-{service}`.

- **Bug Fixes**
  - Sanitized `keyring` errors and cleanup logs to prevent secret leaks.
  - Graceful absence handling (`get` returns `None`; `delete` ignores `NoEntry`), and `delete` attempts both deletions before returning an error.
  - On password write failure, roll back both username and password entries to avoid leaving stale secrets.

<sup>Written for commit 9a12bbdfc78136c7951d0af001035ba0b5c2c89a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Credentials now persist in the OS-native secret store: Keychain (macOS), Secret Service/keyutils (Linux), and Credential Manager (Windows).
  * The default credential storage now uses the OS keyring instead of the non-persistent stub.
  * The non-persistent credential store is retained only as a test stub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->