### PR TITLE
feat(core): implement SqliteStatsRepository (closes #36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `SqliteStatsRepository` — persistent download statistics backed by SQLite (replaces in-memory stub)
+- `SqliteStatsRepo` — persistent download statistics backed by SQLite (replaces in-memory stub)
 - Project scaffolding: Tauri 2 + React 19 + TypeScript + Tailwind CSS 4 + shadcn/ui
 - Nix flake for reproducible development environment
 - Hexagonal architecture folder structure for Rust backend
@@ -232,4 +232,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Plugin hot-reload watcher started with tracing on failure
   - Shared `reqwest::Client` between HTTP metadata port and download engine
   - `NoopCredentialStore` stub for tests (replaced by `KeyringCredentialStore` as default in #35)
-  - `InMemoryStatsRepository` stub for unit tests (replaced by `SqliteStatsRepository` as default in #36)
+  - `InMemoryStatsRepository` stub for unit tests (replaced by `SqliteStatsRepo` as default in #36)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,4 +232,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Plugin hot-reload watcher started with tracing on failure
   - Shared `reqwest::Client` between HTTP metadata port and download engine
   - `NoopCredentialStore` stub for tests (replaced by `KeyringCredentialStore` as default in #35)
-  - `InMemoryStatsRepository` stub until SQLite implementation (with `saturating_add` for overflow safety)
+  - `InMemoryStatsRepository` stub for unit tests (replaced by `SqliteStatsRepository` as default in #36)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `SqliteStatsRepository` — persistent download statistics backed by SQLite (replaces in-memory stub)
 - Project scaffolding: Tauri 2 + React 19 + TypeScript + Tailwind CSS 4 + shadcn/ui
 - Nix flake for reproducible development environment
 - Hexagonal architecture folder structure for Rust backend

--- a/src-tauri/src/adapters/driven/mod.rs
+++ b/src-tauri/src/adapters/driven/mod.rs
@@ -10,5 +10,6 @@ pub mod network;
 pub mod notification;
 pub mod plugin;
 pub mod sqlite;
+#[cfg(test)]
 pub mod stats;
 pub mod tray;

--- a/src-tauri/src/adapters/driven/sqlite/mod.rs
+++ b/src-tauri/src/adapters/driven/sqlite/mod.rs
@@ -4,4 +4,5 @@ pub mod download_repo;
 pub mod entities;
 pub mod history_repo;
 pub mod migrations;
+pub mod stats_repo;
 mod util;

--- a/src-tauri/src/adapters/driven/sqlite/stats_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/stats_repo.rs
@@ -1,0 +1,359 @@
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
+
+use crate::domain::error::DomainError;
+use crate::domain::model::views::{DailyVolume, HostStats, StatsView};
+use crate::domain::ports::driven::stats_repository::StatsRepository;
+
+use super::util::{block_on, map_db_err, safe_u64};
+
+pub struct SqliteStatsRepo {
+    db: DatabaseConnection,
+}
+
+impl SqliteStatsRepo {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+}
+
+impl StatsRepository for SqliteStatsRepo {
+    fn record_completed(&self, bytes: u64, avg_speed: u64) -> Result<(), DomainError> {
+        block_on(async {
+            let sql = "\
+                INSERT INTO statistics (id, date, bytes_downloaded, files_completed, avg_speed, peak_speed) \
+                VALUES (CAST(strftime('%Y%m%d', 'now') AS INTEGER), date('now'), ?1, 1, ?2, ?2) \
+                ON CONFLICT(date) DO UPDATE SET \
+                  bytes_downloaded = bytes_downloaded + excluded.bytes_downloaded, \
+                  files_completed = files_completed + 1, \
+                  avg_speed = CAST((CAST(avg_speed AS REAL) * files_completed + excluded.avg_speed) / (files_completed + 1) AS INTEGER), \
+                  peak_speed = MAX(peak_speed, excluded.peak_speed)";
+
+            self.db
+                .execute(Statement::from_sql_and_values(
+                    DatabaseBackend::Sqlite,
+                    sql,
+                    [
+                        sea_orm::Value::BigInt(Some(bytes as i64)),
+                        sea_orm::Value::BigInt(Some(avg_speed as i64)),
+                    ],
+                ))
+                .await
+                .map_err(map_db_err)?;
+
+            Ok(())
+        })
+    }
+
+    fn get_stats(&self) -> Result<StatsView, DomainError> {
+        block_on(async {
+            // 1. Totals
+            let totals_row = self
+                .db
+                .query_one(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "\
+                    SELECT \
+                      COALESCE(SUM(bytes_downloaded),0), \
+                      COALESCE(SUM(files_completed),0), \
+                      CASE WHEN SUM(files_completed)>0 \
+                        THEN CAST(SUM(CAST(avg_speed AS REAL)*files_completed)/SUM(files_completed) AS INTEGER) \
+                        ELSE 0 END, \
+                      COALESCE(MAX(peak_speed),0) \
+                    FROM statistics"
+                        .to_string(),
+                ))
+                .await
+                .map_err(map_db_err)?;
+
+            let (total_downloaded_bytes, total_files, avg_speed, peak_speed) = match totals_row {
+                Some(row) => {
+                    let b: i64 = row
+                        .try_get_by_index(0)
+                        .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                    let f: i64 = row
+                        .try_get_by_index(1)
+                        .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                    let a: i64 = row
+                        .try_get_by_index(2)
+                        .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                    let p: i64 = row
+                        .try_get_by_index(3)
+                        .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                    (safe_u64(b), safe_u64(f), safe_u64(a), safe_u64(p))
+                }
+                None => (0u64, 0u64, 0u64, 0u64),
+            };
+
+            // 2. Daily volumes
+            let daily_rows = self
+                .db
+                .query_all(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "SELECT date, bytes_downloaded, files_completed FROM statistics ORDER BY date DESC LIMIT 30"
+                        .to_string(),
+                ))
+                .await
+                .map_err(map_db_err)?;
+
+            let mut daily_volumes = Vec::with_capacity(daily_rows.len());
+            for row in daily_rows {
+                let date: String = row
+                    .try_get_by_index(0)
+                    .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                let bytes: i64 = row
+                    .try_get_by_index(1)
+                    .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                let count: i64 = row
+                    .try_get_by_index(2)
+                    .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                daily_volumes.push(DailyVolume {
+                    date,
+                    bytes: safe_u64(bytes),
+                    count: safe_u64(count),
+                });
+            }
+
+            // 3. Success rate
+            let success_row = self
+                .db
+                .query_one(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "SELECT COUNT(*), COALESCE(SUM(CASE WHEN state='Completed' THEN 1 ELSE 0 END),0) \
+                     FROM downloads WHERE state IN ('Completed','Failed','Cancelled')"
+                        .to_string(),
+                ))
+                .await
+                .map_err(map_db_err)?;
+
+            let success_rate = match success_row {
+                Some(row) => {
+                    let total: i64 = row
+                        .try_get_by_index(0)
+                        .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                    let completed: i64 = row
+                        .try_get_by_index(1)
+                        .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                    if total > 0 {
+                        completed as f64 / total as f64
+                    } else {
+                        0.0
+                    }
+                }
+                None => 0.0,
+            };
+
+            // 4. Top hosts
+            let host_rows = self
+                .db
+                .query_all(Statement::from_string(
+                    DatabaseBackend::Sqlite,
+                    "SELECT source_hostname, SUM(downloaded_bytes), COUNT(*) \
+                     FROM downloads \
+                     WHERE source_hostname IS NOT NULL AND source_hostname != '' \
+                     GROUP BY source_hostname \
+                     ORDER BY 2 DESC LIMIT 10"
+                        .to_string(),
+                ))
+                .await
+                .map_err(map_db_err)?;
+
+            let mut top_hosts = Vec::with_capacity(host_rows.len());
+            for row in host_rows {
+                let hostname: String = row
+                    .try_get_by_index(0)
+                    .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                let total_bytes: i64 = row
+                    .try_get_by_index(1)
+                    .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                let count: i64 = row
+                    .try_get_by_index(2)
+                    .map_err(|e| DomainError::StorageError(e.to_string()))?;
+                top_hosts.push(HostStats {
+                    hostname,
+                    total_bytes: safe_u64(total_bytes),
+                    download_count: safe_u64(count),
+                });
+            }
+
+            Ok(StatsView {
+                total_downloaded_bytes,
+                total_files,
+                avg_speed,
+                peak_speed,
+                success_rate,
+                daily_volumes,
+                top_hosts,
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::connection::setup_test_db;
+    use super::*;
+    use sea_orm::{ConnectionTrait, Statement};
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_record_completed_inserts_new_day() {
+        let db = setup_test_db().await.expect("failed to setup test db");
+        let repo = SqliteStatsRepo::new(db.clone());
+
+        repo.record_completed(1024, 512).expect("record_completed");
+
+        let row = db
+            .query_one(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT bytes_downloaded, files_completed FROM statistics LIMIT 1".to_string(),
+            ))
+            .await
+            .expect("query failed")
+            .expect("no row");
+
+        let bytes: i64 = row.try_get_by_index(0).unwrap();
+        let files: i64 = row.try_get_by_index(1).unwrap();
+        assert_eq!(bytes, 1024);
+        assert_eq!(files, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_record_completed_accumulates_same_day() {
+        let db = setup_test_db().await.expect("failed to setup test db");
+        let repo = SqliteStatsRepo::new(db.clone());
+
+        repo.record_completed(1000, 200).expect("first record");
+        repo.record_completed(500, 400).expect("second record");
+
+        let row = db
+            .query_one(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT bytes_downloaded, files_completed, avg_speed, peak_speed FROM statistics LIMIT 1"
+                    .to_string(),
+            ))
+            .await
+            .expect("query failed")
+            .expect("no row");
+
+        let bytes: i64 = row.try_get_by_index(0).unwrap();
+        let files: i64 = row.try_get_by_index(1).unwrap();
+        let avg: i64 = row.try_get_by_index(2).unwrap();
+        let peak: i64 = row.try_get_by_index(3).unwrap();
+        assert_eq!(bytes, 1500);
+        assert_eq!(files, 2);
+        // Running average: (200 * 1 + 400) / 2 = 300
+        assert_eq!(avg, 300);
+        assert_eq!(peak, 400);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_stats_empty_db() {
+        let db = setup_test_db().await.expect("failed to setup test db");
+        let repo = SqliteStatsRepo::new(db);
+
+        let stats = repo.get_stats().expect("get_stats");
+        assert_eq!(stats.total_downloaded_bytes, 0);
+        assert_eq!(stats.total_files, 0);
+        assert_eq!(stats.avg_speed, 0);
+        assert_eq!(stats.peak_speed, 0);
+        assert_eq!(stats.success_rate, 0.0);
+        assert!(stats.daily_volumes.is_empty());
+        assert!(stats.top_hosts.is_empty());
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_stats_daily_volumes() {
+        let db = setup_test_db().await.expect("failed to setup test db");
+
+        // Insert two rows with explicit dates
+        db.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO statistics (id, date, bytes_downloaded, files_completed, avg_speed, peak_speed) \
+             VALUES (20260101, '2026-01-01', 2000, 2, 100, 200)".to_string(),
+        ))
+        .await
+        .expect("insert day 1");
+
+        db.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO statistics (id, date, bytes_downloaded, files_completed, avg_speed, peak_speed) \
+             VALUES (20260102, '2026-01-02', 3000, 3, 150, 300)".to_string(),
+        ))
+        .await
+        .expect("insert day 2");
+
+        let repo = SqliteStatsRepo::new(db);
+        let stats = repo.get_stats().expect("get_stats");
+
+        assert_eq!(stats.daily_volumes.len(), 2);
+        // DESC order: most recent first
+        assert_eq!(stats.daily_volumes[0].date, "2026-01-02");
+        assert_eq!(stats.daily_volumes[0].bytes, 3000);
+        assert_eq!(stats.daily_volumes[1].date, "2026-01-01");
+        assert_eq!(stats.daily_volumes[1].bytes, 2000);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_stats_success_rate() {
+        let db = setup_test_db().await.expect("failed to setup test db");
+
+        // Insert 3 terminal downloads: 2 Completed, 1 Failed — all count for success rate
+        for (id, state) in [(1i64, "Completed"), (2, "Completed"), (3, "Failed")] {
+            db.execute(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                format!(
+                    "INSERT INTO downloads \
+                     (id, url, file_name, state, priority, downloaded_bytes, speed_bytes_per_sec, \
+                      retry_count, max_retries, segments_count, resume_supported, \
+                      source_hostname, protocol, destination_path, created_at, updated_at) \
+                     VALUES ({id}, 'https://example.com/{id}', 'file{id}.zip', '{state}', 5, 0, 0, \
+                             0, 5, 1, 0, 'example.com', 'https', '/tmp', 1000, 2000)"
+                ),
+            ))
+            .await
+            .expect("insert download");
+        }
+
+        let repo = SqliteStatsRepo::new(db);
+        let stats = repo.get_stats().expect("get_stats");
+
+        let expected_rate = 2.0 / 3.0;
+        assert!((stats.success_rate - expected_rate).abs() < 1e-9);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn test_get_stats_top_hosts() {
+        let db = setup_test_db().await.expect("failed to setup test db");
+
+        // 3 downloads on host-a (more bytes), 1 on host-b
+        for (id, hostname, bytes) in [
+            (1i64, "host-a.com", 5000i64),
+            (2, "host-a.com", 3000),
+            (3, "host-a.com", 2000),
+            (4, "host-b.com", 1000),
+        ] {
+            db.execute(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                format!(
+                    "INSERT INTO downloads \
+                     (id, url, file_name, state, priority, downloaded_bytes, speed_bytes_per_sec, \
+                      retry_count, max_retries, segments_count, resume_supported, \
+                      source_hostname, protocol, destination_path, created_at, updated_at) \
+                     VALUES ({id}, 'https://{hostname}/{id}', 'file{id}.zip', 'Completed', 5, \
+                             {bytes}, 0, 0, 5, 1, 0, '{hostname}', 'https', '/tmp', 1000, 2000)"
+                ),
+            ))
+            .await
+            .expect("insert download");
+        }
+
+        let repo = SqliteStatsRepo::new(db);
+        let stats = repo.get_stats().expect("get_stats");
+
+        assert_eq!(stats.top_hosts.len(), 2);
+        // host-a has more total bytes, should be first
+        assert_eq!(stats.top_hosts[0].hostname, "host-a.com");
+        assert_eq!(stats.top_hosts[0].total_bytes, 10000);
+        assert_eq!(stats.top_hosts[0].download_count, 3);
+        assert_eq!(stats.top_hosts[1].hostname, "host-b.com");
+    }
+}

--- a/src-tauri/src/adapters/driven/sqlite/stats_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/stats_repo.rs
@@ -19,9 +19,11 @@ impl SqliteStatsRepo {
 impl StatsRepository for SqliteStatsRepo {
     fn record_completed(&self, bytes: u64, avg_speed: u64) -> Result<(), DomainError> {
         block_on(async {
+            // peak_speed stores the highest per-download avg_speed seen that day
+            // (the trait only exposes avg_speed, not instantaneous peak).
             let sql = "\
                 INSERT INTO statistics (id, date, bytes_downloaded, files_completed, avg_speed, peak_speed) \
-                VALUES (CAST(strftime('%Y%m%d', 'now') AS INTEGER), date('now'), ?1, 1, ?2, ?2) \
+                VALUES (CAST(strftime('%Y%m%d', 'now', 'localtime') AS INTEGER), date('now', 'localtime'), ?1, 1, ?2, ?2) \
                 ON CONFLICT(date) DO UPDATE SET \
                   bytes_downloaded = bytes_downloaded + excluded.bytes_downloaded, \
                   files_completed = files_completed + 1, \
@@ -119,7 +121,7 @@ impl StatsRepository for SqliteStatsRepo {
                 .query_one(Statement::from_string(
                     DatabaseBackend::Sqlite,
                     "SELECT COUNT(*), COALESCE(SUM(CASE WHEN state='Completed' THEN 1 ELSE 0 END),0) \
-                     FROM downloads WHERE state IN ('Completed','Failed','Cancelled')"
+                     FROM downloads WHERE state IN ('Completed','Error')"
                         .to_string(),
                 ))
                 .await
@@ -149,7 +151,8 @@ impl StatsRepository for SqliteStatsRepo {
                     DatabaseBackend::Sqlite,
                     "SELECT source_hostname, SUM(downloaded_bytes), COUNT(*) \
                      FROM downloads \
-                     WHERE source_hostname IS NOT NULL AND source_hostname != '' \
+                     WHERE state = 'Completed' \
+                       AND source_hostname IS NOT NULL AND source_hostname != '' \
                      GROUP BY source_hostname \
                      ORDER BY 2 DESC LIMIT 10"
                         .to_string(),
@@ -296,8 +299,8 @@ mod tests {
     async fn test_get_stats_success_rate() {
         let db = setup_test_db().await.expect("failed to setup test db");
 
-        // Insert 3 terminal downloads: 2 Completed, 1 Failed — all count for success rate
-        for (id, state) in [(1i64, "Completed"), (2, "Completed"), (3, "Failed")] {
+        // Insert 3 terminal downloads: 2 Completed, 1 Error — all count for success rate
+        for (id, state) in [(1i64, "Completed"), (2, "Completed"), (3, "Error")] {
             db.execute(Statement::from_string(
                 DatabaseBackend::Sqlite,
                 format!(

--- a/src-tauri/src/adapters/driven/stats/mod.rs
+++ b/src-tauri/src/adapters/driven/stats/mod.rs
@@ -1,3 +1,1 @@
 mod in_memory_stats_repo;
-
-pub use in_memory_stats_repo::InMemoryStatsRepository;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -31,7 +31,7 @@ pub use adapters::driven::sqlite::connection;
 pub use adapters::driven::sqlite::download_read_repo::SqliteDownloadReadRepo;
 pub use adapters::driven::sqlite::download_repo::SqliteDownloadRepo;
 pub use adapters::driven::sqlite::history_repo::SqliteHistoryRepo;
-pub use adapters::driven::stats::InMemoryStatsRepository;
+pub use adapters::driven::sqlite::stats_repo::SqliteStatsRepo;
 pub use adapters::driven::tray::setup_system_tray;
 pub use application::command_bus::CommandBus;
 pub use application::error::AppError;
@@ -115,9 +115,9 @@ pub fn run() {
                 Arc::new(SqliteDownloadRepo::new(db.clone()));
             let download_read_repo: Arc<dyn DownloadReadRepository> =
                 Arc::new(SqliteDownloadReadRepo::new(db.clone()));
-            let history_repo: Arc<dyn HistoryRepository> = Arc::new(SqliteHistoryRepo::new(db));
-            // TODO: replace with SqliteStatsRepo once implemented
-            let stats_repo: Arc<dyn StatsRepository> = Arc::new(InMemoryStatsRepository::new());
+            let history_repo: Arc<dyn HistoryRepository> =
+                Arc::new(SqliteHistoryRepo::new(db.clone()));
+            let stats_repo: Arc<dyn StatsRepository> = Arc::new(SqliteStatsRepo::new(db));
 
             // ── Plugin system ───────────────────────────────────────
             let shared_resources = Arc::new(SharedHostResources::new());

--- a/src-tauri/tests/app_state_wiring.rs
+++ b/src-tauri/tests/app_state_wiring.rs
@@ -9,9 +9,9 @@ use vortex_lib::domain::ports::driven::{
     HttpClient, PluginLoader, PluginReadRepository, StatsRepository,
 };
 use vortex_lib::{
-    CommandBus, ExtismPluginLoader, ExtractionConfig, FsFileStorage, InMemoryStatsRepository,
-    NoopCredentialStore, QueryBus, ReqwestHttpClient, SegmentedDownloadEngine, SharedHostResources,
-    SqliteDownloadReadRepo, SqliteDownloadRepo, SqliteHistoryRepo, TokioEventBus, TomlConfigStore,
+    CommandBus, ExtismPluginLoader, ExtractionConfig, FsFileStorage, NoopCredentialStore, QueryBus,
+    ReqwestHttpClient, SegmentedDownloadEngine, SharedHostResources, SqliteDownloadReadRepo,
+    SqliteDownloadRepo, SqliteHistoryRepo, SqliteStatsRepo, TokioEventBus, TomlConfigStore,
     VortexArchiveExtractor, connection,
 };
 
@@ -51,8 +51,8 @@ fn test_appstate_wiring_with_in_memory_db() {
     let download_repo: Arc<dyn DownloadRepository> = Arc::new(SqliteDownloadRepo::new(db.clone()));
     let download_read_repo: Arc<dyn DownloadReadRepository> =
         Arc::new(SqliteDownloadReadRepo::new(db.clone()));
-    let history_repo: Arc<dyn HistoryRepository> = Arc::new(SqliteHistoryRepo::new(db));
-    let stats_repo: Arc<dyn StatsRepository> = Arc::new(InMemoryStatsRepository::new());
+    let history_repo: Arc<dyn HistoryRepository> = Arc::new(SqliteHistoryRepo::new(db.clone()));
+    let stats_repo: Arc<dyn StatsRepository> = Arc::new(SqliteStatsRepo::new(db));
 
     // Plugin system
     let plugins_dir = tempfile::tempdir().expect("plugins dir");


### PR DESCRIPTION
## Summary

- Replace `InMemoryStatsRepository` stub with `SqliteStatsRepo` backed by the existing `statistics` table
- Persistent download statistics survive app restarts
- Real `success_rate`, `daily_volumes`, and `top_hosts` computed via SQL aggregation

## Changes

- **New:** `src-tauri/src/adapters/driven/sqlite/stats_repo.rs` — `SqliteStatsRepo` implementing `StatsRepository` trait
  - `record_completed`: UPSERT daily stats row with running average speed and peak speed tracking
  - `get_stats`: 4 raw SQL queries aggregating totals, daily volumes, success rate (terminal states only), and top hosts by download volume
- **Modified:** `src-tauri/src/lib.rs` — wire `SqliteStatsRepo` replacing `InMemoryStatsRepository`
- **Modified:** `src-tauri/src/adapters/driven/mod.rs` — gate `stats` module behind `#[cfg(test)]`
- **Modified:** `src-tauri/tests/app_state_wiring.rs` — use `SqliteStatsRepo` in integration test

## Test plan

- [x] 6 integration tests with in-memory SQLite (`setup_test_db()`)
- [x] Empty DB returns zero-state
- [x] Single record inserts correctly
- [x] Multiple records accumulate (bytes, files, avg_speed, peak_speed)
- [x] Daily volumes returned in DESC order
- [x] Success rate computed from terminal states (Completed/Failed/Cancelled)
- [x] Top hosts ordered by total bytes DESC
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] 443 tests pass, 0 failures

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the in-memory stats stub with SQLite-backed `SqliteStatsRepo` to persist stats and compute aggregates (totals, daily volumes, success rate, top hosts). Wired into the app and tests; the in-memory repo is now test-only; closes #36.

- **New Features**
  - Upserts daily stats with a running average speed and peak speed.

- **Bug Fixes**
  - Use localtime for daily bucketing.
  - Compute success rate from terminal states only (`Completed`, `Error`).
  - Limit top hosts to completed downloads.
  - Fix CHANGELOG to reference `SqliteStatsRepo`.

<sup>Written for commit 460166e5ed2672ff321bb5cbe8d20f916ca4ddcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Statistics are now persisted in SQLite by default, with daily aggregates, rolling averages, peak speeds, and per-host summaries retained across sessions.

* **Bug Fixes**
  * In-memory stats implementation is now only used for unit tests; persistent storage is the default.

* **Tests**
  * Updated tests to validate persistent statistics, daily aggregation ordering, success-rate computation, and top-host ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->