### PR TITLE
fix: add missing global keyboard shortcuts

### DIFF
--- a/src/i18n/__tests__/issue30-ui-fr.test.tsx
+++ b/src/i18n/__tests__/issue30-ui-fr.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, cleanup } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { useDownloadStore } from "@/stores/downloadStore";
 import { useLayoutStore } from "@/stores/layout-store";
@@ -45,7 +46,9 @@ function renderWithProviders(
   const content = options.tooltip ? <TooltipProvider>{ui}</TooltipProvider> : ui;
 
   return render(
-    <QueryClientProvider client={createQueryClient()}>{content}</QueryClientProvider>,
+    <QueryClientProvider client={createQueryClient()}>
+      <MemoryRouter>{content}</MemoryRouter>
+    </QueryClientProvider>,
   );
 }
 

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,17 +1,24 @@
 import { useEffect } from "react";
-import { Outlet, useNavigate } from "react-router";
+import { Outlet, useLocation, useNavigate } from "react-router";
 import { Sidebar } from "./Sidebar";
 import { StatusBar } from "./StatusBar";
 import { ROUTES } from "@/types/layout";
 import { useDownloadProgress } from "@/hooks/useDownloadProgress";
 import { useDownloadEvents } from "@/hooks/useDownloadEvents";
 import { useAppEffects } from "@/hooks/useAppEffects";
+import { tauriInvoke } from "@/api/client";
 import { useTauriQuery } from "@/api/hooks";
 import { useSettingsStore } from "@/stores/settingsStore";
+import { useUiStore } from "@/stores/uiStore";
+import {
+  SHORTCUT_ACTIONS,
+  dispatchShortcutAction,
+} from "@/lib/keyboardShortcuts";
 import type { AppConfig } from "@/types/settings";
 
 export function AppLayout() {
   const navigate = useNavigate();
+  const location = useLocation();
   const setConfig = useSettingsStore((s) => s.setConfig);
   useDownloadProgress();
   useDownloadEvents();
@@ -30,15 +37,85 @@ export function AppLayout() {
   }, [config, setConfig]);
 
   useEffect(() => {
-    function handleKeydown(event: KeyboardEvent) {
-      const modifier = navigator.platform.includes("Mac") ? event.metaKey : event.ctrlKey;
-      if (!modifier) return;
-
-      const target = event.target;
-      if (
+    function isEditableTarget(target: EventTarget | null) {
+      return (
         target instanceof HTMLElement &&
-        (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)
+        (target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable)
+      );
+    }
+
+    function handleKeydown(event: KeyboardEvent) {
+      if (
+        event.key === "Escape" &&
+        useUiStore.getState().detailsPanelOpen
       ) {
+        event.preventDefault();
+        useUiStore.getState().setDetailsPanelOpen(false);
+        return;
+      }
+
+      const modifier = navigator.platform.includes("Mac") ? event.metaKey : event.ctrlKey;
+      if (!modifier) {
+        if (isEditableTarget(event.target)) return;
+
+        if (
+          location.pathname === "/downloads" &&
+          (event.key === " " || event.code === "Space")
+        ) {
+          event.preventDefault();
+          dispatchShortcutAction(SHORTCUT_ACTIONS.downloadsToggleSelected);
+          return;
+        }
+
+        if (
+          location.pathname === "/downloads" &&
+          (event.key === "Delete" || event.key === "Backspace")
+        ) {
+          event.preventDefault();
+          dispatchShortcutAction(SHORTCUT_ACTIONS.downloadsRemoveSelected);
+        }
+        return;
+      }
+
+      if (isEditableTarget(event.target)) return;
+
+      const lowerKey = event.key.toLowerCase();
+
+      if (event.shiftKey && lowerKey === "p") {
+        event.preventDefault();
+        const currentConfig = useSettingsStore.getState().config;
+        const nextEnabled = !(currentConfig?.clipboardMonitoring ?? false);
+        void tauriInvoke<boolean>("clipboard_toggle", { enabled: nextEnabled }).then(
+          (confirmed) => {
+            const latestConfig = useSettingsStore.getState().config;
+            if (latestConfig) {
+              setConfig({ ...latestConfig, clipboardMonitoring: confirmed });
+            }
+          },
+        );
+        return;
+      }
+
+      if (lowerKey === "f" && location.pathname === "/downloads") {
+        event.preventDefault();
+        dispatchShortcutAction(SHORTCUT_ACTIONS.downloadsFocusSearch);
+        return;
+      }
+
+      if (lowerKey === "n") {
+        event.preventDefault();
+        void navigate("/link-grabber", {
+          replace: location.pathname === "/link-grabber",
+          state: { focusPaste: true },
+        });
+        return;
+      }
+
+      if (lowerKey === "a" && location.pathname === "/downloads") {
+        event.preventDefault();
+        dispatchShortcutAction(SHORTCUT_ACTIONS.downloadsSelectAll);
         return;
       }
 
@@ -57,7 +134,7 @@ export function AppLayout() {
 
     window.addEventListener("keydown", handleKeydown);
     return () => window.removeEventListener("keydown", handleKeydown);
-  }, [navigate]);
+  }, [location.pathname, navigate, setConfig]);
 
   return (
     <div className="flex h-screen w-screen overflow-hidden font-mono text-[13px] leading-normal text-text">

--- a/src/layouts/__tests__/AppLayout.test.tsx
+++ b/src/layouts/__tests__/AppLayout.test.tsx
@@ -1,11 +1,51 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { invoke } from "@tauri-apps/api/core";
 import { AppLayout } from "../AppLayout";
+import { useUiStore } from "@/stores/uiStore";
+import { useSettingsStore } from "@/stores/settingsStore";
+import type { AppConfig } from "@/types/settings";
 
 const mockNavigate = vi.fn();
 const originalPlatform = navigator.platform;
+const mockInvoke = vi.mocked(invoke);
+
+const baseConfig: AppConfig = {
+  downloadDir: null,
+  maxConcurrentDownloads: 3,
+  maxSegmentsPerDownload: 8,
+  speedLimitBytesPerSec: null,
+  autoExtract: false,
+  theme: "dark",
+  locale: "en",
+  clipboardMonitoring: false,
+  startMinimized: false,
+  notificationsEnabled: true,
+  soundEnabled: false,
+  confirmDelete: true,
+  subfolderPerPackage: false,
+  maxRetries: 3,
+  retryDelaySeconds: 5,
+  verifyChecksums: true,
+  preAllocateSpace: false,
+  proxyType: "none",
+  proxyUrl: null,
+  userAgent: "Vortex/1.0",
+  dnsOverHttps: false,
+  connectionTimeoutSeconds: 30,
+  webInterfaceEnabled: false,
+  webInterfacePort: 9666,
+  restApiEnabled: false,
+  apiKey: "",
+  websocketEnabled: false,
+  minFileSizeMb: 1,
+  excludedDomains: [],
+  excludedExtensions: [],
+  accentColor: "#4F46E5",
+  compactMode: false,
+};
 
 vi.mock("@/hooks/useDownloadProgress", () => ({
   useDownloadProgress: vi.fn(),
@@ -41,6 +81,7 @@ function renderAppLayout(initialRoute = "/downloads") {
         <Routes>
           <Route element={<AppLayout />}>
             <Route path="downloads" element={<div>Downloads Page</div>} />
+            <Route path="link-grabber" element={<div>Link Grabber Page</div>} />
             <Route path="settings" element={<div>Settings Page</div>} />
           </Route>
         </Routes>
@@ -52,6 +93,24 @@ function renderAppLayout(initialRoute = "/downloads") {
 describe("AppLayout", () => {
   beforeEach(() => {
     mockNavigate.mockClear();
+    mockInvoke.mockReset();
+    mockInvoke.mockImplementation(async (command: string) => {
+      if (command === "settings_get") {
+        return { ...baseConfig };
+      }
+      return undefined;
+    });
+    useUiStore.setState({
+      selectedDownloadId: null,
+      selectedDownloadIds: [],
+      detailsPanelOpen: false,
+      filterBarExpanded: false,
+    });
+    useSettingsStore.setState({
+      config: { ...baseConfig },
+      isLoading: false,
+      error: null,
+    });
   });
 
   afterEach(() => {
@@ -92,5 +151,60 @@ describe("AppLayout", () => {
     renderAppLayout();
     fireEvent.keyDown(window, { key: "1" });
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("should dispatch downloads focus shortcut on Ctrl+F", () => {
+    const shortcutSpy = vi.fn();
+    const listener = (event: Event) => {
+      shortcutSpy((event as CustomEvent<string>).detail);
+    };
+
+    window.addEventListener("vortex:shortcut-action", listener as EventListener);
+
+    try {
+      renderAppLayout();
+      fireEvent.keyDown(window, { key: "f", ctrlKey: true });
+      expect(shortcutSpy).toHaveBeenCalledWith("downloads.focus-search");
+    } finally {
+      window.removeEventListener("vortex:shortcut-action", listener as EventListener);
+    }
+  });
+
+  it("should navigate to link grabber on Ctrl+N", () => {
+    renderAppLayout();
+
+    fireEvent.keyDown(window, { key: "n", ctrlKey: true });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/link-grabber", {
+      replace: false,
+      state: { focusPaste: true },
+    });
+  });
+
+  it("should toggle clipboard monitoring on Ctrl+Shift+P", async () => {
+    mockInvoke.mockResolvedValue(true);
+    renderAppLayout();
+
+    fireEvent.keyDown(window, { key: "P", ctrlKey: true, shiftKey: true });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith("clipboard_toggle", {
+        enabled: true,
+      });
+    });
+  });
+
+  it("should close the details panel on Escape", () => {
+    useUiStore.setState({
+      selectedDownloadId: "download-1",
+      selectedDownloadIds: ["download-1"],
+      detailsPanelOpen: true,
+      filterBarExpanded: false,
+    });
+
+    renderAppLayout();
+    fireEvent.keyDown(window, { key: "Escape" });
+
+    expect(useUiStore.getState().detailsPanelOpen).toBe(false);
   });
 });

--- a/src/lib/keyboardShortcuts.ts
+++ b/src/lib/keyboardShortcuts.ts
@@ -10,6 +10,13 @@ export const SHORTCUT_ACTIONS = {
 export type ShortcutAction =
   (typeof SHORTCUT_ACTIONS)[keyof typeof SHORTCUT_ACTIONS];
 
+function isShortcutAction(value: unknown): value is ShortcutAction {
+  return (
+    typeof value === 'string' &&
+    Object.values(SHORTCUT_ACTIONS).includes(value as ShortcutAction)
+  );
+}
+
 export function dispatchShortcutAction(action: ShortcutAction) {
   window.dispatchEvent(
     new CustomEvent<ShortcutAction>(SHORTCUT_ACTION_EVENT, {
@@ -22,7 +29,12 @@ export function subscribeShortcutAction(
   handler: (action: ShortcutAction) => void,
 ) {
   const listener = (event: Event) => {
-    handler((event as CustomEvent<ShortcutAction>).detail);
+    if (!(event instanceof CustomEvent)) return;
+
+    const detail = (event as CustomEvent<unknown>).detail;
+    if (isShortcutAction(detail)) {
+      handler(detail);
+    }
   };
 
   window.addEventListener(SHORTCUT_ACTION_EVENT, listener as EventListener);

--- a/src/lib/keyboardShortcuts.ts
+++ b/src/lib/keyboardShortcuts.ts
@@ -1,0 +1,35 @@
+export const SHORTCUT_ACTION_EVENT = 'vortex:shortcut-action';
+
+export const SHORTCUT_ACTIONS = {
+  downloadsFocusSearch: 'downloads.focus-search',
+  downloadsSelectAll: 'downloads.select-all',
+  downloadsToggleSelected: 'downloads.toggle-selected',
+  downloadsRemoveSelected: 'downloads.remove-selected',
+} as const;
+
+export type ShortcutAction =
+  (typeof SHORTCUT_ACTIONS)[keyof typeof SHORTCUT_ACTIONS];
+
+export function dispatchShortcutAction(action: ShortcutAction) {
+  window.dispatchEvent(
+    new CustomEvent<ShortcutAction>(SHORTCUT_ACTION_EVENT, {
+      detail: action,
+    }),
+  );
+}
+
+export function subscribeShortcutAction(
+  handler: (action: ShortcutAction) => void,
+) {
+  const listener = (event: Event) => {
+    handler((event as CustomEvent<ShortcutAction>).detail);
+  };
+
+  window.addEventListener(SHORTCUT_ACTION_EVENT, listener as EventListener);
+  return () => {
+    window.removeEventListener(
+      SHORTCUT_ACTION_EVENT,
+      listener as EventListener,
+    );
+  };
+}

--- a/src/views/DownloadsView/DownloadsTable.tsx
+++ b/src/views/DownloadsView/DownloadsTable.tsx
@@ -55,6 +55,12 @@ interface DownloadsTableProps {
   searchQuery?: string;
 }
 
+interface FilterDownloadsOptions {
+  downloadsAreFiltered?: boolean;
+  filter?: FilterType;
+  searchQuery?: string;
+}
+
 const STATE_FILTER_MAP: Record<FilterType, DownloadState[] | null> = {
   all: null,
   active: ['Downloading', 'Queued'],
@@ -75,6 +81,38 @@ function extractHostname(url: string): string {
   } catch {
     return '\u2014';
   }
+}
+
+export function filterDownloads(
+  downloads: DownloadView[],
+  {
+    downloadsAreFiltered = false,
+    filter = 'all',
+    searchQuery = '',
+  }: FilterDownloadsOptions = {},
+) {
+  if (downloadsAreFiltered) {
+    return downloads;
+  }
+
+  let result = downloads;
+
+  const allowedStates = STATE_FILTER_MAP[filter];
+  if (allowedStates) {
+    result = result.filter((download) => allowedStates.includes(download.state));
+  }
+
+  if (!searchQuery) {
+    return result;
+  }
+
+  const query = searchQuery.toLowerCase();
+  return result.filter(
+    (download) =>
+      download.fileName.toLowerCase().includes(query) ||
+      download.url.toLowerCase().includes(query) ||
+      extractHostname(download.url).toLowerCase().includes(query),
+  );
 }
 
 interface RowActions {
@@ -312,32 +350,15 @@ export function DownloadsTable({
   );
   const clearSelection = useUiStore((s) => s.clearSelection);
 
-  const filteredDownloads = useMemo(() => {
-    if (downloadsAreFiltered) {
-      return downloads;
-    }
-
-    let result = downloads;
-
-    const allowedStates = STATE_FILTER_MAP[filter];
-    if (allowedStates) {
-      result = result.filter((d) =>
-        allowedStates.includes(d.state),
-      );
-    }
-
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      result = result.filter(
-        (d) =>
-          d.fileName.toLowerCase().includes(query) ||
-          d.url.toLowerCase().includes(query) ||
-          extractHostname(d.url).toLowerCase().includes(query),
-      );
-    }
-
-    return result;
-  }, [downloads, downloadsAreFiltered, filter, searchQuery]);
+  const filteredDownloads = useMemo(
+    () =>
+      filterDownloads(downloads, {
+        downloadsAreFiltered,
+        filter,
+        searchQuery,
+      }),
+    [downloads, downloadsAreFiltered, filter, searchQuery],
+  );
 
   const rowSelection = useMemo(() => {
     const selectedSet = new Set(selectedDownloadIds);

--- a/src/views/DownloadsView/DownloadsTable.tsx
+++ b/src/views/DownloadsView/DownloadsTable.tsx
@@ -49,9 +49,10 @@ type Translate = (key: string, options?: Record<string, unknown>) => string;
 
 interface DownloadsTableProps {
   downloads: DownloadView[];
+  downloadsAreFiltered?: boolean;
   isLoading: boolean;
-  filter: FilterType;
-  searchQuery: string;
+  filter?: FilterType;
+  searchQuery?: string;
 }
 
 const STATE_FILTER_MAP: Record<FilterType, DownloadState[] | null> = {
@@ -278,9 +279,10 @@ function getColumns(t: Translate): ColumnDef<DownloadView>[] {
 
 export function DownloadsTable({
   downloads,
+  downloadsAreFiltered = false,
   isLoading,
-  filter,
-  searchQuery,
+  filter = 'all',
+  searchQuery = '',
 }: DownloadsTableProps) {
   const { t } = useTranslation();
   const [sorting, setSorting] = useState<SortingState>([]);
@@ -311,6 +313,10 @@ export function DownloadsTable({
   const clearSelection = useUiStore((s) => s.clearSelection);
 
   const filteredDownloads = useMemo(() => {
+    if (downloadsAreFiltered) {
+      return downloads;
+    }
+
     let result = downloads;
 
     const allowedStates = STATE_FILTER_MAP[filter];
@@ -331,7 +337,7 @@ export function DownloadsTable({
     }
 
     return result;
-  }, [downloads, filter, searchQuery]);
+  }, [downloads, downloadsAreFiltered, filter, searchQuery]);
 
   const rowSelection = useMemo(() => {
     const selectedSet = new Set(selectedDownloadIds);

--- a/src/views/DownloadsView/DownloadsView.tsx
+++ b/src/views/DownloadsView/DownloadsView.tsx
@@ -9,7 +9,7 @@ import type { FilterType } from './types';
 import { SearchBar } from './SearchBar';
 import { FilterBar } from './FilterBar';
 import { ActionsBar } from './ActionsBar';
-import { DownloadsTable } from './DownloadsTable';
+import { DownloadsTable, filterDownloads } from './DownloadsTable';
 import { DownloadDetailsPanel } from '../DownloadDetailsPanel';
 
 const INVALIDATE_KEYS = [
@@ -20,7 +20,9 @@ const INVALIDATE_KEYS = [
 export function DownloadsView() {
   const [filter, setFilter] = useState<FilterType>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const selectedDownloadId = useUiStore((s) => s.selectedDownloadId);
   const selectedDownloadIds = useUiStore((s) => s.selectedDownloadIds);
+  const selectDownload = useUiStore((s) => s.selectDownload);
   const setSelectedDownloadIds = useUiStore((s) => s.setSelectedDownloadIds);
   const clearSelection = useUiStore((s) => s.clearSelection);
 
@@ -51,80 +53,83 @@ export function DownloadsView() {
 
   const filteredDownloads = useMemo(
     () =>
-      (downloads ?? []).filter((download) => {
-        if (
-          filter === 'active' &&
-          !['Downloading', 'Queued'].includes(download.state)
-        ) {
-          return false;
-        }
-
-        if (filter === 'queued' && download.state !== 'Queued') {
-          return false;
-        }
-
-        if (filter === 'done' && download.state !== 'Completed') {
-          return false;
-        }
-
-        if (
-          filter === 'failed' &&
-          !['Error', 'Retry'].includes(download.state)
-        ) {
-          return false;
-        }
-
-        if (!searchQuery) return true;
-
-        const query = searchQuery.toLowerCase();
-        let hostname = '';
-        try {
-          hostname = new URL(download.url).hostname.toLowerCase();
-        } catch {
-          hostname = '';
-        }
-
-        return (
-          download.fileName.toLowerCase().includes(query) ||
-          download.url.toLowerCase().includes(query) ||
-          hostname.includes(query)
-        );
+      filterDownloads(downloads ?? [], {
+        filter,
+        searchQuery,
       }),
     [downloads, filter, searchQuery],
   );
 
-  const handleToggleSelected = useCallback(async () => {
-    if (selectedDownloadIds.length === 0) return;
+  const visibleSelectedDownloadIds = useMemo(() => {
+    const visibleIds = new Set(filteredDownloads.map((download) => download.id));
+    return selectedDownloadIds.filter((id) => visibleIds.has(id));
+  }, [filteredDownloads, selectedDownloadIds]);
 
-    const selectedSet = new Set(selectedDownloadIds);
-    const selectedDownloads = (downloads ?? []).filter((download) =>
-      selectedSet.has(download.id),
+  const visibleSelectedDownloads = useMemo(() => {
+    const visibleSelectedSet = new Set(visibleSelectedDownloadIds);
+    return filteredDownloads.filter((download) =>
+      visibleSelectedSet.has(download.id),
     );
+  }, [filteredDownloads, visibleSelectedDownloadIds]);
+
+  useEffect(() => {
+    const selectionChanged =
+      selectedDownloadIds.length !== visibleSelectedDownloadIds.length ||
+      selectedDownloadIds.some(
+        (id, index) => id !== visibleSelectedDownloadIds[index],
+      );
+
+    if (selectionChanged) {
+      setSelectedDownloadIds(visibleSelectedDownloadIds);
+    }
+
+    if (
+      selectedDownloadId &&
+      !visibleSelectedDownloadIds.includes(selectedDownloadId)
+    ) {
+      selectDownload(null);
+    }
+  }, [
+    selectedDownloadId,
+    selectedDownloadIds,
+    selectDownload,
+    setSelectedDownloadIds,
+    visibleSelectedDownloadIds,
+  ]);
+
+  const handleToggleSelected = useCallback(async () => {
+    if (visibleSelectedDownloads.length === 0) return;
 
     const tasks = [
-      ...selectedDownloads
+      ...visibleSelectedDownloads
         .filter((download) =>
           download.state === 'Downloading' || download.state === 'Queued',
         )
         .map((download) => pauseMut.mutateAsync({ id: download.id })),
-      ...selectedDownloads
+      ...visibleSelectedDownloads
         .filter((download) => download.state === 'Paused')
         .map((download) => resumeMut.mutateAsync({ id: download.id })),
     ];
 
     if (tasks.length === 0) return;
     await Promise.allSettled(tasks);
-  }, [downloads, pauseMut, resumeMut, selectedDownloadIds]);
+  }, [pauseMut, resumeMut, visibleSelectedDownloads]);
 
   const handleRemoveSelected = useCallback(async () => {
-    if (selectedDownloadIds.length === 0) return;
+    if (visibleSelectedDownloadIds.length === 0) return;
 
-    const snapshot = [...selectedDownloadIds];
+    const snapshot = [...visibleSelectedDownloadIds];
     const results = await Promise.allSettled(
       snapshot.map((id) => removeMut.mutateAsync({ id, deleteFiles: false })),
     );
-    const failedIds = snapshot.filter((_, index) => results[index].status === 'rejected');
-    const currentIds = useUiStore.getState().selectedDownloadIds;
+    const failedIds = snapshot.filter(
+      (_, index) => results[index].status === 'rejected',
+    );
+    const currentState = useUiStore.getState();
+    const snapshotSet = new Set(snapshot);
+    const currentIds = currentState.selectedDownloadIds.filter((id) =>
+      snapshotSet.has(id),
+    );
     const unchanged =
       currentIds.length === snapshot.length &&
       currentIds.every((id, index) => id === snapshot[index]);
@@ -137,7 +142,19 @@ export function DownloadsView() {
     }
 
     setSelectedDownloadIds(failedIds);
-  }, [clearSelection, removeMut, selectedDownloadIds, setSelectedDownloadIds]);
+    if (
+      currentState.selectedDownloadId &&
+      !failedIds.includes(currentState.selectedDownloadId)
+    ) {
+      selectDownload(null);
+    }
+  }, [
+    clearSelection,
+    removeMut,
+    selectDownload,
+    setSelectedDownloadIds,
+    visibleSelectedDownloadIds,
+  ]);
 
   useEffect(() => {
     return subscribeShortcutAction((action) => {

--- a/src/views/DownloadsView/DownloadsView.tsx
+++ b/src/views/DownloadsView/DownloadsView.tsx
@@ -85,11 +85,12 @@ export function DownloadsView() {
 
     if (
       selectedDownloadId &&
-      !visibleSelectedDownloadIds.includes(selectedDownloadId)
+      !filteredDownloads.some((download) => download.id === selectedDownloadId)
     ) {
       selectDownload(null);
     }
   }, [
+    filteredDownloads,
     selectedDownloadId,
     selectedDownloadIds,
     selectDownload,
@@ -118,21 +119,25 @@ export function DownloadsView() {
   const handleRemoveSelected = useCallback(async () => {
     if (visibleSelectedDownloadIds.length === 0) return;
 
-    const snapshot = [...visibleSelectedDownloadIds];
+    const selectionSnapshot = {
+      ids: [...visibleSelectedDownloadIds],
+      activeId: useUiStore.getState().selectedDownloadId,
+    };
     const results = await Promise.allSettled(
-      snapshot.map((id) => removeMut.mutateAsync({ id, deleteFiles: false })),
+      selectionSnapshot.ids.map((id) =>
+        removeMut.mutateAsync({ id, deleteFiles: false }),
+      ),
     );
-    const failedIds = snapshot.filter(
+    const failedIds = selectionSnapshot.ids.filter(
       (_, index) => results[index].status === 'rejected',
     );
     const currentState = useUiStore.getState();
-    const snapshotSet = new Set(snapshot);
-    const currentIds = currentState.selectedDownloadIds.filter((id) =>
-      snapshotSet.has(id),
-    );
     const unchanged =
-      currentIds.length === snapshot.length &&
-      currentIds.every((id, index) => id === snapshot[index]);
+      currentState.selectedDownloadId === selectionSnapshot.activeId &&
+      currentState.selectedDownloadIds.length === selectionSnapshot.ids.length &&
+      currentState.selectedDownloadIds.every(
+        (id, index) => id === selectionSnapshot.ids[index],
+      );
 
     if (!unchanged) return;
 

--- a/src/views/DownloadsView/DownloadsView.tsx
+++ b/src/views/DownloadsView/DownloadsView.tsx
@@ -1,7 +1,10 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useTauriQuery } from '@/api/hooks';
+import { useTauriMutation } from '@/api/hooks';
 import { downloadQueries } from '@/api/queries';
 import { useDownloadProgress } from '@/hooks/useDownloadProgress';
+import { subscribeShortcutAction, SHORTCUT_ACTIONS } from '@/lib/keyboardShortcuts';
+import { useUiStore } from '@/stores/uiStore';
 import type { DownloadView } from '@/types/download';
 import type { FilterType } from './types';
 import { SearchBar } from './SearchBar';
@@ -10,11 +13,30 @@ import { ActionsBar } from './ActionsBar';
 import { DownloadsTable } from './DownloadsTable';
 import { DownloadDetailsPanel } from '../DownloadDetailsPanel';
 
+const INVALIDATE_KEYS = [
+  downloadQueries.lists(),
+  downloadQueries.countByState(),
+] as const;
+
 export function DownloadsView() {
   const [filter, setFilter] = useState<FilterType>('all');
   const [searchQuery, setSearchQuery] = useState('');
+  const selectedDownloadIds = useUiStore((s) => s.selectedDownloadIds);
+  const setSelectedDownloadIds = useUiStore((s) => s.setSelectedDownloadIds);
+  const clearSelection = useUiStore((s) => s.clearSelection);
 
   useDownloadProgress();
+
+  const pauseMut = useTauriMutation<void, { id: string }>('download_pause', {
+    invalidateKeys: INVALIDATE_KEYS,
+  });
+  const resumeMut = useTauriMutation<void, { id: string }>('download_resume', {
+    invalidateKeys: INVALIDATE_KEYS,
+  });
+  const removeMut = useTauriMutation<void, { id: string; deleteFiles: boolean }>(
+    'download_remove',
+    { invalidateKeys: INVALIDATE_KEYS },
+  );
 
   const { data: downloads, isLoading } = useTauriQuery<DownloadView[]>(
     'download_list',
@@ -27,6 +49,121 @@ export function DownloadsView() {
     undefined,
     { queryKey: downloadQueries.countByState(), staleTime: 2000 },
   );
+
+  const filteredDownloads = (downloads ?? []).filter((download) => {
+    if (
+      filter === 'active' &&
+      !['Downloading', 'Queued'].includes(download.state)
+    ) {
+      return false;
+    }
+
+    if (filter === 'queued' && download.state !== 'Queued') {
+      return false;
+    }
+
+    if (filter === 'done' && download.state !== 'Completed') {
+      return false;
+    }
+
+    if (filter === 'failed' && !['Error', 'Retry'].includes(download.state)) {
+      return false;
+    }
+
+    if (!searchQuery) return true;
+
+    const query = searchQuery.toLowerCase();
+    let hostname = '';
+    try {
+      hostname = new URL(download.url).hostname.toLowerCase();
+    } catch {
+      hostname = '';
+    }
+
+    return (
+      download.fileName.toLowerCase().includes(query) ||
+      download.url.toLowerCase().includes(query) ||
+      hostname.includes(query)
+    );
+  });
+
+  const handleToggleSelected = useCallback(async () => {
+    if (selectedDownloadIds.length === 0) return;
+
+    const selectedSet = new Set(selectedDownloadIds);
+    const selectedDownloads = (downloads ?? []).filter((download) =>
+      selectedSet.has(download.id),
+    );
+
+    const tasks = [
+      ...selectedDownloads
+        .filter((download) =>
+          download.state === 'Downloading' || download.state === 'Queued',
+        )
+        .map((download) => pauseMut.mutateAsync({ id: download.id })),
+      ...selectedDownloads
+        .filter((download) => download.state === 'Paused')
+        .map((download) => resumeMut.mutateAsync({ id: download.id })),
+    ];
+
+    if (tasks.length === 0) return;
+    await Promise.allSettled(tasks);
+  }, [downloads, pauseMut, resumeMut, selectedDownloadIds]);
+
+  const handleRemoveSelected = useCallback(async () => {
+    if (selectedDownloadIds.length === 0) return;
+
+    const snapshot = [...selectedDownloadIds];
+    const results = await Promise.allSettled(
+      snapshot.map((id) => removeMut.mutateAsync({ id, deleteFiles: false })),
+    );
+    const failedIds = snapshot.filter((_, index) => results[index].status === 'rejected');
+    const currentIds = useUiStore.getState().selectedDownloadIds;
+    const unchanged =
+      currentIds.length === snapshot.length &&
+      currentIds.every((id, index) => id === snapshot[index]);
+
+    if (!unchanged) return;
+
+    if (failedIds.length === 0) {
+      clearSelection();
+      return;
+    }
+
+    setSelectedDownloadIds(failedIds);
+  }, [clearSelection, removeMut, selectedDownloadIds, setSelectedDownloadIds]);
+
+  useEffect(() => {
+    return subscribeShortcutAction((action) => {
+      switch (action) {
+        case SHORTCUT_ACTIONS.downloadsFocusSearch: {
+          const input = document.querySelector<HTMLInputElement>(
+            '[data-shortcut-target="downloads-search"]',
+          );
+          input?.focus();
+          input?.select();
+          return;
+        }
+        case SHORTCUT_ACTIONS.downloadsSelectAll:
+          setSelectedDownloadIds(filteredDownloads.map((download) => download.id));
+          return;
+        case SHORTCUT_ACTIONS.downloadsToggleSelected:
+          void handleToggleSelected();
+          return;
+        case SHORTCUT_ACTIONS.downloadsRemoveSelected:
+          void handleRemoveSelected();
+          return;
+        default:
+          return;
+      }
+    });
+  }, [
+    clearSelection,
+    filteredDownloads,
+    handleRemoveSelected,
+    handleToggleSelected,
+    setSelectedDownloadIds,
+  ]);
 
   return (
     <div className="flex h-full">

--- a/src/views/DownloadsView/DownloadsView.tsx
+++ b/src/views/DownloadsView/DownloadsView.tsx
@@ -1,6 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useTauriQuery } from '@/api/hooks';
-import { useTauriMutation } from '@/api/hooks';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTauriMutation, useTauriQuery } from '@/api/hooks';
 import { downloadQueries } from '@/api/queries';
 import { useDownloadProgress } from '@/hooks/useDownloadProgress';
 import { subscribeShortcutAction, SHORTCUT_ACTIONS } from '@/lib/keyboardShortcuts';
@@ -50,42 +49,49 @@ export function DownloadsView() {
     { queryKey: downloadQueries.countByState(), staleTime: 2000 },
   );
 
-  const filteredDownloads = (downloads ?? []).filter((download) => {
-    if (
-      filter === 'active' &&
-      !['Downloading', 'Queued'].includes(download.state)
-    ) {
-      return false;
-    }
+  const filteredDownloads = useMemo(
+    () =>
+      (downloads ?? []).filter((download) => {
+        if (
+          filter === 'active' &&
+          !['Downloading', 'Queued'].includes(download.state)
+        ) {
+          return false;
+        }
 
-    if (filter === 'queued' && download.state !== 'Queued') {
-      return false;
-    }
+        if (filter === 'queued' && download.state !== 'Queued') {
+          return false;
+        }
 
-    if (filter === 'done' && download.state !== 'Completed') {
-      return false;
-    }
+        if (filter === 'done' && download.state !== 'Completed') {
+          return false;
+        }
 
-    if (filter === 'failed' && !['Error', 'Retry'].includes(download.state)) {
-      return false;
-    }
+        if (
+          filter === 'failed' &&
+          !['Error', 'Retry'].includes(download.state)
+        ) {
+          return false;
+        }
 
-    if (!searchQuery) return true;
+        if (!searchQuery) return true;
 
-    const query = searchQuery.toLowerCase();
-    let hostname = '';
-    try {
-      hostname = new URL(download.url).hostname.toLowerCase();
-    } catch {
-      hostname = '';
-    }
+        const query = searchQuery.toLowerCase();
+        let hostname = '';
+        try {
+          hostname = new URL(download.url).hostname.toLowerCase();
+        } catch {
+          hostname = '';
+        }
 
-    return (
-      download.fileName.toLowerCase().includes(query) ||
-      download.url.toLowerCase().includes(query) ||
-      hostname.includes(query)
-    );
-  });
+        return (
+          download.fileName.toLowerCase().includes(query) ||
+          download.url.toLowerCase().includes(query) ||
+          hostname.includes(query)
+        );
+      }),
+    [downloads, filter, searchQuery],
+  );
 
   const handleToggleSelected = useCallback(async () => {
     if (selectedDownloadIds.length === 0) return;
@@ -158,7 +164,6 @@ export function DownloadsView() {
       }
     });
   }, [
-    clearSelection,
     filteredDownloads,
     handleRemoveSelected,
     handleToggleSelected,
@@ -176,7 +181,8 @@ export function DownloadsView() {
         />
         <ActionsBar />
         <DownloadsTable
-          downloads={downloads ?? []}
+          downloads={filteredDownloads}
+          downloadsAreFiltered
           isLoading={isLoading}
           filter={filter}
           searchQuery={searchQuery}

--- a/src/views/DownloadsView/SearchBar.tsx
+++ b/src/views/DownloadsView/SearchBar.tsx
@@ -14,6 +14,7 @@ export function SearchBar({ value, onChange }: SearchBarProps) {
     <div className="relative">
       <Search className="absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
       <Input
+        data-shortcut-target="downloads-search"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={t('downloads.searchPlaceholder')}

--- a/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
@@ -4,6 +4,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { invoke } from '@tauri-apps/api/core';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { downloadQueries } from '@/api/queries';
+import {
+  SHORTCUT_ACTION_EVENT,
+  SHORTCUT_ACTIONS,
+} from '@/lib/keyboardShortcuts';
 import { DownloadsView } from '../DownloadsView';
 import { useUiStore } from '@/stores/uiStore';
 import type { DownloadView } from '@/types/download';
@@ -143,8 +147,8 @@ describe('DownloadsView', () => {
 
     const input = await screen.findByPlaceholderText('Search downloads...');
     window.dispatchEvent(
-      new CustomEvent('vortex:shortcut-action', {
-        detail: 'downloads.focus-search',
+      new CustomEvent(SHORTCUT_ACTION_EVENT, {
+        detail: SHORTCUT_ACTIONS.downloadsFocusSearch,
       }),
     );
 
@@ -157,8 +161,8 @@ describe('DownloadsView', () => {
 
     await act(async () => {
       window.dispatchEvent(
-        new CustomEvent('vortex:shortcut-action', {
-          detail: 'downloads.select-all',
+        new CustomEvent(SHORTCUT_ACTION_EVENT, {
+          detail: SHORTCUT_ACTIONS.downloadsSelectAll,
         }),
       );
     });
@@ -181,8 +185,8 @@ describe('DownloadsView', () => {
 
     await act(async () => {
       window.dispatchEvent(
-        new CustomEvent('vortex:shortcut-action', {
-          detail: 'downloads.toggle-selected',
+        new CustomEvent(SHORTCUT_ACTION_EVENT, {
+          detail: SHORTCUT_ACTIONS.downloadsToggleSelected,
         }),
       );
     });
@@ -206,8 +210,8 @@ describe('DownloadsView', () => {
 
     await act(async () => {
       window.dispatchEvent(
-        new CustomEvent('vortex:shortcut-action', {
-          detail: 'downloads.remove-selected',
+        new CustomEvent(SHORTCUT_ACTION_EVENT, {
+          detail: SHORTCUT_ACTIONS.downloadsRemoveSelected,
         }),
       );
     });

--- a/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
@@ -262,6 +262,26 @@ describe('DownloadsView', () => {
     expect(mockInvoke).not.toHaveBeenCalledWith('download_resume', { id: '2' });
   });
 
+  it('should keep the active details selection when it remains visible after filtering', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({
+      selectedDownloadId: '1',
+      selectedDownloadIds: ['2'],
+      detailsPanelOpen: true,
+      filterBarExpanded: false,
+    });
+
+    renderWithProviders();
+    await screen.findByPlaceholderText('Search downloads...');
+
+    await user.click(screen.getByRole('button', { name: /Active/i }));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().selectedDownloadIds).toEqual([]);
+      expect(useUiStore.getState().selectedDownloadId).toBe('1');
+    });
+  });
+
   it('should clear the active details selection when partial removals succeed', async () => {
     useUiStore.setState({
       selectedDownloadId: '1',
@@ -325,6 +345,100 @@ describe('DownloadsView', () => {
     await waitFor(() => {
       expect(useUiStore.getState().selectedDownloadIds).toEqual(['2']);
       expect(useUiStore.getState().selectedDownloadId).toBeNull();
+    });
+  });
+
+  it('should ignore stale remove results when only the active details selection changes', async () => {
+    let resolveFirstRemoval: (() => void) | undefined;
+    let resolveSecondRemoval: (() => void) | undefined;
+
+    useUiStore.setState({
+      selectedDownloadId: '1',
+      selectedDownloadIds: ['1', '2'],
+      detailsPanelOpen: true,
+      filterBarExpanded: false,
+    });
+    mockInvoke.mockImplementation(
+      async (command: string, args?: unknown) => {
+        const payload =
+          args && typeof args === 'object' ? (args as { id?: string }) : {};
+        switch (command) {
+          case 'query_download_detail':
+            return {
+              id: '1',
+              fileName: 'file1.zip',
+              url: 'https://example.com/file1.zip',
+              downloadPath: '/tmp/file1.zip',
+              tempPath: '/tmp/file1.zip.part',
+              state: 'Downloading',
+              totalBytes: 10000,
+              downloadedBytes: 4200,
+              progressPercent: 42,
+              speedBytesPerSec: 1024,
+              etaSeconds: 10,
+              segmentsActive: 2,
+              segmentsTotal: 4,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              moduleName: null,
+              accountName: null,
+              checksum: null,
+              mimeType: null,
+              referrer: null,
+              userAgent: null,
+              logs: [],
+              segments: [],
+            };
+          case 'download_remove':
+            if (payload.id === '1') {
+              await new Promise<void>((resolve) => {
+                resolveFirstRemoval = resolve;
+              });
+              return undefined;
+            }
+            if (payload.id === '2') {
+              await new Promise<void>((resolve) => {
+                resolveSecondRemoval = resolve;
+              });
+              throw new Error('remove failed');
+            }
+            return undefined;
+          default:
+            return undefined;
+        }
+      },
+    );
+
+    renderWithProviders();
+    await screen.findByPlaceholderText('Search downloads...');
+
+    const removal = act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(SHORTCUT_ACTION_EVENT, {
+          detail: SHORTCUT_ACTIONS.downloadsRemoveSelected,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(resolveFirstRemoval).toBeTypeOf('function');
+      expect(resolveSecondRemoval).toBeTypeOf('function');
+    });
+
+    useUiStore.setState({
+      selectedDownloadId: '2',
+      selectedDownloadIds: ['1', '2'],
+      detailsPanelOpen: true,
+      filterBarExpanded: false,
+    });
+
+    resolveFirstRemoval?.();
+    resolveSecondRemoval?.();
+    await removal;
+
+    await waitFor(() => {
+      expect(useUiStore.getState().selectedDownloadIds).toEqual(['1', '2']);
+      expect(useUiStore.getState().selectedDownloadId).toBe('2');
     });
   });
 });

--- a/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
@@ -1,15 +1,57 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { invoke } from '@tauri-apps/api/core';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { downloadQueries } from '@/api/queries';
 import { DownloadsView } from '../DownloadsView';
+import { useUiStore } from '@/stores/uiStore';
+import type { DownloadView } from '@/types/download';
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn().mockResolvedValue([]),
+  invoke: vi.fn(),
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn().mockResolvedValue(vi.fn()),
 }));
+
+const mockInvoke = vi.mocked(invoke);
+
+const mockDownloads: DownloadView[] = [
+  {
+    id: '1',
+    fileName: 'file1.zip',
+    url: 'https://example.com/file1.zip',
+    state: 'Downloading',
+    progressPercent: 42,
+    speedBytesPerSec: 1024,
+    downloadedBytes: 4200,
+    totalBytes: 10000,
+    etaSeconds: 10,
+    segmentsActive: 2,
+    segmentsTotal: 4,
+    moduleName: null,
+    accountName: null,
+    createdAt: Date.now(),
+  },
+  {
+    id: '2',
+    fileName: 'file2.zip',
+    url: 'https://example.com/file2.zip',
+    state: 'Paused',
+    progressPercent: 50,
+    speedBytesPerSec: 0,
+    downloadedBytes: 5000,
+    totalBytes: 10000,
+    etaSeconds: null,
+    segmentsActive: 0,
+    segmentsTotal: 4,
+    moduleName: null,
+    accountName: null,
+    createdAt: Date.now(),
+  },
+];
 
 function renderWithProviders() {
   const queryClient = new QueryClient({
@@ -18,16 +60,66 @@ function renderWithProviders() {
       mutations: { retry: false },
     },
   });
+  queryClient.setQueryData(downloadQueries.lists(), mockDownloads);
+  queryClient.setQueryData(downloadQueries.countByState(), {
+    total: mockDownloads.length,
+    Downloading: 1,
+    Paused: 1,
+  });
   return render(
     <QueryClientProvider client={queryClient}>
-      <div style={{ height: '600px' }}>
-        <DownloadsView />
-      </div>
+      <TooltipProvider>
+        <div style={{ height: '600px' }}>
+          <DownloadsView />
+        </div>
+      </TooltipProvider>
     </QueryClientProvider>,
   );
 }
 
 describe('DownloadsView', () => {
+  beforeEach(() => {
+    mockInvoke.mockReset();
+    mockInvoke.mockImplementation(async (command: string) => {
+      switch (command) {
+        case 'query_download_detail':
+          return {
+            id: '1',
+            fileName: 'file1.zip',
+            url: 'https://example.com/file1.zip',
+            downloadPath: '/tmp/file1.zip',
+            tempPath: '/tmp/file1.zip.part',
+            state: 'Downloading',
+            totalBytes: 10000,
+            downloadedBytes: 4200,
+            progressPercent: 42,
+            speedBytesPerSec: 1024,
+            etaSeconds: 10,
+            segmentsActive: 2,
+            segmentsTotal: 4,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+            moduleName: null,
+            accountName: null,
+            checksum: null,
+            mimeType: null,
+            referrer: null,
+            userAgent: null,
+            logs: [],
+            segments: [],
+          };
+        default:
+          return undefined;
+      }
+    });
+    useUiStore.setState({
+      selectedDownloadId: null,
+      selectedDownloadIds: [],
+      detailsPanelOpen: false,
+      filterBarExpanded: false,
+    });
+  });
+
   it('should render search bar', () => {
     renderWithProviders();
     expect(screen.getByPlaceholderText('Search downloads...')).toBeInTheDocument();
@@ -44,5 +136,91 @@ describe('DownloadsView', () => {
     renderWithProviders();
     expect(screen.getByText('Pause All')).toBeInTheDocument();
     expect(screen.getByText('Resume All')).toBeInTheDocument();
+  });
+
+  it('should focus the search input when the global shortcut event is dispatched', async () => {
+    renderWithProviders();
+
+    const input = await screen.findByPlaceholderText('Search downloads...');
+    window.dispatchEvent(
+      new CustomEvent('vortex:shortcut-action', {
+        detail: 'downloads.focus-search',
+      }),
+    );
+
+    expect(input).toHaveFocus();
+  });
+
+  it('should select all downloads when the global shortcut event is dispatched', async () => {
+    renderWithProviders();
+    await screen.findByPlaceholderText('Search downloads...');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('vortex:shortcut-action', {
+          detail: 'downloads.select-all',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(useUiStore.getState().selectedDownloadIds).toEqual(['1', '2']);
+    });
+  });
+
+  it('should pause active downloads and resume paused downloads when the space shortcut event is dispatched', async () => {
+    useUiStore.setState({
+      selectedDownloadId: null,
+      selectedDownloadIds: ['1', '2'],
+      detailsPanelOpen: false,
+      filterBarExpanded: false,
+    });
+
+    renderWithProviders();
+    await screen.findByPlaceholderText('Search downloads...');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('vortex:shortcut-action', {
+          detail: 'downloads.toggle-selected',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('download_pause', { id: '1' });
+      expect(mockInvoke).toHaveBeenCalledWith('download_resume', { id: '2' });
+    });
+  });
+
+  it('should remove selected downloads when the delete shortcut event is dispatched', async () => {
+    useUiStore.setState({
+      selectedDownloadId: null,
+      selectedDownloadIds: ['1', '2'],
+      detailsPanelOpen: false,
+      filterBarExpanded: false,
+    });
+
+    renderWithProviders();
+    await screen.findByPlaceholderText('Search downloads...');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent('vortex:shortcut-action', {
+          detail: 'downloads.remove-selected',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('download_remove', {
+        id: '1',
+        deleteFiles: false,
+      });
+      expect(mockInvoke).toHaveBeenCalledWith('download_remove', {
+        id: '2',
+        deleteFiles: false,
+      });
+    });
   });
 });

--- a/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { invoke } from '@tauri-apps/api/core';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -225,6 +226,105 @@ describe('DownloadsView', () => {
         id: '2',
         deleteFiles: false,
       });
+    });
+  });
+
+  it('should limit shortcut actions to the visible selection after filtering', async () => {
+    const user = userEvent.setup();
+    useUiStore.setState({
+      selectedDownloadId: '2',
+      selectedDownloadIds: ['1', '2'],
+      detailsPanelOpen: true,
+      filterBarExpanded: false,
+    });
+
+    renderWithProviders();
+    await screen.findByPlaceholderText('Search downloads...');
+
+    await user.click(screen.getByRole('button', { name: /Active/i }));
+
+    await waitFor(() => {
+      expect(useUiStore.getState().selectedDownloadIds).toEqual(['1']);
+      expect(useUiStore.getState().selectedDownloadId).toBeNull();
+    });
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(SHORTCUT_ACTION_EVENT, {
+          detail: SHORTCUT_ACTIONS.downloadsToggleSelected,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('download_pause', { id: '1' });
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith('download_resume', { id: '2' });
+  });
+
+  it('should clear the active details selection when partial removals succeed', async () => {
+    useUiStore.setState({
+      selectedDownloadId: '1',
+      selectedDownloadIds: ['1', '2'],
+      detailsPanelOpen: true,
+      filterBarExpanded: false,
+    });
+    mockInvoke.mockImplementation(
+      async (command: string, args?: unknown) => {
+        const payload =
+          args && typeof args === 'object' ? (args as { id?: string }) : {};
+        switch (command) {
+          case 'query_download_detail':
+            return {
+              id: '1',
+              fileName: 'file1.zip',
+              url: 'https://example.com/file1.zip',
+              downloadPath: '/tmp/file1.zip',
+              tempPath: '/tmp/file1.zip.part',
+              state: 'Downloading',
+              totalBytes: 10000,
+              downloadedBytes: 4200,
+              progressPercent: 42,
+              speedBytesPerSec: 1024,
+              etaSeconds: 10,
+              segmentsActive: 2,
+              segmentsTotal: 4,
+              createdAt: Date.now(),
+              updatedAt: Date.now(),
+              moduleName: null,
+              accountName: null,
+              checksum: null,
+              mimeType: null,
+              referrer: null,
+              userAgent: null,
+              logs: [],
+              segments: [],
+            };
+          case 'download_remove':
+            if (payload.id === '2') {
+              throw new Error('remove failed');
+            }
+            return undefined;
+          default:
+            return undefined;
+        }
+      },
+    );
+
+    renderWithProviders();
+    await screen.findByPlaceholderText('Search downloads...');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(SHORTCUT_ACTION_EVENT, {
+          detail: SHORTCUT_ACTIONS.downloadsRemoveSelected,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(useUiStore.getState().selectedDownloadIds).toEqual(['2']);
+      expect(useUiStore.getState().selectedDownloadId).toBeNull();
     });
   });
 });

--- a/src/views/LinkGrabberView/LinkGrabberView.tsx
+++ b/src/views/LinkGrabberView/LinkGrabberView.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useLocation, useNavigate } from "react-router";
 import { Switch } from "@/components/ui/switch";
 import { useTauriMutation } from "@/api/hooks";
 import { tauriInvoke } from "@/api/client";
@@ -15,6 +16,8 @@ import type { MediaGrabberOptions } from "@/types/media";
 
 export function LinkGrabberView() {
   const { t } = useTranslation();
+  const location = useLocation();
+  const navigate = useNavigate();
   const [resolvedLinks, setResolvedLinks] = useState<ResolvedLink[]>([]);
   const [resolveError, setResolveError] = useState<string | null>(null);
   const [filter, setFilter] = useState<FilterType>("all");
@@ -96,6 +99,22 @@ export function LinkGrabberView() {
       });
     }
   };
+
+  useEffect(() => {
+    const shouldFocusPaste =
+      !!location.state &&
+      typeof location.state === "object" &&
+      "focusPaste" in location.state &&
+      location.state.focusPaste === true;
+
+    if (!shouldFocusPaste) return;
+
+    const textarea = document.querySelector<HTMLTextAreaElement>(
+      '[data-shortcut-target="link-grabber-paste"]',
+    );
+    textarea?.focus();
+    void navigate(location.pathname, { replace: true, state: null });
+  }, [location.pathname, location.state, navigate]);
 
   return (
     <div className="flex h-full flex-col gap-4 p-4">

--- a/src/views/LinkGrabberView/PasteZone.tsx
+++ b/src/views/LinkGrabberView/PasteZone.tsx
@@ -84,6 +84,7 @@ export function PasteZone({
       onDrop={handleDrop}
     >
       <textarea
+        data-shortcut-target="link-grabber-paste"
         ref={textareaRef}
         className="h-32 w-full resize-none rounded border bg-background p-3 text-sm focus:outline-none focus:ring-2 focus:ring-accent"
         placeholder={t("linkGrabber.pastePlaceholder")}

--- a/src/views/LinkGrabberView/__tests__/LinkGrabberView.test.tsx
+++ b/src/views/LinkGrabberView/__tests__/LinkGrabberView.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, it, expect, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router";
 import { invoke } from "@tauri-apps/api/core";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { LinkGrabberView } from "../LinkGrabberView";
@@ -16,7 +17,7 @@ vi.mock("@tauri-apps/api/event", () => ({
 
 const mockInvoke = vi.mocked(invoke);
 
-function renderWithProviders() {
+function renderWithProviders(initialEntry: string | { pathname: string; state?: unknown } = "/link-grabber") {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -25,9 +26,11 @@ function renderWithProviders() {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <LinkGrabberView />
-      </TooltipProvider>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <TooltipProvider>
+          <LinkGrabberView />
+        </TooltipProvider>
+      </MemoryRouter>
     </QueryClientProvider>,
   );
 }
@@ -190,6 +193,17 @@ describe("LinkGrabberView", () => {
       expect(
         screen.queryByRole("button", { name: "All" }),
       ).not.toBeInTheDocument();
+    });
+  });
+
+  it("should focus the paste textarea when opened from the global add-urls shortcut", async () => {
+    renderWithProviders({
+      pathname: "/link-grabber",
+      state: { focusPaste: true },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveFocus();
     });
   });
 });


### PR DESCRIPTION
## Summary

• add the missing global shortcuts for downloads actions, clipboard toggle, and escape handling
• route shortcut intent into Downloads and Link Grabber views for focus, selection, pause/resume, remove, and add-URLs flow
• extend frontend tests for keyboard coverage and fix the French Link Grabber i18n test to render inside a router

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing global keyboard shortcuts for managing downloads, toggling clipboard monitoring, and opening `Link Grabber` with focus. Addresses Linear issue #31 with scoped handlers and expanded tests.

- **New Features**
  - Esc closes the details panel.
  - Downloads: Ctrl/Cmd+F focus search; Ctrl/Cmd+A select visible; Space toggles pause/resume for selected; Delete/Backspace remove selected.
  - Navigation: Ctrl/Cmd+N opens `Link Grabber` and auto-focuses the paste area (via route state).
  - Clipboard: Ctrl/Cmd+Shift+P toggles monitoring and persists via `clipboard_toggle`.
  - Added a lightweight shortcut bus (`vortex:shortcut-action`) via `keyboardShortcuts`, with handlers in `AppLayout` and `DownloadsView`; moved filtering into `DownloadsView` and added `downloadsAreFiltered` to `DownloadsTable` to keep selection/actions scoped to visible items.

- **Bug Fixes**
  - Shortcuts are ignored when typing in inputs, textareas, or contenteditable.
  - Bulk remove handles partial failures and preserves selection intent; paste area focus in `Link Grabber` occurs once and clears route state.
  - Fixed the French Link Grabber i18n test by rendering inside a router.

<sup>Written for commit b86664027ee3ee6ab239111dd8557d223dd15480. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global keyboard shortcuts: Ctrl/Cmd+F (search), Ctrl/Cmd+A (select all), Space (toggle), Delete/Backspace (remove), Escape (close details).
  * Ctrl/Cmd+N navigates to Link Grabber and auto-focuses the paste area; Ctrl/Cmd+Shift+P toggles clipboard monitoring.
  * Bulk download actions (pause/resume/remove) operate only on visible/filtered items and handle partial failures gracefully.

* **Tests**
  * Expanded tests for shortcuts, navigation-focus, selection behavior, and native-side effects.

* **Other**
  * Search and paste fields annotated as shortcut targets; downloads table accepts pre-filtered data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->