### PR TITLE
fix(link): show inline analysis error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `NoopCredentialStore` remains available for tests
 
 ### Fixed
+- Link Grabber now shows an inline error message when `link_resolve` fails, instead of silently resetting after "Analyze Links" (#29)
 - Settings view now displays the actual backend error message when `settings_get` fails, instead of only a generic "Failed to load settings" (#28)
 - **CRITICAL**: All 22 IPC commands now work — `AppState` is constructed and registered via `.manage()` in the Tauri setup closure (#27)
   - Database connection (SQLite WAL mode) with migrations run at startup

--- a/src/views/LinkGrabberView/LinkGrabberView.tsx
+++ b/src/views/LinkGrabberView/LinkGrabberView.tsx
@@ -14,6 +14,7 @@ import type { MediaGrabberOptions } from "@/types/media";
 
 export function LinkGrabberView() {
   const [resolvedLinks, setResolvedLinks] = useState<ResolvedLink[]>([]);
+  const [resolveError, setResolveError] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterType>("all");
   const [selectedLinkIds, setSelectedLinkIds] = useState<string[]>([]);
   const [groupingMode, setGroupingMode] = useState<GroupingMode>("hostname");
@@ -30,8 +31,12 @@ export function LinkGrabberView() {
     { urls: string[] }
   >("link_resolve", {
     onSuccess: (resolved) => {
+      setResolveError(null);
       setResolvedLinks(resolved);
       setSelectedLinkIds([]);
+    },
+    onError: (error) => {
+      setResolveError(error.message);
     },
   });
 
@@ -46,6 +51,7 @@ export function LinkGrabberView() {
 
   const handlePasteUrls = (urls: string[]) => {
     // TODO: container: entries need a dedicated backend command for decryption
+    setResolveError(null);
     const validUrls = urls.filter(
       (u) =>
         u.startsWith("http://") ||
@@ -110,7 +116,11 @@ export function LinkGrabberView() {
         </div>
       </div>
 
-      <PasteZone onPasteUrls={handlePasteUrls} isLoading={isResolving} />
+      <PasteZone
+        onPasteUrls={handlePasteUrls}
+        isLoading={isResolving}
+        errorMessage={resolveError}
+      />
 
       {resolvedLinks.length > 0 && (
         <>

--- a/src/views/LinkGrabberView/PasteZone.tsx
+++ b/src/views/LinkGrabberView/PasteZone.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 interface PasteZoneProps {
   onPasteUrls: (urls: string[]) => void;
   isLoading?: boolean;
+  errorMessage?: string | null;
 }
 
 export function extractUrls(text: string): string[] {
@@ -13,7 +14,11 @@ export function extractUrls(text: string): string[] {
   return (matches ?? []).map((url) => url.replace(/[),.;:>}"'!?]+$/, ""));
 }
 
-export function PasteZone({ onPasteUrls, isLoading }: PasteZoneProps) {
+export function PasteZone({
+  onPasteUrls,
+  isLoading,
+  errorMessage,
+}: PasteZoneProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -89,6 +94,14 @@ export function PasteZone({ onPasteUrls, isLoading }: PasteZoneProps) {
           {isLoading ? "Resolving…" : "Analyze Links"}
         </Button>
       </div>
+      {errorMessage && (
+        <div className="mt-3 space-y-1" role="alert">
+          <p className="text-sm text-destructive">
+            Failed to analyze links. Please try again.
+          </p>
+          <p className="text-xs text-muted-foreground">{errorMessage}</p>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/views/LinkGrabberView/__tests__/LinkGrabberView.test.tsx
+++ b/src/views/LinkGrabberView/__tests__/LinkGrabberView.test.tsx
@@ -88,8 +88,21 @@ describe("LinkGrabberView", () => {
     });
   });
 
-  it("should show inline error when link resolution fails", async () => {
-    mockInvoke.mockRejectedValueOnce(new Error("AppState not registered"));
+  it("should clear inline error when retry succeeds", async () => {
+    mockInvoke
+      .mockRejectedValueOnce(new Error("AppState not registered"))
+      .mockResolvedValueOnce([
+        {
+          id: "1",
+          originalUrl: "https://example.com/file.zip",
+          resolvedUrl: "https://example.com/file.zip",
+          filename: "file.zip",
+          sizeBytes: 1024,
+          status: "online",
+          moduleName: "http",
+          isMedia: false,
+        },
+      ]);
 
     const user = userEvent.setup();
     renderWithProviders();
@@ -102,6 +115,15 @@ describe("LinkGrabberView", () => {
       "Failed to analyze links. Please try again.",
     );
     expect(screen.getByText("AppState not registered")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Analyze Links" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Select All (1)" }),
+      ).toBeInTheDocument();
+    });
   });
 
   it("should show filter/grouping/actions sections after links are resolved", async () => {

--- a/src/views/LinkGrabberView/__tests__/LinkGrabberView.test.tsx
+++ b/src/views/LinkGrabberView/__tests__/LinkGrabberView.test.tsx
@@ -88,6 +88,22 @@ describe("LinkGrabberView", () => {
     });
   });
 
+  it("should show inline error when link resolution fails", async () => {
+    mockInvoke.mockRejectedValueOnce(new Error("AppState not registered"));
+
+    const user = userEvent.setup();
+    renderWithProviders();
+
+    const textarea = screen.getByRole("textbox");
+    await user.type(textarea, "https://example.com/file.zip");
+    await user.click(screen.getByRole("button", { name: "Analyze Links" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Failed to analyze links. Please try again.",
+    );
+    expect(screen.getByText("AppState not registered")).toBeInTheDocument();
+  });
+
   it("should show filter/grouping/actions sections after links are resolved", async () => {
     mockInvoke.mockResolvedValue([
       {


### PR DESCRIPTION
## Summary
- show an inline error below the paste zone when `link_resolve` fails
- clear stale errors on retry or success while keeping the existing analysis flow
- add a regression test and changelog entry for issue #29

## Type
fix

Closes #29

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show an inline error under the paste zone when `link_resolve` fails, and clear it on retry or success. Fixes #29 by replacing the silent reset with clear, in-context feedback that includes backend error details.

- **Bug Fixes**
  - Show an inline alert in `PasteZone` on analysis failure with friendly copy plus the backend error message.
  - Clear stale errors on new paste and after a successful resolve.
  - Added tests for the failure case and for clearing the error on a successful retry; updated changelog.

<sup>Written for commit faf5257db2f34a1eb73d910cc0f6ad9135e6dae3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Link Grabber now shows an inline error alert when link analysis fails instead of silently resetting.

* **Tests**
  * Added a test that verifies the inline error is shown on failure and cleared after a successful retry.

* **Documentation**
  * CHANGELOG updated with the new "Fixed" entry describing the inline error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->