### PR TITLE
fix(core): prevent CQRS state divergence when download engine fails

### DIFF
--- a/src-tauri/src/application/services/queue_manager.rs
+++ b/src-tauri/src/application/services/queue_manager.rs
@@ -142,7 +142,11 @@ impl QueueManager {
         self.on_slot_freed().await
     }
 
-    pub async fn handle_download_failed(self: &Arc<Self>, id: DownloadId) -> Result<(), AppError> {
+    pub async fn handle_download_failed(
+        self: &Arc<Self>,
+        id: DownloadId,
+        error: String,
+    ) -> Result<(), AppError> {
         // Single find_by_id — avoids TOCTOU from double read
         let mut download = match self.download_repo.find_by_id(id)? {
             Some(d) => d,
@@ -164,6 +168,22 @@ impl QueueManager {
                 | DownloadState::Extracting
         ) {
             self.safe_decrement();
+            // Persist the Error state before attempting retry. The engine
+            // already emitted DownloadFailed to the Tauri bridge (UI update),
+            // but SQLite must be updated too to prevent the CQRS divergence
+            // where the download stays stuck as Downloading indefinitely.
+            match download.fail(error) {
+                Ok(_) => {
+                    self.download_repo.save(&download)?;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        download_id = id.0,
+                        error = %e,
+                        "handle_download_failed: unexpected fail() transition error"
+                    );
+                }
+            }
         }
 
         match download.retry() {
@@ -180,6 +200,7 @@ impl QueueManager {
                 Ok(())
             }
             Err(DomainError::MaxRetriesExceeded { .. }) => {
+                // Error state already persisted above via fail() — nothing more to save.
                 self.on_slot_freed().await?;
                 Ok(())
             }
@@ -251,8 +272,8 @@ impl QueueManager {
                     DomainEvent::DownloadCompleted { .. }
                     | DomainEvent::DownloadPaused { .. }
                     | DomainEvent::DownloadCancelled { .. } => self.decrement_and_schedule().await,
-                    DomainEvent::DownloadFailed { id, .. } => {
-                        self.handle_download_failed(*id).await
+                    DomainEvent::DownloadFailed { id, error } => {
+                        self.handle_download_failed(*id, error.clone()).await
                     }
                     DomainEvent::DownloadCreated { .. } | DomainEvent::DownloadRetrying { .. } => {
                         self.on_slot_freed().await
@@ -579,7 +600,9 @@ mod tests {
             1,
         );
 
-        qm.handle_download_failed(DownloadId(1)).await.unwrap();
+        qm.handle_download_failed(DownloadId(1), "circuit breaker".to_string())
+            .await
+            .unwrap();
 
         // Download should remain in Error state
         let saved = repo.find_by_id(DownloadId(1)).unwrap().unwrap();
@@ -646,7 +669,9 @@ mod tests {
             1,
         );
 
-        qm.handle_download_failed(DownloadId(1)).await.unwrap();
+        qm.handle_download_failed(DownloadId(1), "rollback".to_string())
+            .await
+            .unwrap();
 
         // No decrement — download was already Error (rollback), active stays 1
         assert_eq!(qm.active_count(), 1);
@@ -654,5 +679,76 @@ mod tests {
         // Download is in Retry state, waiting for backoff timer
         let saved = repo.find_by_id(DownloadId(1)).unwrap().unwrap();
         assert_eq!(saved.state(), DownloadState::Retry);
+    }
+
+    // --- Issue #46: CQRS state divergence ---
+
+    #[tokio::test]
+    async fn test_handle_download_failed_persists_error_state_when_downloading() {
+        // Regression for issue #46: when the engine task fails asynchronously
+        // (e.g. HEAD timeout), handle_download_failed must transition the download
+        // from Downloading → Error → Retry in SQLite, not leave it stuck as Downloading.
+        let mut d = make_download(1, 5, DownloadState::Queued);
+        d.start().unwrap(); // Simulate engine started → now Downloading in DB
+        assert_eq!(d.state(), DownloadState::Downloading);
+
+        let repo = Arc::new(MockDownloadRepo::new(vec![d]));
+        let engine = Arc::new(MockEngine::new());
+        let bus = Arc::new(MockEventBus::new());
+        let qm = make_manager(
+            Arc::clone(&repo),
+            Arc::clone(&engine),
+            Arc::clone(&bus),
+            3,
+            1,
+        );
+
+        qm.handle_download_failed(DownloadId(1), "HEAD request timeout".to_string())
+            .await
+            .unwrap();
+
+        let saved = repo.find_by_id(DownloadId(1)).unwrap().unwrap();
+        assert_ne!(
+            saved.state(),
+            DownloadState::Downloading,
+            "download must NOT stay stuck in Downloading state"
+        );
+        // With default max_retries (5) and 0 retries so far → should be Retry
+        assert_eq!(saved.state(), DownloadState::Retry);
+        assert_eq!(qm.active_count(), 0, "active slot must be freed");
+    }
+
+    #[tokio::test]
+    async fn test_handle_download_failed_transitions_to_error_when_max_retries_exceeded() {
+        // Regression for issue #46: when max retries = 0, the download must end in
+        // Error state (not Downloading) after the engine task fails.
+        let mut d = make_download(1, 5, DownloadState::Queued);
+        d = d.with_max_retries(0); // No retries allowed
+        d.start().unwrap();
+        assert_eq!(d.state(), DownloadState::Downloading);
+
+        let repo = Arc::new(MockDownloadRepo::new(vec![d]));
+        let engine = Arc::new(MockEngine::new());
+        let bus = Arc::new(MockEventBus::new());
+        let qm = make_manager(
+            Arc::clone(&repo),
+            Arc::clone(&engine),
+            Arc::clone(&bus),
+            3,
+            1,
+        );
+
+        qm.handle_download_failed(DownloadId(1), "connection refused".to_string())
+            .await
+            .unwrap();
+
+        let saved = repo.find_by_id(DownloadId(1)).unwrap().unwrap();
+        assert_eq!(
+            saved.state(),
+            DownloadState::Error,
+            "max retries exceeded: download must be Error"
+        );
+        assert_ne!(saved.state(), DownloadState::Downloading);
+        assert_eq!(qm.active_count(), 0, "active slot must be freed");
     }
 }

--- a/src-tauri/src/application/services/queue_manager.rs
+++ b/src-tauri/src/application/services/queue_manager.rs
@@ -177,11 +177,15 @@ impl QueueManager {
                     self.download_repo.save(&download)?;
                 }
                 Err(e) => {
-                    tracing::warn!(
+                    // fail() accepts the same states as the if-matches guard above,
+                    // so this branch is unreachable in practice. Propagate to avoid
+                    // silently re-introducing the CQRS divergence if states diverge.
+                    tracing::error!(
                         download_id = id.0,
                         error = %e,
-                        "handle_download_failed: unexpected fail() transition error"
+                        "handle_download_failed: unexpected fail() transition error — download may be stuck"
                     );
+                    return Err(AppError::Domain(e));
                 }
             }
         }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import './i18n/i18n';
 import { BrowserRouter, Routes, Route, Navigate } from "react-router";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppLayout } from "@/layouts/AppLayout";
 import {
   DownloadsView,
@@ -19,6 +20,7 @@ import { queryClient } from "@/api/client";
 export function App() {
   return (
     <QueryClientProvider client={queryClient}>
+      <TooltipProvider>
       <BrowserRouter>
         <Routes>
           <Route element={<AppLayout />}>
@@ -37,6 +39,7 @@ export function App() {
           </Route>
         </Routes>
       </BrowserRouter>
+      </TooltipProvider>
     </QueryClientProvider>
   );
 }

--- a/src/hooks/__tests__/useDownloadDetail.test.ts
+++ b/src/hooks/__tests__/useDownloadDetail.test.ts
@@ -42,17 +42,17 @@ function createWrapper() {
 }
 
 describe('useDownloadDetail', () => {
-  it('should call query_download_detail with correct args', async () => {
+  it('should call download_detail with numeric id', async () => {
     const { invoke } = await import('@tauri-apps/api/core');
     vi.mocked(invoke).mockResolvedValue(mockDownloadDetail());
 
-    const { result } = renderHook(() => useDownloadDetail('dl-1'), {
+    const { result } = renderHook(() => useDownloadDetail('7274895108243456'), {
       wrapper: createWrapper(),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(invoke).toHaveBeenCalledWith('query_download_detail', { id: 'dl-1' });
+    expect(invoke).toHaveBeenCalledWith('download_detail', { id: 7274895108243456 });
     expect(result.current.data?.id).toBe('dl-1');
   });
 });

--- a/src/hooks/useAppEffects.ts
+++ b/src/hooks/useAppEffects.ts
@@ -3,11 +3,30 @@ import { useSettingsStore } from '@/stores/settingsStore';
 
 /**
  * Applies global DOM effects based on app config:
+ * - dark class on :root (theme)
  * - compact-mode class on body
  * - --color-accent CSS variable on :root
  */
 export function useAppEffects() {
   const config = useSettingsStore((s) => s.config);
+
+  useEffect(() => {
+    if (!config?.theme) return;
+
+    const root = document.documentElement;
+    const prefersDark =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches;
+    const isDark = config.theme === 'dark' || (config.theme === 'auto' && prefersDark);
+    root.classList.toggle('dark', isDark);
+
+    try {
+      localStorage.setItem('vortex-theme', config.theme);
+    } catch {
+      // SecurityError in private browsing — ignore
+    }
+  }, [config?.theme]);
 
   useEffect(() => {
     if (config === null) return;

--- a/src/hooks/useAppEffects.ts
+++ b/src/hooks/useAppEffects.ts
@@ -3,30 +3,13 @@ import { useSettingsStore } from '@/stores/settingsStore';
 
 /**
  * Applies global DOM effects based on app config:
- * - dark class on :root (theme)
  * - compact-mode class on body
  * - --color-accent CSS variable on :root
+ *
+ * Note: theme (dark class + localStorage) is owned exclusively by ThemeProvider.
  */
 export function useAppEffects() {
   const config = useSettingsStore((s) => s.config);
-
-  useEffect(() => {
-    if (!config?.theme) return;
-
-    const root = document.documentElement;
-    const prefersDark =
-      typeof window !== 'undefined' &&
-      typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const isDark = config.theme === 'dark' || (config.theme === 'auto' && prefersDark);
-    root.classList.toggle('dark', isDark);
-
-    try {
-      localStorage.setItem('vortex-theme', config.theme);
-    } catch {
-      // SecurityError in private browsing — ignore
-    }
-  }, [config?.theme]);
 
   useEffect(() => {
     if (config === null) return;

--- a/src/hooks/useDownloadDetail.ts
+++ b/src/hooks/useDownloadDetail.ts
@@ -4,8 +4,8 @@ import type { DownloadDetailView } from '@/types/download';
 
 export function useDownloadDetail(downloadId: string) {
   return useTauriQuery<DownloadDetailView>(
-    'query_download_detail',
-    { id: downloadId },
+    'download_detail',
+    { id: Number(downloadId) },
     { queryKey: downloadQueries.detail(downloadId), staleTime: 500, enabled: !!downloadId },
   );
 }

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -9,6 +9,8 @@ import { useDownloadEvents } from "@/hooks/useDownloadEvents";
 import { useAppEffects } from "@/hooks/useAppEffects";
 import { tauriInvoke } from "@/api/client";
 import { useTauriQuery } from "@/api/hooks";
+import { downloadQueries } from "@/api/queries";
+import { useDownloadStore } from "@/stores/downloadStore";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { useUiStore } from "@/stores/uiStore";
 import {
@@ -22,6 +24,7 @@ export function AppLayout() {
   const location = useLocation();
   const { i18n } = useTranslation();
   const setConfig = useSettingsStore((s) => s.setConfig);
+  const updateCountByState = useDownloadStore((s) => s.updateCountByState);
   useDownloadProgress();
   useDownloadEvents();
   useAppEffects();
@@ -32,11 +35,23 @@ export function AppLayout() {
     { queryKey: ['settings_get'], staleTime: 30_000 },
   );
 
+  const { data: countByState } = useTauriQuery<Record<string, number>>(
+    'download_count_by_state',
+    undefined,
+    { queryKey: downloadQueries.countByState(), staleTime: 5_000 },
+  );
+
   useEffect(() => {
     if (config) {
       setConfig(config);
     }
   }, [config, setConfig]);
+
+  useEffect(() => {
+    if (countByState) {
+      updateCountByState(countByState);
+    }
+  }, [countByState, updateCountByState]);
 
   useEffect(() => {
     if (!config?.locale) return;

--- a/src/views/DownloadsView/ActionsBar.tsx
+++ b/src/views/DownloadsView/ActionsBar.tsx
@@ -25,7 +25,7 @@ export function ActionsBar() {
     invalidateKeys: INVALIDATE_KEYS,
   });
 
-  const cancelDownload = useTauriMutation<void, { id: string }>('download_cancel', {
+  const cancelDownload = useTauriMutation<void, { id: number }>('download_cancel', {
     invalidateKeys: INVALIDATE_KEYS,
   });
 
@@ -37,7 +37,7 @@ export function ActionsBar() {
     const snapshot = [...selectedDownloadIds];
     try {
       const results = await Promise.allSettled(
-        snapshot.map((id) => cancelDownload.mutateAsync({ id })),
+        snapshot.map((id) => cancelDownload.mutateAsync({ id: Number(id) })),
       );
       const failedIds = snapshot.filter((_, i) => results[i].status === 'rejected');
       const currentIds = useUiStore.getState().selectedDownloadIds;

--- a/src/views/DownloadsView/DownloadsTable.tsx
+++ b/src/views/DownloadsView/DownloadsTable.tsx
@@ -328,19 +328,19 @@ export function DownloadsTable({
   const columns = useMemo(() => getColumns(t), [t]);
 
   const invalidateKeys = useMemo(() => [downloadQueries.lists(), downloadQueries.countByState()] as const, []);
-  const pauseMut = useTauriMutation<unknown, { id: string }>('download_pause', { invalidateKeys });
-  const resumeMut = useTauriMutation<unknown, { id: string }>('download_resume', { invalidateKeys });
-  const startMut = useTauriMutation<unknown, { id: string }>('download_start', { invalidateKeys });
-  const removeMut = useTauriMutation<unknown, { id: string; deleteFiles: boolean }>('download_remove', { invalidateKeys });
-  const priorityMut = useTauriMutation<unknown, { id: string; priority: number }>('download_set_priority', { invalidateKeys });
+  const pauseMut = useTauriMutation<unknown, { id: number }>('download_pause', { invalidateKeys });
+  const resumeMut = useTauriMutation<unknown, { id: number }>('download_resume', { invalidateKeys });
+  const retryMut = useTauriMutation<unknown, { id: number }>('download_retry', { invalidateKeys });
+  const removeMut = useTauriMutation<unknown, { id: number; deleteFiles: boolean }>('download_remove', { invalidateKeys });
+  const priorityMut = useTauriMutation<unknown, { id: number; priority: number }>('download_set_priority', { invalidateKeys });
 
   const rowActions = useMemo<RowActions>(() => ({
-    pause: (id) => pauseMut.mutate({ id }),
-    resume: (id) => resumeMut.mutate({ id }),
-    start: (id) => startMut.mutate({ id }),
-    remove: (id) => removeMut.mutate({ id, deleteFiles: false }),
-    setPriority: (id, priority) => priorityMut.mutate({ id, priority }),
-  }), [pauseMut, resumeMut, startMut, removeMut, priorityMut]);
+    pause: (id) => pauseMut.mutate({ id: Number(id) }),
+    resume: (id) => resumeMut.mutate({ id: Number(id) }),
+    start: (id) => retryMut.mutate({ id: Number(id) }),
+    remove: (id) => removeMut.mutate({ id: Number(id), deleteFiles: false }),
+    setPriority: (id, priority) => priorityMut.mutate({ id: Number(id), priority }),
+  }), [pauseMut, resumeMut, retryMut, removeMut, priorityMut]);
 
   const selectedDownloadIds = useUiStore((s) => s.selectedDownloadIds);
   const selectDownload = useUiStore((s) => s.selectDownload);

--- a/src/views/DownloadsView/DownloadsView.tsx
+++ b/src/views/DownloadsView/DownloadsView.tsx
@@ -28,13 +28,13 @@ export function DownloadsView() {
 
   useDownloadProgress();
 
-  const pauseMut = useTauriMutation<void, { id: string }>('download_pause', {
+  const pauseMut = useTauriMutation<void, { id: number }>('download_pause', {
     invalidateKeys: INVALIDATE_KEYS,
   });
-  const resumeMut = useTauriMutation<void, { id: string }>('download_resume', {
+  const resumeMut = useTauriMutation<void, { id: number }>('download_resume', {
     invalidateKeys: INVALIDATE_KEYS,
   });
-  const removeMut = useTauriMutation<void, { id: string; deleteFiles: boolean }>(
+  const removeMut = useTauriMutation<void, { id: number; deleteFiles: boolean }>(
     'download_remove',
     { invalidateKeys: INVALIDATE_KEYS },
   );
@@ -106,10 +106,10 @@ export function DownloadsView() {
         .filter((download) =>
           download.state === 'Downloading' || download.state === 'Queued',
         )
-        .map((download) => pauseMut.mutateAsync({ id: download.id })),
+        .map((download) => pauseMut.mutateAsync({ id: Number(download.id) })),
       ...visibleSelectedDownloads
         .filter((download) => download.state === 'Paused')
-        .map((download) => resumeMut.mutateAsync({ id: download.id })),
+        .map((download) => resumeMut.mutateAsync({ id: Number(download.id) })),
     ];
 
     if (tasks.length === 0) return;
@@ -125,7 +125,7 @@ export function DownloadsView() {
     };
     const results = await Promise.allSettled(
       selectionSnapshot.ids.map((id) =>
-        removeMut.mutateAsync({ id, deleteFiles: false }),
+        removeMut.mutateAsync({ id: Number(id), deleteFiles: false }),
       ),
     );
     const failedIds = selectionSnapshot.ids.filter(

--- a/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
@@ -87,7 +87,7 @@ describe('DownloadsView', () => {
     mockInvoke.mockReset();
     mockInvoke.mockImplementation(async (command: string) => {
       switch (command) {
-        case 'query_download_detail':
+        case 'download_detail':
           return {
             id: '1',
             fileName: 'file1.zip',
@@ -193,8 +193,8 @@ describe('DownloadsView', () => {
     });
 
     await waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith('download_pause', { id: '1' });
-      expect(mockInvoke).toHaveBeenCalledWith('download_resume', { id: '2' });
+      expect(mockInvoke).toHaveBeenCalledWith('download_pause', { id: 1 });
+      expect(mockInvoke).toHaveBeenCalledWith('download_resume', { id: 2 });
     });
   });
 
@@ -219,11 +219,11 @@ describe('DownloadsView', () => {
 
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith('download_remove', {
-        id: '1',
+        id: 1,
         deleteFiles: false,
       });
       expect(mockInvoke).toHaveBeenCalledWith('download_remove', {
-        id: '2',
+        id: 2,
         deleteFiles: false,
       });
     });
@@ -257,9 +257,9 @@ describe('DownloadsView', () => {
     });
 
     await waitFor(() => {
-      expect(mockInvoke).toHaveBeenCalledWith('download_pause', { id: '1' });
+      expect(mockInvoke).toHaveBeenCalledWith('download_pause', { id: 1 });
     });
-    expect(mockInvoke).not.toHaveBeenCalledWith('download_resume', { id: '2' });
+    expect(mockInvoke).not.toHaveBeenCalledWith('download_resume', { id: 2 });
   });
 
   it('should keep the active details selection when it remains visible after filtering', async () => {
@@ -292,9 +292,9 @@ describe('DownloadsView', () => {
     mockInvoke.mockImplementation(
       async (command: string, args?: unknown) => {
         const payload =
-          args && typeof args === 'object' ? (args as { id?: string }) : {};
+          args && typeof args === 'object' ? (args as { id?: number }) : {};
         switch (command) {
-          case 'query_download_detail':
+          case 'download_detail':
             return {
               id: '1',
               fileName: 'file1.zip',
@@ -321,7 +321,7 @@ describe('DownloadsView', () => {
               segments: [],
             };
           case 'download_remove':
-            if (payload.id === '2') {
+            if (payload.id === 2) {
               throw new Error('remove failed');
             }
             return undefined;
@@ -361,9 +361,9 @@ describe('DownloadsView', () => {
     mockInvoke.mockImplementation(
       async (command: string, args?: unknown) => {
         const payload =
-          args && typeof args === 'object' ? (args as { id?: string }) : {};
+          args && typeof args === 'object' ? (args as { id?: number }) : {};
         switch (command) {
-          case 'query_download_detail':
+          case 'download_detail':
             return {
               id: '1',
               fileName: 'file1.zip',
@@ -390,13 +390,13 @@ describe('DownloadsView', () => {
               segments: [],
             };
           case 'download_remove':
-            if (payload.id === '1') {
+            if (payload.id === 1) {
               await new Promise<void>((resolve) => {
                 resolveFirstRemoval = resolve;
               });
               return undefined;
             }
-            if (payload.id === '2') {
+            if (payload.id === 2) {
               await new Promise<void>((resolve) => {
                 resolveSecondRemoval = resolve;
               });


### PR DESCRIPTION
## Summary

Fixes issue #46: downloads were getting stuck in `Downloading` state after engine task failures.

## Root Cause

When a download's async engine task failed (e.g., HEAD request timeout), the `QueueManager.handle_download_failed()` would call `retry()` directly on a download still in `Downloading` state. Since `retry()` requires `Error` state, it would fail with `InvalidTransition`, and the error wasn't persisted to SQLite.

## Changes

- **`handle_download_failed()`**: Now accepts `error: String` parameter and calls `download.fail(error)` to transition from `Downloading` → `Error` before attempting retry
- **`start_listening()`**: Passes error message from `DownloadFailed` event to `handle_download_failed`
- **Tests**: Added two regression tests to prevent this divergence happening again

## Test Plan

- [x] All 451 Rust tests pass
- [x] New tests verify:
  - Download with default retries transitions to `Retry` state (not stuck in `Downloading`)
  - Download with max_retries=0 transitions to `Error` state (not stuck in `Downloading`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents downloads from getting stuck in Downloading after engine failures by persisting Error before retrying. Also fixes IPC id types, uses the correct retry/detail commands, keeps active counts in sync, and removes duplicate theme logic.

- **Bug Fixes**
  - Core: `handle_download_failed(id, error)` persists `Downloading → Error` via `download.fail(error)` before `retry()`, `start_listening` forwards the error, and `fail()` transition errors now propagate. Adds regression tests for default retries and `max_retries=0`.
  - IPC: All mutations pass numeric ids (`Number(id)`) to Tauri, fixing silent failures for `download_pause`, `download_resume`, `download_remove`, `download_set_priority`, and `download_retry`.
  - Commands: Retry action now calls `download_retry` (not `download_start`). Detail view uses `download_detail` with a numeric id; tests updated.
  - UI state: `download_count_by_state` is queried in `AppLayout` and synced to the store for accurate active counts. Removed duplicate theme toggling in `useAppEffects`; `ThemeProvider` owns the `.dark` class and localStorage.

<sup>Written for commit b45d37afdf5c7e03b356fa115e68a4501f759e8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where failed downloads could remain stuck in "Downloading"; downloads now move to retry or error and free active slots.

* **New Features**
  * Tooltips are now consistently available across the app.

* **Improvements**
  * Download counts are now fetched and kept up-to-date to reflect current state in the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->