### PR TITLE
fix: complete i18n coverage for remaining UI strings

### DIFF
--- a/src/components/ClipboardIndicator.tsx
+++ b/src/components/ClipboardIndicator.tsx
@@ -1,7 +1,9 @@
 import { useClipboardMonitoring } from '@/hooks/useClipboardMonitoring';
+import { useTranslation } from 'react-i18next';
 import { useSettingsStore } from '@/stores/settingsStore';
 
 export function ClipboardIndicator() {
+  const { t } = useTranslation();
   const initialEnabled = useSettingsStore(
     (s) => s.config?.clipboardMonitoring ?? false
   );
@@ -13,14 +15,14 @@ export function ClipboardIndicator() {
       onClick={() => toggle(!isEnabled)}
       aria-pressed={isEnabled}
       className="flex items-center gap-1.5 text-[11px] text-text-dim hover:text-text transition-colors"
-      title={isEnabled ? 'Clipboard monitoring active' : 'Clipboard monitoring paused'}
+      title={isEnabled ? t('statusBar.clipboardActive') : t('statusBar.clipboardPaused')}
     >
       <div
         className={`h-[7px] w-[7px] rounded-full transition-colors ${
           isEnabled ? 'bg-success' : 'bg-border'
         }`}
       />
-      <span>Clipboard</span>
+      <span>{t('statusBar.clipboard')}</span>
     </button>
   );
 }

--- a/src/i18n/__tests__/issue30-ui-fr.test.tsx
+++ b/src/i18n/__tests__/issue30-ui-fr.test.tsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { useUiStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import { DownloadsView } from "@/views/DownloadsView";
+import { LinkGrabberView } from "@/views/LinkGrabberView";
+import { StatusBar } from "@/layouts/StatusBar";
+import { PackagesView } from "@/views/PackagesView";
+import { AccountsView } from "@/views/AccountsView";
+import { CaptchaView } from "@/views/CaptchaView";
+import { PluginsView } from "@/views/PluginsView";
+import { SchedulerView } from "@/views/SchedulerView";
+import { HistoryView } from "@/views/HistoryView";
+import { StatisticsView } from "@/views/StatisticsView";
+
+const { mockInvoke } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mockInvoke,
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn().mockResolvedValue(vi.fn()),
+}));
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderWithProviders(
+  ui: React.ReactElement,
+  options: { tooltip?: boolean } = {},
+) {
+  const content = options.tooltip ? <TooltipProvider>{ui}</TooltipProvider> : ui;
+
+  return render(
+    <QueryClientProvider client={createQueryClient()}>{content}</QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.setItem("i18nextLng", "fr");
+  mockInvoke.mockReset();
+  mockInvoke.mockImplementation(async (command: string) => {
+    switch (command) {
+      case "download_list":
+        return [];
+      case "download_count_by_state":
+        return {
+          total: 0,
+          Downloading: 0,
+          Queued: 0,
+          Completed: 0,
+          Error: 0,
+          Retry: 0,
+        };
+      case "clipboard_toggle":
+        return true;
+      default:
+        return undefined;
+    }
+  });
+  useUiStore.setState({
+    selectedDownloadId: null,
+    selectedDownloadIds: [],
+    detailsPanelOpen: false,
+    filterBarExpanded: false,
+  });
+  useSettingsStore.setState({ config: null, isLoading: false, error: null });
+  cleanup();
+});
+
+describe("issue #30 — French UI translations", () => {
+  it("renders downloads view strings in French", async () => {
+    renderWithProviders(
+      <div style={{ height: "600px" }}>
+        <DownloadsView />
+      </div>,
+      { tooltip: true },
+    );
+
+    expect(await screen.findByText("Aucun téléchargement")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Rechercher des téléchargements...")).toBeInTheDocument();
+    expect(screen.getByText("Tous")).toBeInTheDocument();
+    expect(screen.getByText("Actifs")).toBeInTheDocument();
+    expect(screen.getByText("En attente")).toBeInTheDocument();
+    expect(screen.getByText("Terminés")).toBeInTheDocument();
+    expect(screen.getByText("Échoués")).toBeInTheDocument();
+    expect(screen.getByText("Tout suspendre")).toBeInTheDocument();
+    expect(screen.getByText("Tout reprendre")).toBeInTheDocument();
+  });
+
+  it("renders link grabber shell strings in French", () => {
+    renderWithProviders(<LinkGrabberView />, { tooltip: true });
+
+    expect(screen.getByText("Capteur de liens")).toBeInTheDocument();
+    expect(screen.getByText("Surveillance du presse-papiers")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Collez des URL ici (une par ligne)…"),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Effacer" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Analyser les liens" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders status bar strings in French", () => {
+    renderWithProviders(<StatusBar />);
+
+    expect(screen.getByText("Limite : illimitée")).toBeInTheDocument();
+    expect(screen.getByText("-- GB libres")).toBeInTheDocument();
+    expect(screen.getByText("Presse-papiers")).toBeInTheDocument();
+    expect(screen.getByText("0 actifs")).toBeInTheDocument();
+  });
+
+  it("renders placeholder views in French", () => {
+    const views = [
+      { component: <PackagesView />, title: "Paquets" },
+      { component: <AccountsView />, title: "Comptes" },
+      { component: <CaptchaView />, title: "Captcha" },
+      { component: <PluginsView />, title: "Plugins" },
+      { component: <SchedulerView />, title: "Planificateur" },
+      { component: <HistoryView />, title: "Historique" },
+      { component: <StatisticsView />, title: "Statistiques" },
+    ];
+
+    for (const view of views) {
+      const result = render(view.component);
+      expect(screen.getByText(view.title)).toBeInTheDocument();
+      expect(screen.getByText("Bientôt disponible")).toBeInTheDocument();
+      result.unmount();
+    }
+  });
+});

--- a/src/i18n/__tests__/issue30-ui-fr.test.tsx
+++ b/src/i18n/__tests__/issue30-ui-fr.test.tsx
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { useDownloadStore } from "@/stores/downloadStore";
+import { useLayoutStore } from "@/stores/layout-store";
 import { useUiStore } from "@/stores/uiStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { DownloadsView } from "@/views/DownloadsView";
@@ -76,6 +78,13 @@ beforeEach(() => {
     filterBarExpanded: false,
   });
   useSettingsStore.setState({ config: null, isLoading: false, error: null });
+  useLayoutStore.setState({
+    speedLimit: 0,
+    freeSpace: "-- GB",
+    appVersion: "0.1.0",
+    sidebarCollapsed: false,
+  });
+  useDownloadStore.setState({ progressMap: {}, countByState: {} });
   cleanup();
 });
 
@@ -119,7 +128,7 @@ describe("issue #30 — French UI translations", () => {
     expect(screen.getByText("Limite : illimitée")).toBeInTheDocument();
     expect(screen.getByText("-- GB libres")).toBeInTheDocument();
     expect(screen.getByText("Presse-papiers")).toBeInTheDocument();
-    expect(screen.getByText("0 actifs")).toBeInTheDocument();
+    expect(screen.getByText("0 actif")).toBeInTheDocument();
   });
 
   it("renders placeholder views in French", () => {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -135,9 +135,33 @@
       "resumeAll": "Resume All",
       "cancelSelected": "Cancel Selected"
     },
-    "selectedCount": "{{count}} selected",
+    "selectedCount_one": "{{count}} selected",
+    "selectedCount_other": "{{count}} selected",
     "empty": "No downloads",
-    "loading": "Loading..."
+    "loading": "Loading...",
+    "table": {
+      "selectAll": "Select all",
+      "selectRow": "Select row",
+      "moreActions": "More actions",
+      "columns": {
+        "state": "State",
+        "fileName": "Filename",
+        "type": "Type",
+        "host": "Host",
+        "progress": "Progress",
+        "speed": "Speed",
+        "eta": "ETA"
+      },
+      "actions": {
+        "setPriority": "Set Priority",
+        "remove": "Remove"
+      },
+      "priority": {
+        "high": "High",
+        "normal": "Normal",
+        "low": "Low"
+      }
+    }
   },
   "linkGrabber": {
     "clipboardMonitoringLabel": "Clipboard Monitoring",
@@ -168,7 +192,8 @@
   "statusBar": {
     "limit": "Limit: {{value}}",
     "freeSpace": "{{value}} free",
-    "activeCount": "{{count}} active",
+    "activeCount_one": "{{count}} active",
+    "activeCount_other": "{{count}} active",
     "clipboard": "Clipboard",
     "clipboardActive": "Clipboard monitoring active",
     "clipboardPaused": "Clipboard monitoring paused"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -122,7 +122,56 @@
     "fileSize": "Size",
     "mimeType": "MIME Type",
     "added": "Added",
-    "destination": "Destination"
+    "destination": "Destination",
+    "filters": {
+      "all": "All",
+      "active": "Active",
+      "queued": "Queued",
+      "done": "Done",
+      "failed": "Failed"
+    },
+    "actions": {
+      "pauseAll": "Pause All",
+      "resumeAll": "Resume All",
+      "cancelSelected": "Cancel Selected"
+    },
+    "selectedCount": "{{count}} selected",
+    "empty": "No downloads",
+    "loading": "Loading..."
+  },
+  "linkGrabber": {
+    "clipboardMonitoringLabel": "Clipboard Monitoring",
+    "pastePlaceholder": "Paste URLs here (one per line)…",
+    "analyze": "Analyze Links",
+    "resolving": "Resolving…",
+    "analyzeFailed": "Failed to analyze links. Please try again.",
+    "clipboardComingSoon": "Coming in a future update",
+    "filters": {
+      "all": "All",
+      "online": "Online",
+      "offline": "Offline",
+      "media": "Media"
+    },
+    "actions": {
+      "selectAll": "Select All ({{count}})",
+      "startSelected": "Start Selected ({{count}})",
+      "startAllOnline": "Start All Online"
+    },
+    "grouping": {
+      "label": "Group Into Packages:",
+      "none": "No Grouping",
+      "hostname": "By Hostname",
+      "extension": "By Extension",
+      "type": "By Type"
+    }
+  },
+  "statusBar": {
+    "limit": "Limit: {{value}}",
+    "freeSpace": "{{value}} free",
+    "activeCount": "{{count}} active",
+    "clipboard": "Clipboard",
+    "clipboardActive": "Clipboard monitoring active",
+    "clipboardPaused": "Clipboard monitoring paused"
   },
   "mediaGrabber": {
     "title": "Media Grabber Options",
@@ -134,6 +183,9 @@
   },
   "common": {
     "retry": "Retry",
-    "failedToLoadSettings": "Failed to load settings"
+    "failedToLoadSettings": "Failed to load settings",
+    "comingSoon": "Coming soon",
+    "clear": "Clear",
+    "unlimited": "unlimited"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -122,7 +122,56 @@
     "fileSize": "Taille",
     "mimeType": "Type MIME",
     "added": "Ajouté",
-    "destination": "Destination"
+    "destination": "Destination",
+    "filters": {
+      "all": "Tous",
+      "active": "Actifs",
+      "queued": "En attente",
+      "done": "Terminés",
+      "failed": "Échoués"
+    },
+    "actions": {
+      "pauseAll": "Tout suspendre",
+      "resumeAll": "Tout reprendre",
+      "cancelSelected": "Annuler la sélection"
+    },
+    "selectedCount": "{{count}} sélectionnés",
+    "empty": "Aucun téléchargement",
+    "loading": "Chargement..."
+  },
+  "linkGrabber": {
+    "clipboardMonitoringLabel": "Surveillance du presse-papiers",
+    "pastePlaceholder": "Collez des URL ici (une par ligne)…",
+    "analyze": "Analyser les liens",
+    "resolving": "Résolution…",
+    "analyzeFailed": "Échec de l'analyse des liens. Veuillez réessayer.",
+    "clipboardComingSoon": "Disponible dans une prochaine mise à jour",
+    "filters": {
+      "all": "Tous",
+      "online": "En ligne",
+      "offline": "Hors ligne",
+      "media": "Média"
+    },
+    "actions": {
+      "selectAll": "Tout sélectionner ({{count}})",
+      "startSelected": "Démarrer la sélection ({{count}})",
+      "startAllOnline": "Tout démarrer en ligne"
+    },
+    "grouping": {
+      "label": "Regrouper en paquets :",
+      "none": "Aucun regroupement",
+      "hostname": "Par hôte",
+      "extension": "Par extension",
+      "type": "Par type"
+    }
+  },
+  "statusBar": {
+    "limit": "Limite : {{value}}",
+    "freeSpace": "{{value}} libres",
+    "activeCount": "{{count}} actifs",
+    "clipboard": "Presse-papiers",
+    "clipboardActive": "Surveillance du presse-papiers active",
+    "clipboardPaused": "Surveillance du presse-papiers en pause"
   },
   "mediaGrabber": {
     "title": "Options du capteur multimédia",
@@ -134,6 +183,9 @@
   },
   "common": {
     "retry": "Réessayer",
-    "failedToLoadSettings": "Échec du chargement des paramètres"
+    "failedToLoadSettings": "Échec du chargement des paramètres",
+    "comingSoon": "Bientôt disponible",
+    "clear": "Effacer",
+    "unlimited": "illimitée"
   }
 }

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -135,9 +135,33 @@
       "resumeAll": "Tout reprendre",
       "cancelSelected": "Annuler la sélection"
     },
-    "selectedCount": "{{count}} sélectionnés",
+    "selectedCount_one": "{{count}} sélectionné",
+    "selectedCount_other": "{{count}} sélectionnés",
     "empty": "Aucun téléchargement",
-    "loading": "Chargement..."
+    "loading": "Chargement...",
+    "table": {
+      "selectAll": "Tout sélectionner",
+      "selectRow": "Sélectionner la ligne",
+      "moreActions": "Plus d’actions",
+      "columns": {
+        "state": "État",
+        "fileName": "Nom du fichier",
+        "type": "Type",
+        "host": "Hôte",
+        "progress": "Progression",
+        "speed": "Vitesse",
+        "eta": "Temps restant"
+      },
+      "actions": {
+        "setPriority": "Définir la priorité",
+        "remove": "Supprimer"
+      },
+      "priority": {
+        "high": "Haute",
+        "normal": "Normale",
+        "low": "Basse"
+      }
+    }
   },
   "linkGrabber": {
     "clipboardMonitoringLabel": "Surveillance du presse-papiers",
@@ -168,7 +192,8 @@
   "statusBar": {
     "limit": "Limite : {{value}}",
     "freeSpace": "{{value}} libres",
-    "activeCount": "{{count}} actifs",
+    "activeCount_one": "{{count}} actif",
+    "activeCount_other": "{{count}} actifs",
     "clipboard": "Presse-papiers",
     "clipboardActive": "Surveillance du presse-papiers active",
     "clipboardPaused": "Surveillance du presse-papiers en pause"

--- a/src/layouts/StatusBar.tsx
+++ b/src/layouts/StatusBar.tsx
@@ -1,4 +1,5 @@
 import { useLayoutStore } from "@/stores/layout-store";
+import { useTranslation } from "react-i18next";
 import { useDownloadStore, selectTotalSpeed, selectActiveCount } from "@/stores/downloadStore";
 import { ClipboardIndicator } from '@/components/ClipboardIndicator';
 
@@ -7,13 +8,14 @@ function Dot() {
 }
 
 export function StatusBar() {
+  const { t } = useTranslation();
   const totalSpeed = useDownloadStore(selectTotalSpeed);
   const activeCount = useDownloadStore(selectActiveCount);
   const speedLimit = useLayoutStore((state) => state.speedLimit);
   const freeSpace = useLayoutStore((state) => state.freeSpace);
   const appVersion = useLayoutStore((state) => state.appVersion);
 
-  const limitLabel = speedLimit > 0 ? `${speedLimit} MB/s` : "unlimited";
+  const limitValue = speedLimit > 0 ? `${speedLimit} MB/s` : t("common.unlimited");
 
   return (
     <footer className="flex h-[38px] shrink-0 items-center justify-between border-t border-border bg-surface px-6 text-[11px]">
@@ -22,9 +24,9 @@ export function StatusBar() {
           ↓ {totalSpeed.toFixed(1)} MB/s
         </span>
         <Dot />
-        <span className="text-text-dim">Limit: {limitLabel}</span>
+        <span className="text-text-dim">{t("statusBar.limit", { value: limitValue })}</span>
         <Dot />
-        <span className="text-text-dim">{freeSpace} free</span>
+        <span className="text-text-dim">{t("statusBar.freeSpace", { value: freeSpace })}</span>
         <Dot />
         <ClipboardIndicator />
       </div>
@@ -33,7 +35,7 @@ export function StatusBar() {
         <Dot />
         <div className="flex items-center gap-1.5">
           <div className="h-[7px] w-[7px] rounded-full bg-success" />
-          <span className="text-text-dim">{activeCount} active</span>
+          <span className="text-text-dim">{t("statusBar.activeCount", { count: activeCount })}</span>
         </div>
       </div>
     </footer>

--- a/src/layouts/__tests__/StatusBar.test.tsx
+++ b/src/layouts/__tests__/StatusBar.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { StatusBar } from "../StatusBar";
+import { useDownloadStore } from "@/stores/downloadStore";
 
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
@@ -21,6 +22,19 @@ function renderWithProviders(ui: React.ReactElement) {
 }
 
 describe("StatusBar", () => {
+  beforeEach(() => {
+    useDownloadStore.setState({ countByState: {}, progressMap: {} });
+  });
+
+  it("should use the singular French label when one download is active", () => {
+    window.localStorage.setItem("i18nextLng", "fr");
+    useDownloadStore.setState({ countByState: { Downloading: 1 } });
+
+    renderWithProviders(<StatusBar />);
+
+    expect(screen.getByText("1 actif")).toBeInTheDocument();
+  });
+
   it("should render download speed", () => {
     renderWithProviders(<StatusBar />);
     expect(screen.getByText(/0\.0 MB\/s/)).toBeInTheDocument();

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,6 +1,13 @@
 import "@testing-library/jest-dom/vitest";
 import { beforeEach, vi } from "vitest";
 
+function resolveMockLanguage(options?: Record<string, unknown>): "en" | "fr" {
+  const requestedLanguage = options?.lng;
+  if (requestedLanguage === "fr") return "fr";
+  if (requestedLanguage === "en") return "en";
+  return getMockLanguage();
+}
+
 function getMockLanguage(): "en" | "fr" {
   if (typeof window === "undefined") return "en";
   return window.localStorage.getItem("i18nextLng") === "fr" ? "fr" : "en";
@@ -31,10 +38,12 @@ vi.mock("react-i18next", async () => {
   };
 
   const t = (key: string, options?: Record<string, unknown>) => {
-    const language = getMockLanguage();
+    const language = resolveMockLanguage(options);
     const count = options?.count;
+    const pluralCategory =
+      typeof count === "number" ? new Intl.PluralRules(language).select(count) : null;
     const pluralKey =
-      typeof count === "number" ? `${key}_${count === 1 ? "one" : "other"}` : key;
+      pluralCategory === null ? key : `${key}_${pluralCategory}`;
     const pluralTemplate = lookupKey(translations[language], pluralKey);
     const template =
       pluralTemplate !== pluralKey

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -1,32 +1,56 @@
 import "@testing-library/jest-dom/vitest";
-import { vi } from "vitest";
+import { beforeEach, vi } from "vitest";
 
-// Mock react-i18next globally — t(key) returns the English translation value
-// so existing tests that assert on English text continue to work
+function getMockLanguage(): "en" | "fr" {
+  if (typeof window === "undefined") return "en";
+  return window.localStorage.getItem("i18nextLng") === "fr" ? "fr" : "en";
+}
+
+function lookupKey(obj: Record<string, unknown>, key: string): string {
+  const parts = key.split(".");
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current && typeof current === "object") {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return key;
+    }
+  }
+  return typeof current === "string" ? current : key;
+}
+
+// Mock react-i18next globally. Tests default to English, but can switch to
+// French by setting localStorage.i18nextLng before rendering.
 vi.mock("react-i18next", async () => {
   const en = await import("./i18n/locales/en.json");
+  const fr = await import("./i18n/locales/fr.json");
 
-  function lookupKey(obj: Record<string, unknown>, key: string): string {
-    const parts = key.split(".");
-    let current: unknown = obj;
-    for (const part of parts) {
-      if (current && typeof current === "object") {
-        current = (current as Record<string, unknown>)[part];
-      } else {
-        return key;
-      }
-    }
-    return typeof current === "string" ? current : key;
-  }
+  const translations = {
+    en: en.default as unknown as Record<string, unknown>,
+    fr: fr.default as unknown as Record<string, unknown>,
+  };
 
-  const t = (key: string) => lookupKey(en.default as unknown as Record<string, unknown>, key);
+  const t = (key: string, options?: Record<string, unknown>) => {
+    const template = lookupKey(translations[getMockLanguage()], key);
+
+    if (!options) return template;
+
+    return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => {
+      const value = options[name];
+      return value == null ? `{{${name}}}` : String(value);
+    });
+  };
 
   return {
     useTranslation: () => ({
       t,
       i18n: {
-        language: "en",
-        changeLanguage: vi.fn().mockResolvedValue(undefined),
+        language: getMockLanguage(),
+        changeLanguage: vi.fn().mockImplementation(async (language: string) => {
+          if (typeof window !== "undefined") {
+            window.localStorage.setItem("i18nextLng", language);
+          }
+        }),
       },
       ready: true,
     }),
@@ -49,4 +73,8 @@ Object.defineProperty(window, "matchMedia", {
     removeEventListener: vi.fn(),
     dispatchEvent: vi.fn(() => true),
   })),
+});
+
+beforeEach(() => {
+  window.localStorage.removeItem("i18nextLng");
 });

--- a/src/test-setup.ts
+++ b/src/test-setup.ts
@@ -31,13 +31,21 @@ vi.mock("react-i18next", async () => {
   };
 
   const t = (key: string, options?: Record<string, unknown>) => {
-    const template = lookupKey(translations[getMockLanguage()], key);
+    const language = getMockLanguage();
+    const count = options?.count;
+    const pluralKey =
+      typeof count === "number" ? `${key}_${count === 1 ? "one" : "other"}` : key;
+    const pluralTemplate = lookupKey(translations[language], pluralKey);
+    const template =
+      pluralTemplate !== pluralKey
+        ? pluralTemplate
+        : lookupKey(translations[language], key);
 
     if (!options) return template;
 
     return template.replace(/\{\{(\w+)\}\}/g, (_, name: string) => {
       const value = options[name];
-      return value == null ? `{{${name}}}` : String(value);
+      return value === null || value === undefined ? `{{${name}}}` : String(value);
     });
   };
 

--- a/src/views/AccountsView.tsx
+++ b/src/views/AccountsView.tsx
@@ -1,13 +1,6 @@
 import { User } from "lucide-react";
+import { PlaceholderView } from "./PlaceholderView";
 
 export function AccountsView() {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-4">
-      <User className="h-16 w-16 text-muted-foreground" />
-      <div className="text-center">
-        <h1 className="text-2xl font-bold">Accounts</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Coming soon</p>
-      </div>
-    </div>
-  );
+  return <PlaceholderView icon={User} titleKey="nav.accounts" />;
 }

--- a/src/views/CaptchaView.tsx
+++ b/src/views/CaptchaView.tsx
@@ -1,13 +1,6 @@
 import { Shield } from "lucide-react";
+import { PlaceholderView } from "./PlaceholderView";
 
 export function CaptchaView() {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-4">
-      <Shield className="h-16 w-16 text-muted-foreground" />
-      <div className="text-center">
-        <h1 className="text-2xl font-bold">CAPTCHA</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Coming soon</p>
-      </div>
-    </div>
-  );
+  return <PlaceholderView icon={Shield} titleKey="nav.captcha" />;
 }

--- a/src/views/DownloadsView/ActionsBar.tsx
+++ b/src/views/DownloadsView/ActionsBar.tsx
@@ -1,5 +1,6 @@
 import { useRef } from 'react';
 import { Pause, Play, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { useTauriMutation } from '@/api/hooks';
 import { downloadQueries } from '@/api/queries';
@@ -11,6 +12,7 @@ const INVALIDATE_KEYS = [
 ] as const;
 
 export function ActionsBar() {
+  const { t } = useTranslation();
   const selectedDownloadIds = useUiStore((s) => s.selectedDownloadIds);
   const setSelectedDownloadIds = useUiStore((s) => s.setSelectedDownloadIds);
   const clearSelection = useUiStore((s) => s.clearSelection);
@@ -60,25 +62,25 @@ export function ActionsBar() {
       {hasSelection ? (
         <>
           <span className="text-sm text-muted-foreground">
-            {selectedDownloadIds.length} selected
+            {t('downloads.selectedCount', { count: selectedDownloadIds.length })}
           </span>
           <Button variant="ghost" size="sm" onClick={handleCancelSelected}>
             <X className="mr-1 h-4 w-4" />
-            Cancel Selected
+            {t('downloads.actions.cancelSelected')}
           </Button>
           <Button variant="ghost" size="sm" onClick={clearSelection}>
-            Clear
+            {t('common.clear')}
           </Button>
         </>
       ) : (
         <>
           <Button variant="ghost" size="sm" onClick={() => pauseAll.mutate()}>
             <Pause className="mr-1 h-4 w-4" />
-            Pause All
+            {t('downloads.actions.pauseAll')}
           </Button>
           <Button variant="ghost" size="sm" onClick={() => resumeAll.mutate()}>
             <Play className="mr-1 h-4 w-4" />
-            Resume All
+            {t('downloads.actions.resumeAll')}
           </Button>
         </>
       )}

--- a/src/views/DownloadsView/DownloadsTable.tsx
+++ b/src/views/DownloadsView/DownloadsTable.tsx
@@ -45,6 +45,8 @@ import { ProgressCell } from './ProgressCell';
 import { SpeedCell } from './SpeedCell';
 import { EtaCell } from './EtaCell';
 
+type Translate = (key: string, options?: Record<string, unknown>) => string;
+
 interface DownloadsTableProps {
   downloads: DownloadView[];
   isLoading: boolean;
@@ -92,9 +94,10 @@ function useRowActions(): RowActions {
 
 interface ActionCellProps {
   download: DownloadView;
+  t: Translate;
 }
 
-function ActionCell({ download }: ActionCellProps) {
+function ActionCell({ download, t }: ActionCellProps) {
   const actions = useRowActions();
 
   return (
@@ -144,6 +147,7 @@ function ActionCell({ download }: ActionCellProps) {
             variant="ghost"
             size="icon"
             className="h-7 w-7"
+            aria-label={t('downloads.table.moreActions')}
             onClick={(e) => e.stopPropagation()}
           >
             <MoreHorizontal className="size-3.5" />
@@ -151,12 +155,12 @@ function ActionCell({ download }: ActionCellProps) {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuSub>
-            <DropdownMenuSubTrigger>Set Priority</DropdownMenuSubTrigger>
+            <DropdownMenuSubTrigger>{t('downloads.table.actions.setPriority')}</DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {[
-                { label: 'High', value: 1 },
-                { label: 'Normal', value: 5 },
-                { label: 'Low', value: 10 },
+                { label: t('downloads.table.priority.high'), value: 1 },
+                { label: t('downloads.table.priority.normal'), value: 5 },
+                { label: t('downloads.table.priority.low'), value: 10 },
               ].map((p) => (
                 <DropdownMenuItem
                   key={p.value}
@@ -179,7 +183,7 @@ function ActionCell({ download }: ActionCellProps) {
             }}
           >
             <Trash2 className="size-3.5" />
-            Remove
+            {t('downloads.table.actions.remove')}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -187,88 +191,90 @@ function ActionCell({ download }: ActionCellProps) {
   );
 }
 
-const columns: ColumnDef<DownloadView>[] = [
-  {
-    id: 'select',
-    header: ({ table }) => (
-      <Checkbox
-        checked={table.getIsAllRowsSelected()}
-        onCheckedChange={(checked) => table.toggleAllRowsSelected(!!checked)}
-        aria-label="Select all"
-      />
-    ),
-    cell: ({ row }) => (
-      <Checkbox
-        checked={row.getIsSelected()}
-        onCheckedChange={(checked) => row.toggleSelected(!!checked)}
-        onClick={(e) => e.stopPropagation()}
-        aria-label="Select row"
-      />
-    ),
-    enableSorting: false,
-  },
-  {
-    accessorKey: 'state',
-    header: 'State',
-    cell: ({ row }) => <StateIndicator state={row.original.state} />,
-  },
-  {
-    accessorKey: 'fileName',
-    header: 'Filename',
-    cell: ({ row }) => (
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <span className="block max-w-[200px] truncate">
-            {row.original.fileName}
-          </span>
-        </TooltipTrigger>
-        <TooltipContent>
-          <p className="max-w-[400px] break-all">{row.original.url}</p>
-        </TooltipContent>
-      </Tooltip>
-    ),
-  },
-  {
-    id: 'type',
-    header: 'Type',
-    cell: ({ row }) => {
-      const ext = extractExtension(row.original.fileName);
-      return ext ? <Badge variant="outline">{ext}</Badge> : null;
+function getColumns(t: Translate): ColumnDef<DownloadView>[] {
+  return [
+    {
+      id: 'select',
+      header: ({ table }) => (
+        <Checkbox
+          checked={table.getIsAllRowsSelected()}
+          onCheckedChange={(checked) => table.toggleAllRowsSelected(!!checked)}
+          aria-label={t('downloads.table.selectAll')}
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(checked) => row.toggleSelected(!!checked)}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={t('downloads.table.selectRow')}
+        />
+      ),
+      enableSorting: false,
     },
-  },
-  {
-    id: 'host',
-    header: 'Host',
-    cell: ({ row }) => (
-      <span className="text-xs text-muted-foreground">
-        {extractHostname(row.original.url)}
-      </span>
-    ),
-  },
-  {
-    accessorKey: 'progressPercent',
-    header: 'Progress',
-    cell: ({ row }) => <ProgressCell download={row.original} />,
-  },
-  {
-    id: 'speed',
-    header: 'Speed',
-    cell: ({ row }) => <SpeedCell downloadId={row.original.id} />,
-    enableSorting: false,
-  },
-  {
-    id: 'eta',
-    header: 'ETA',
-    cell: ({ row }) => <EtaCell downloadId={row.original.id} />,
-    enableSorting: false,
-  },
-  {
-    id: 'actions',
-    header: '',
-    cell: ({ row }) => <ActionCell download={row.original} />,
-    enableSorting: false,
-  },
-];
+    {
+      accessorKey: 'state',
+      header: t('downloads.table.columns.state'),
+      cell: ({ row }) => <StateIndicator state={row.original.state} />,
+    },
+    {
+      accessorKey: 'fileName',
+      header: t('downloads.table.columns.fileName'),
+      cell: ({ row }) => (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="block max-w-[200px] truncate">
+              {row.original.fileName}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="max-w-[400px] break-all">{row.original.url}</p>
+          </TooltipContent>
+        </Tooltip>
+      ),
+    },
+    {
+      id: 'type',
+      header: t('downloads.table.columns.type'),
+      cell: ({ row }) => {
+        const ext = extractExtension(row.original.fileName);
+        return ext ? <Badge variant="outline">{ext}</Badge> : null;
+      },
+    },
+    {
+      id: 'host',
+      header: t('downloads.table.columns.host'),
+      cell: ({ row }) => (
+        <span className="text-xs text-muted-foreground">
+          {extractHostname(row.original.url)}
+        </span>
+      ),
+    },
+    {
+      accessorKey: 'progressPercent',
+      header: t('downloads.table.columns.progress'),
+      cell: ({ row }) => <ProgressCell download={row.original} />,
+    },
+    {
+      id: 'speed',
+      header: t('downloads.table.columns.speed'),
+      cell: ({ row }) => <SpeedCell downloadId={row.original.id} />,
+      enableSorting: false,
+    },
+    {
+      id: 'eta',
+      header: t('downloads.table.columns.eta'),
+      cell: ({ row }) => <EtaCell downloadId={row.original.id} />,
+      enableSorting: false,
+    },
+    {
+      id: 'actions',
+      header: '',
+      cell: ({ row }) => <ActionCell download={row.original} t={t} />,
+      enableSorting: false,
+    },
+  ];
+}
 
 export function DownloadsTable({
   downloads,
@@ -279,6 +285,7 @@ export function DownloadsTable({
   const { t } = useTranslation();
   const [sorting, setSorting] = useState<SortingState>([]);
   const tableContainerRef = useRef<HTMLDivElement>(null);
+  const columns = useMemo(() => getColumns(t), [t]);
 
   const invalidateKeys = useMemo(() => [downloadQueries.lists(), downloadQueries.countByState()] as const, []);
   const pauseMut = useTauriMutation<unknown, { id: string }>('download_pause', { invalidateKeys });

--- a/src/views/DownloadsView/DownloadsTable.tsx
+++ b/src/views/DownloadsView/DownloadsTable.tsx
@@ -7,6 +7,7 @@ import {
 } from '@tanstack/react-table';
 import type { ColumnDef, SortingState } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
+import { useTranslation } from 'react-i18next';
 import {
   Pause,
   Play,
@@ -275,6 +276,7 @@ export function DownloadsTable({
   filter,
   searchQuery,
 }: DownloadsTableProps) {
+  const { t } = useTranslation();
   const [sorting, setSorting] = useState<SortingState>([]);
   const tableContainerRef = useRef<HTMLDivElement>(null);
 
@@ -376,7 +378,7 @@ export function DownloadsTable({
   if (isLoading) {
     return (
       <div className="flex flex-1 items-center justify-center">
-        <span className="text-sm text-muted-foreground">Loading...</span>
+        <span className="text-sm text-muted-foreground">{t('downloads.loading')}</span>
       </div>
     );
   }
@@ -384,7 +386,7 @@ export function DownloadsTable({
   if (filteredDownloads.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center">
-        <span className="text-sm text-muted-foreground">No downloads</span>
+        <span className="text-sm text-muted-foreground">{t('downloads.empty')}</span>
       </div>
     );
   }

--- a/src/views/DownloadsView/FilterBar.tsx
+++ b/src/views/DownloadsView/FilterBar.tsx
@@ -1,13 +1,14 @@
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { useTranslation } from 'react-i18next';
 import type { FilterType, FilterConfig } from './types';
 
 const FILTERS: FilterConfig[] = [
-  { type: 'all', label: 'All' },
-  { type: 'active', label: 'Active', states: ['Downloading', 'Queued'] },
-  { type: 'queued', label: 'Queued', states: ['Queued'] },
-  { type: 'done', label: 'Done', states: ['Completed'] },
-  { type: 'failed', label: 'Failed', states: ['Error', 'Retry'] },
+  { type: 'all', labelKey: 'downloads.filters.all' },
+  { type: 'active', labelKey: 'downloads.filters.active', states: ['Downloading', 'Queued'] },
+  { type: 'queued', labelKey: 'downloads.filters.queued', states: ['Queued'] },
+  { type: 'done', labelKey: 'downloads.filters.done', states: ['Completed'] },
+  { type: 'failed', labelKey: 'downloads.filters.failed', states: ['Error', 'Retry'] },
 ];
 
 interface FilterBarProps {
@@ -26,6 +27,8 @@ function getFilterCount(filter: FilterConfig, counts: Record<string, number> | u
 }
 
 export function FilterBar({ activeFilter, onFilterChange, counts }: FilterBarProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="flex gap-1.5 border-b pb-2">
       {FILTERS.map((filter) => (
@@ -35,7 +38,7 @@ export function FilterBar({ activeFilter, onFilterChange, counts }: FilterBarPro
           size="sm"
           onClick={() => onFilterChange(filter.type)}
         >
-          {filter.label}
+          {t(filter.labelKey)}
           <Badge variant="secondary" className="ml-1.5">
             {getFilterCount(filter, counts)}
           </Badge>

--- a/src/views/DownloadsView/__tests__/ActionsBar.test.tsx
+++ b/src/views/DownloadsView/__tests__/ActionsBar.test.tsx
@@ -44,4 +44,13 @@ describe('ActionsBar', () => {
     await user.click(screen.getByText('Clear'));
     expect(useUiStore.getState().selectedDownloadIds).toEqual([]);
   });
+
+  it('should use the singular French label when one item is selected', () => {
+    window.localStorage.setItem('i18nextLng', 'fr');
+    useUiStore.setState({ selectedDownloadIds: ['1'] });
+
+    renderWithQuery(<ActionsBar />);
+
+    expect(screen.getByText('1 sélectionné')).toBeInTheDocument();
+  });
 });

--- a/src/views/DownloadsView/__tests__/DownloadsTable.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsTable.test.tsx
@@ -167,6 +167,36 @@ describe('DownloadsTable', () => {
     expect(screen.getByText('ETA')).toBeInTheDocument();
   });
 
+  it('should render French column headers when locale is fr', () => {
+    window.localStorage.setItem('i18nextLng', 'fr');
+
+    renderTable();
+
+    expect(screen.getByText('Nom du fichier')).toBeInTheDocument();
+    expect(screen.getByText('État')).toBeInTheDocument();
+    expect(screen.getByText('Type')).toBeInTheDocument();
+    expect(screen.getByText('Hôte')).toBeInTheDocument();
+    expect(screen.getByText('Progression')).toBeInTheDocument();
+    expect(screen.getByText('Vitesse')).toBeInTheDocument();
+    expect(screen.getByText('Temps restant')).toBeInTheDocument();
+  });
+
+  it('should render French action menu labels when locale is fr', async () => {
+    window.localStorage.setItem('i18nextLng', 'fr');
+    const user = userEvent.setup();
+
+    renderTable();
+
+    await user.click(screen.getAllByLabelText('Plus d’actions')[0]);
+    await user.click(screen.getByText('Définir la priorité'));
+
+    expect(screen.getByText('Définir la priorité')).toBeInTheDocument();
+    expect(screen.getByText('Haute')).toBeInTheDocument();
+    expect(screen.getByText('Normale')).toBeInTheDocument();
+    expect(screen.getByText('Basse')).toBeInTheDocument();
+    expect(screen.getByText('Supprimer')).toBeInTheDocument();
+  });
+
   it('should extract and show file type badge', () => {
     renderTable();
     expect(screen.getByText('ZIP')).toBeInTheDocument();

--- a/src/views/DownloadsView/types.ts
+++ b/src/views/DownloadsView/types.ts
@@ -4,6 +4,6 @@ export type FilterType = 'all' | 'active' | 'queued' | 'done' | 'failed';
 
 export interface FilterConfig {
   type: FilterType;
-  label: string;
+  labelKey: string;
   states?: DownloadState[];
 }

--- a/src/views/HistoryView.tsx
+++ b/src/views/HistoryView.tsx
@@ -1,13 +1,6 @@
 import { History } from "lucide-react";
+import { PlaceholderView } from "./PlaceholderView";
 
 export function HistoryView() {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-4">
-      <History className="h-16 w-16 text-muted-foreground" />
-      <div className="text-center">
-        <h1 className="text-2xl font-bold">History</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Coming soon</p>
-      </div>
-    </div>
-  );
+  return <PlaceholderView icon={History} titleKey="nav.history" />;
 }

--- a/src/views/LinkGrabberView/ActionsBar.tsx
+++ b/src/views/LinkGrabberView/ActionsBar.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { useTranslation } from "react-i18next";
 
 interface ActionsBarProps {
   selectedCount: number;
@@ -17,21 +18,23 @@ export function ActionsBar({
   onClearAll,
   onSelectAll,
 }: ActionsBarProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="flex gap-2">
       <Button onClick={onSelectAll} variant="outline" size="sm">
-        Select All ({totalCount})
+        {t("linkGrabber.actions.selectAll", { count: totalCount })}
       </Button>
       {selectedCount > 0 && (
         <Button onClick={onStartSelected} size="sm">
-          Start Selected ({selectedCount})
+          {t("linkGrabber.actions.startSelected", { count: selectedCount })}
         </Button>
       )}
       <Button onClick={onStartAll} variant="secondary" size="sm">
-        Start All Online
+        {t("linkGrabber.actions.startAllOnline")}
       </Button>
       <Button onClick={onClearAll} variant="destructive" size="sm">
-        Clear
+        {t("common.clear")}
       </Button>
     </div>
   );

--- a/src/views/LinkGrabberView/FilterBar.tsx
+++ b/src/views/LinkGrabberView/FilterBar.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { useTranslation } from "react-i18next";
 import type { FilterType } from "./types";
 
 interface FilterBarProps {
@@ -7,11 +8,12 @@ interface FilterBarProps {
 }
 
 export function FilterBar({ activeFilter, onFilterChange }: FilterBarProps) {
+  const { t } = useTranslation();
   const filters: { type: FilterType; label: string }[] = [
-    { type: "all", label: "All" },
-    { type: "online", label: "Online" },
-    { type: "offline", label: "Offline" },
-    { type: "media", label: "Media" },
+    { type: "all", label: t("linkGrabber.filters.all") },
+    { type: "online", label: t("linkGrabber.filters.online") },
+    { type: "offline", label: t("linkGrabber.filters.offline") },
+    { type: "media", label: t("linkGrabber.filters.media") },
   ];
 
   return (

--- a/src/views/LinkGrabberView/LinkGrabberView.tsx
+++ b/src/views/LinkGrabberView/LinkGrabberView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Switch } from "@/components/ui/switch";
 import { useTauriMutation } from "@/api/hooks";
 import { tauriInvoke } from "@/api/client";
@@ -13,6 +14,7 @@ import type { ResolvedLink, FilterType, GroupingMode } from "./types";
 import type { MediaGrabberOptions } from "@/types/media";
 
 export function LinkGrabberView() {
+  const { t } = useTranslation();
   const [resolvedLinks, setResolvedLinks] = useState<ResolvedLink[]>([]);
   const [resolveError, setResolveError] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterType>("all");
@@ -98,10 +100,10 @@ export function LinkGrabberView() {
   return (
     <div className="flex h-full flex-col gap-4 p-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-lg font-bold">Link Grabber</h1>
-        <div className="flex items-center gap-2" title="Coming in a future update">
+        <h1 className="text-lg font-bold">{t("nav.linkGrabber")}</h1>
+        <div className="flex items-center gap-2" title={t("linkGrabber.clipboardComingSoon")}>
           <label className="text-sm" htmlFor="clipboard-toggle">
-            Clipboard Monitoring
+            {t("linkGrabber.clipboardMonitoringLabel")}
           </label>
           <Switch
             id="clipboard-toggle"

--- a/src/views/LinkGrabberView/PackageGrouping.tsx
+++ b/src/views/LinkGrabberView/PackageGrouping.tsx
@@ -5,6 +5,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useTranslation } from "react-i18next";
 import type { GroupingMode } from "./types";
 
 interface PackageGroupingProps {
@@ -13,20 +14,22 @@ interface PackageGroupingProps {
 }
 
 export function PackageGrouping({ mode, onModeChange }: PackageGroupingProps) {
+  const { t } = useTranslation();
+
   return (
     <div className="flex items-center gap-2">
       <label id="grouping-label" className="text-sm font-semibold">
-        Group Into Packages:
+        {t("linkGrabber.grouping.label")}
       </label>
       <Select value={mode} onValueChange={(v) => onModeChange(v as GroupingMode)}>
         <SelectTrigger className="w-40" aria-labelledby="grouping-label">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="none">No Grouping</SelectItem>
-          <SelectItem value="hostname">By Hostname</SelectItem>
-          <SelectItem value="extension">By Extension</SelectItem>
-          <SelectItem value="type">By Type</SelectItem>
+          <SelectItem value="none">{t("linkGrabber.grouping.none")}</SelectItem>
+          <SelectItem value="hostname">{t("linkGrabber.grouping.hostname")}</SelectItem>
+          <SelectItem value="extension">{t("linkGrabber.grouping.extension")}</SelectItem>
+          <SelectItem value="type">{t("linkGrabber.grouping.type")}</SelectItem>
         </SelectContent>
       </Select>
     </div>

--- a/src/views/LinkGrabberView/PasteZone.tsx
+++ b/src/views/LinkGrabberView/PasteZone.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 
 interface PasteZoneProps {
@@ -19,6 +20,7 @@ export function PasteZone({
   isLoading,
   errorMessage,
 }: PasteZoneProps) {
+  const { t } = useTranslation();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -84,20 +86,20 @@ export function PasteZone({
       <textarea
         ref={textareaRef}
         className="h-32 w-full resize-none rounded border bg-background p-3 text-sm focus:outline-none focus:ring-2 focus:ring-accent"
-        placeholder="Paste URLs here (one per line)…"
+        placeholder={t("linkGrabber.pastePlaceholder")}
       />
       <div className="mt-3 flex gap-2">
         <Button variant="outline" onClick={handleClear}>
-          Clear
+          {t("common.clear")}
         </Button>
         <Button onClick={handleAnalyze} disabled={isLoading}>
-          {isLoading ? "Resolving…" : "Analyze Links"}
+          {isLoading ? t("linkGrabber.resolving") : t("linkGrabber.analyze")}
         </Button>
       </div>
       {errorMessage && (
         <div className="mt-3 space-y-1" role="alert">
           <p className="text-sm text-destructive">
-            Failed to analyze links. Please try again.
+            {t("linkGrabber.analyzeFailed")}
           </p>
           <p className="text-xs text-muted-foreground">{errorMessage}</p>
         </div>

--- a/src/views/PackagesView.tsx
+++ b/src/views/PackagesView.tsx
@@ -1,13 +1,6 @@
 import { Package } from "lucide-react";
+import { PlaceholderView } from "./PlaceholderView";
 
 export function PackagesView() {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-4">
-      <Package className="h-16 w-16 text-muted-foreground" />
-      <div className="text-center">
-        <h1 className="text-2xl font-bold">Packages</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Coming soon</p>
-      </div>
-    </div>
-  );
+  return <PlaceholderView icon={Package} titleKey="nav.packages" />;
 }

--- a/src/views/PlaceholderView.tsx
+++ b/src/views/PlaceholderView.tsx
@@ -1,9 +1,18 @@
 import type { LucideIcon } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
+type PlaceholderNavKey =
+  | "accounts"
+  | "captcha"
+  | "history"
+  | "packages"
+  | "plugins"
+  | "scheduler"
+  | "statistics";
+
 interface PlaceholderViewProps {
   icon: LucideIcon;
-  titleKey: string;
+  titleKey: `nav.${PlaceholderNavKey}`;
 }
 
 export function PlaceholderView({ icon: Icon, titleKey }: PlaceholderViewProps) {

--- a/src/views/PlaceholderView.tsx
+++ b/src/views/PlaceholderView.tsx
@@ -1,0 +1,21 @@
+import type { LucideIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface PlaceholderViewProps {
+  icon: LucideIcon;
+  titleKey: string;
+}
+
+export function PlaceholderView({ icon: Icon, titleKey }: PlaceholderViewProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-4">
+      <Icon className="h-16 w-16 text-muted-foreground" />
+      <div className="text-center">
+        <h1 className="text-2xl font-bold">{t(titleKey)}</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{t("common.comingSoon")}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -1,13 +1,6 @@
 import { Puzzle } from "lucide-react";
+import { PlaceholderView } from "./PlaceholderView";
 
 export function PluginsView() {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-4">
-      <Puzzle className="h-16 w-16 text-muted-foreground" />
-      <div className="text-center">
-        <h1 className="text-2xl font-bold">Plugins</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Coming soon</p>
-      </div>
-    </div>
-  );
+  return <PlaceholderView icon={Puzzle} titleKey="nav.plugins" />;
 }

--- a/src/views/SchedulerView.tsx
+++ b/src/views/SchedulerView.tsx
@@ -1,13 +1,6 @@
 import { Clock } from "lucide-react";
+import { PlaceholderView } from "./PlaceholderView";
 
 export function SchedulerView() {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-4">
-      <Clock className="h-16 w-16 text-muted-foreground" />
-      <div className="text-center">
-        <h1 className="text-2xl font-bold">Scheduler</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Coming soon</p>
-      </div>
-    </div>
-  );
+  return <PlaceholderView icon={Clock} titleKey="nav.scheduler" />;
 }

--- a/src/views/StatisticsView.tsx
+++ b/src/views/StatisticsView.tsx
@@ -1,13 +1,6 @@
 import { BarChart3 } from "lucide-react";
+import { PlaceholderView } from "./PlaceholderView";
 
 export function StatisticsView() {
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-4">
-      <BarChart3 className="h-16 w-16 text-muted-foreground" />
-      <div className="text-center">
-        <h1 className="text-2xl font-bold">Statistics</h1>
-        <p className="mt-1 text-sm text-muted-foreground">Coming soon</p>
-      </div>
-    </div>
-  );
+  return <PlaceholderView icon={BarChart3} titleKey="nav.statistics" />;
 }


### PR DESCRIPTION
Closes #30

## Summary

• localize the remaining downloads, link grabber, status bar, and placeholder UI strings
• add missing English and French translation keys and reuse a shared placeholder view
• add a French UI regression test and make the test i18n mock language-aware

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes UI i18n coverage for the app, addressing #30. All remaining UI strings now use EN/FR keys with pluralization and interpolation across Downloads, Link Grabber, Status Bar/Clipboard, and shared placeholder views.

- **New Features**
  - Downloads: localized table headers, aria labels (select all/row, more actions), row menus (priority labels, remove), filters, actions, selected count, and empty/loading.
  - Link Grabber: localized title (`nav.linkGrabber`), clipboard label/tooltip, paste placeholder, analyze/resolving/error messages, filters, actions with counts, and package grouping labels.
  - Status bar and Clipboard: localized limit/free space templates, active count (pluralized), clipboard label/tooltips using `statusBar.*` and `common.unlimited`.
  - Shared `PlaceholderView` for Accounts, Packages, Plugins, Captcha, Scheduler, History, and Statistics using `nav.*` titles and `common.comingSoon`.

- **Tests**
  - Added French UI regression test covering Downloads, Link Grabber, Status Bar, and placeholder views.
  - New assertions for French plurals (e.g., “1 actif”, “1 sélectionné”) and Downloads table/menu labels.
  - Updated the i18n test mock to read `i18nextLng`, support interpolation/pluralization, and allow language switching within tests.

<sup>Written for commit f2512b9b95ff51a06e232ce276366f7e86bb6116. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many English and French UI strings, including new sections, status bar labels, link grabber and downloads copy with pluralization and interpolation.

* **Refactor**
  * Replaced numerous hardcoded placeholders with a reusable placeholder view and updated visible UI text to use localization keys.

* **Tests**
  * Added and updated tests to verify French translations, pluralization, and language switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->