### PR TITLE
fix download logs IPC for details panel

### DIFF
--- a/src-tauri/src/adapters/driven/event/tauri_bridge.rs
+++ b/src-tauri/src/adapters/driven/event/tauri_bridge.rs
@@ -247,6 +247,15 @@ mod tests {
     }
 
     #[test]
+    fn test_event_payload_download_removed() {
+        let event = DomainEvent::DownloadRemoved { id: DownloadId(9) };
+        let (name, payload) = to_tauri_event(&event);
+
+        assert_eq!(name, "download-removed");
+        assert_eq!(payload["id"], 9);
+    }
+
+    #[test]
     fn test_event_name_clipboard_url_detected() {
         assert_eq!(
             event_name(&DomainEvent::ClipboardUrlDetected {

--- a/src-tauri/src/adapters/driven/event/tauri_bridge.rs
+++ b/src-tauri/src/adapters/driven/event/tauri_bridge.rs
@@ -25,6 +25,7 @@ fn event_name(event: &DomainEvent) -> &'static str {
         DomainEvent::DownloadWaiting { .. } => "download-waiting",
         DomainEvent::DownloadChecking { .. } => "download-checking",
         DomainEvent::DownloadCancelled { .. } => "download-cancelled",
+        DomainEvent::DownloadRemoved { .. } => "download-removed",
         DomainEvent::DownloadExtracting { .. } => "download-extracting",
         DomainEvent::DownloadProgress { .. } => "download-progress",
         DomainEvent::SegmentStarted { .. } => "segment-started",
@@ -47,6 +48,7 @@ fn event_payload(event: &DomainEvent) -> serde_json::Value {
         | DomainEvent::DownloadResumedFromWait { id }
         | DomainEvent::DownloadCompleted { id }
         | DomainEvent::DownloadCancelled { id }
+        | DomainEvent::DownloadRemoved { id }
         | DomainEvent::DownloadWaiting { id }
         | DomainEvent::DownloadChecking { id }
         | DomainEvent::DownloadExtracting { id } => json!({ "id": id.0 }),
@@ -147,6 +149,10 @@ mod tests {
         assert_eq!(
             event_name(&DomainEvent::DownloadChecking { id: DownloadId(1) }),
             "download-checking"
+        );
+        assert_eq!(
+            event_name(&DomainEvent::DownloadRemoved { id: DownloadId(1) }),
+            "download-removed"
         );
         assert_eq!(
             event_name(&DomainEvent::DownloadExtracting { id: DownloadId(1) }),

--- a/src-tauri/src/adapters/driven/logging/download_log_bridge.rs
+++ b/src-tauri/src/adapters/driven/logging/download_log_bridge.rs
@@ -52,6 +52,9 @@ fn record_download_event(store: &DownloadLogStore, event: &DomainEvent) {
         DomainEvent::DownloadExtracting { id } => {
             store.push(id.0, "[INFO] Extracting archive".to_string());
         }
+        DomainEvent::DownloadRemoved { id } => {
+            store.remove(id.0);
+        }
         DomainEvent::SegmentStarted {
             download_id,
             segment_id,
@@ -126,6 +129,16 @@ mod tests {
                 version: "1.0.0".to_string(),
             },
         );
+
+        assert!(store.recent(42, 10).is_empty());
+    }
+
+    #[test]
+    fn clears_logs_when_download_is_removed() {
+        let store = DownloadLogStore::new(8);
+
+        record_download_event(&store, &DomainEvent::DownloadStarted { id: DownloadId(42) });
+        record_download_event(&store, &DomainEvent::DownloadRemoved { id: DownloadId(42) });
 
         assert!(store.recent(42, 10).is_empty());
     }

--- a/src-tauri/src/adapters/driven/logging/download_log_bridge.rs
+++ b/src-tauri/src/adapters/driven/logging/download_log_bridge.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+
+use crate::domain::event::DomainEvent;
+use crate::domain::ports::driven::EventBus;
+
+use super::download_log_store::DownloadLogStore;
+
+pub fn spawn_download_log_bridge(event_bus: &dyn EventBus, store: Arc<DownloadLogStore>) {
+    event_bus.subscribe(Box::new(move |event| {
+        record_download_event(store.as_ref(), event);
+    }));
+}
+
+fn record_download_event(store: &DownloadLogStore, event: &DomainEvent) {
+    match event {
+        DomainEvent::DownloadCreated { id } => {
+            store.push(id.0, "[INFO] Download created".to_string());
+        }
+        DomainEvent::DownloadStarted { id } => {
+            store.push(id.0, "[INFO] Download started".to_string());
+        }
+        DomainEvent::DownloadPaused { id } => {
+            store.push(id.0, "[INFO] Download paused".to_string());
+        }
+        DomainEvent::DownloadResumed { id } => {
+            store.push(id.0, "[INFO] Download resumed".to_string());
+        }
+        DomainEvent::DownloadResumedFromWait { id } => {
+            store.push(id.0, "[INFO] Download resumed after waiting".to_string());
+        }
+        DomainEvent::DownloadCompleted { id } => {
+            store.push(id.0, "[INFO] Download completed".to_string());
+        }
+        DomainEvent::DownloadFailed { id, error } => {
+            store.push(id.0, format!("[ERROR] Download failed: {error}"));
+        }
+        DomainEvent::DownloadRetrying { id, attempt } => {
+            store.push(
+                id.0,
+                format!("[WARN] Retrying download (attempt {attempt})"),
+            );
+        }
+        DomainEvent::DownloadWaiting { id } => {
+            store.push(id.0, "[INFO] Download waiting".to_string());
+        }
+        DomainEvent::DownloadChecking { id } => {
+            store.push(id.0, "[INFO] Checking download".to_string());
+        }
+        DomainEvent::DownloadCancelled { id } => {
+            store.push(id.0, "[INFO] Download cancelled".to_string());
+        }
+        DomainEvent::DownloadExtracting { id } => {
+            store.push(id.0, "[INFO] Extracting archive".to_string());
+        }
+        DomainEvent::SegmentStarted {
+            download_id,
+            segment_id,
+        } => {
+            store.push(
+                download_id.0,
+                format!("[DEBUG] Segment {segment_id} started"),
+            );
+        }
+        DomainEvent::SegmentCompleted {
+            download_id,
+            segment_id,
+        } => {
+            store.push(
+                download_id.0,
+                format!("[DEBUG] Segment {segment_id} completed"),
+            );
+        }
+        DomainEvent::SegmentFailed {
+            download_id,
+            segment_id,
+            error,
+        } => {
+            store.push(
+                download_id.0,
+                format!("[ERROR] Segment {segment_id} failed: {error}"),
+            );
+        }
+        DomainEvent::DownloadProgress { .. }
+        | DomainEvent::PluginLoaded { .. }
+        | DomainEvent::PluginUnloaded { .. }
+        | DomainEvent::PackageCreated { .. }
+        | DomainEvent::ClipboardUrlDetected { .. }
+        | DomainEvent::SettingsUpdated => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::record_download_event;
+    use crate::domain::event::DomainEvent;
+    use crate::domain::model::download::DownloadId;
+
+    use super::DownloadLogStore;
+
+    #[test]
+    fn records_download_failure_lines() {
+        let store = DownloadLogStore::new(8);
+
+        record_download_event(
+            &store,
+            &DomainEvent::DownloadFailed {
+                id: DownloadId(42),
+                error: "timeout".to_string(),
+            },
+        );
+
+        assert_eq!(
+            store.recent(42, 10),
+            vec!["[ERROR] Download failed: timeout".to_string()]
+        );
+    }
+
+    #[test]
+    fn ignores_unscoped_events() {
+        let store = DownloadLogStore::new(8);
+
+        record_download_event(
+            &store,
+            &DomainEvent::PluginLoaded {
+                name: "yt".to_string(),
+                version: "1.0.0".to_string(),
+            },
+        );
+
+        assert!(store.recent(42, 10).is_empty());
+    }
+}

--- a/src-tauri/src/adapters/driven/logging/download_log_store.rs
+++ b/src-tauri/src/adapters/driven/logging/download_log_store.rs
@@ -24,6 +24,10 @@ impl DownloadLogStore {
         }
     }
 
+    pub fn remove(&self, download_id: u64) {
+        self.lines_by_download.remove(&download_id);
+    }
+
     pub fn recent(&self, download_id: u64, limit: usize) -> Vec<String> {
         if limit == 0 {
             return Vec::new();
@@ -71,5 +75,15 @@ mod tests {
 
         assert_eq!(store.recent(1, 10), vec!["[INFO] first".to_string()]);
         assert_eq!(store.recent(2, 10), vec!["[INFO] second".to_string()]);
+    }
+
+    #[test]
+    fn removes_all_lines_for_a_download() {
+        let store = DownloadLogStore::new(4);
+
+        store.push(1, "[INFO] first".to_string());
+        store.remove(1);
+
+        assert!(store.recent(1, 10).is_empty());
     }
 }

--- a/src-tauri/src/adapters/driven/logging/download_log_store.rs
+++ b/src-tauri/src/adapters/driven/logging/download_log_store.rs
@@ -1,0 +1,75 @@
+use std::collections::VecDeque;
+
+use dashmap::DashMap;
+
+#[derive(Debug)]
+pub struct DownloadLogStore {
+    max_entries_per_download: usize,
+    lines_by_download: DashMap<u64, VecDeque<String>>,
+}
+
+impl DownloadLogStore {
+    pub fn new(max_entries_per_download: usize) -> Self {
+        Self {
+            max_entries_per_download: max_entries_per_download.max(1),
+            lines_by_download: DashMap::new(),
+        }
+    }
+
+    pub fn push(&self, download_id: u64, line: String) {
+        let mut lines = self.lines_by_download.entry(download_id).or_default();
+        lines.push_back(line);
+        if lines.len() > self.max_entries_per_download {
+            lines.pop_front();
+        }
+    }
+
+    pub fn recent(&self, download_id: u64, limit: usize) -> Vec<String> {
+        if limit == 0 {
+            return Vec::new();
+        }
+
+        self.lines_by_download
+            .get(&download_id)
+            .map(|lines| {
+                let start = lines.len().saturating_sub(limit);
+                lines.iter().skip(start).cloned().collect()
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DownloadLogStore;
+
+    #[test]
+    fn keeps_only_the_most_recent_lines_for_a_download() {
+        let store = DownloadLogStore::new(3);
+
+        store.push(7, "[INFO] queued".to_string());
+        store.push(7, "[INFO] started".to_string());
+        store.push(7, "[WARN] retrying".to_string());
+        store.push(7, "[INFO] resumed".to_string());
+
+        assert_eq!(
+            store.recent(7, 10),
+            vec![
+                "[INFO] started".to_string(),
+                "[WARN] retrying".to_string(),
+                "[INFO] resumed".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn isolates_lines_by_download_id() {
+        let store = DownloadLogStore::new(4);
+
+        store.push(1, "[INFO] first".to_string());
+        store.push(2, "[INFO] second".to_string());
+
+        assert_eq!(store.recent(1, 10), vec!["[INFO] first".to_string()]);
+        assert_eq!(store.recent(2, 10), vec!["[INFO] second".to_string()]);
+    }
+}

--- a/src-tauri/src/adapters/driven/logging/download_log_store.rs
+++ b/src-tauri/src/adapters/driven/logging/download_log_store.rs
@@ -17,9 +17,12 @@ impl DownloadLogStore {
     }
 
     pub fn push(&self, download_id: u64, line: String) {
-        let mut lines = self.lines_by_download.entry(download_id).or_default();
+        let mut lines = self
+            .lines_by_download
+            .entry(download_id)
+            .or_insert_with(|| VecDeque::with_capacity(self.max_entries_per_download));
         lines.push_back(line);
-        if lines.len() > self.max_entries_per_download {
+        while lines.len() > self.max_entries_per_download {
             lines.pop_front();
         }
     }
@@ -85,5 +88,14 @@ mod tests {
         store.remove(1);
 
         assert!(store.recent(1, 10).is_empty());
+    }
+
+    #[test]
+    fn returns_empty_when_limit_is_zero() {
+        let store = DownloadLogStore::new(4);
+
+        store.push(1, "[INFO] first".to_string());
+
+        assert!(store.recent(1, 0).is_empty());
     }
 }

--- a/src-tauri/src/adapters/driven/logging/mod.rs
+++ b/src-tauri/src/adapters/driven/logging/mod.rs
@@ -1,0 +1,2 @@
+pub mod download_log_bridge;
+pub mod download_log_store;

--- a/src-tauri/src/adapters/driven/mod.rs
+++ b/src-tauri/src/adapters/driven/mod.rs
@@ -6,6 +6,7 @@ pub mod credential;
 pub mod event;
 pub mod extractor;
 pub mod filesystem;
+pub mod logging;
 pub mod network;
 pub mod notification;
 pub mod plugin;

--- a/src-tauri/src/adapters/driving/tauri_ipc.rs
+++ b/src-tauri/src/adapters/driving/tauri_ipc.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use tauri::State;
 use tracing;
 
+use crate::adapters::driven::logging::download_log_store::DownloadLogStore;
 use crate::application::command_bus::CommandBus;
 use crate::application::commands::{
     CancelDownloadCommand, DisablePluginCommand, EnablePluginCommand, InstallPluginCommand,
@@ -32,6 +33,7 @@ use crate::domain::model::views::{DownloadFilter, SortDirection, SortField, Sort
 pub struct AppState {
     pub command_bus: Arc<CommandBus>,
     pub query_bus: Arc<QueryBus>,
+    pub download_log_store: Arc<DownloadLogStore>,
 }
 
 #[tauri::command]
@@ -261,6 +263,15 @@ pub async fn download_detail(
         .await
         .map(DownloadDetailViewDto::from)
         .map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn download_logs(
+    state: State<'_, AppState>,
+    id: u64,
+    limit: usize,
+) -> Result<Vec<String>, String> {
+    Ok(state.download_log_store.recent(id, limit))
 }
 
 #[tauri::command]

--- a/src-tauri/src/application/commands/cancel_download.rs
+++ b/src-tauri/src/application/commands/cancel_download.rs
@@ -41,6 +41,9 @@ impl CommandBus {
                 .publish(DomainEvent::DownloadCancelled { id: cmd.id });
         }
 
+        self.event_bus()
+            .publish(DomainEvent::DownloadRemoved { id: cmd.id });
+
         Ok(())
     }
 }
@@ -372,7 +375,10 @@ mod tests {
         let emitted = events.events.lock().unwrap();
         assert_eq!(
             emitted.as_slice(),
-            &[DomainEvent::DownloadCancelled { id: DownloadId(1) }]
+            &[
+                DomainEvent::DownloadCancelled { id: DownloadId(1) },
+                DomainEvent::DownloadRemoved { id: DownloadId(1) },
+            ]
         );
     }
 
@@ -412,7 +418,11 @@ mod tests {
         assert!(engine.cancelled.lock().unwrap().is_empty());
         // Download still removed
         assert!(repo.find_by_id(DownloadId(2)).unwrap().is_none());
-        // No DownloadCancelled event for non-active downloads
-        assert!(events.events.lock().unwrap().is_empty());
+        // No DownloadCancelled event for non-active downloads, but removal is still emitted.
+        let emitted = events.events.lock().unwrap();
+        assert_eq!(
+            emitted.as_slice(),
+            &[DomainEvent::DownloadRemoved { id: DownloadId(2) }]
+        );
     }
 }

--- a/src-tauri/src/application/commands/remove_download.rs
+++ b/src-tauri/src/application/commands/remove_download.rs
@@ -45,6 +45,9 @@ impl CommandBus {
                 .publish(DomainEvent::DownloadCancelled { id: cmd.id });
         }
 
+        self.event_bus()
+            .publish(DomainEvent::DownloadRemoved { id: cmd.id });
+
         Ok(())
     }
 }
@@ -434,5 +437,21 @@ mod tests {
         let deleted = harness.file_storage.deleted_metas.lock().unwrap();
         assert_eq!(deleted.len(), 1);
         assert_eq!(deleted[0], "/tmp/f.zip.vortex-meta");
+    }
+
+    #[tokio::test]
+    async fn test_remove_emits_download_removed_event() {
+        let dl = make_download();
+        let repo = MockDownloadRepo::new().with_download(dl);
+        let harness = make_harness(repo);
+
+        let cmd = RemoveDownloadCommand {
+            id: DownloadId(1),
+            delete_files: false,
+        };
+        harness.bus.handle_remove_download(cmd).await.unwrap();
+
+        let events = harness.event_bus.events.lock().unwrap();
+        assert!(events.contains(&DomainEvent::DownloadRemoved { id: DownloadId(1) }));
     }
 }

--- a/src-tauri/src/domain/event.rs
+++ b/src-tauri/src/domain/event.rs
@@ -38,6 +38,9 @@ pub enum DomainEvent {
     DownloadCancelled {
         id: DownloadId,
     },
+    DownloadRemoved {
+        id: DownloadId,
+    },
     DownloadExtracting {
         id: DownloadId,
     },

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -21,6 +21,8 @@ pub use adapters::driven::event::TokioEventBus;
 pub use adapters::driven::event::spawn_tauri_event_bridge;
 pub use adapters::driven::extractor::VortexArchiveExtractor;
 pub use adapters::driven::filesystem::FsFileStorage;
+pub use adapters::driven::logging::download_log_bridge::spawn_download_log_bridge;
+pub use adapters::driven::logging::download_log_store::DownloadLogStore;
 pub use adapters::driven::network::ReqwestHttpClient;
 pub use adapters::driven::network::SegmentedDownloadEngine;
 pub use adapters::driven::notification::spawn_notification_bridge;
@@ -48,10 +50,10 @@ pub use domain::model::ExtractionConfig;
 
 pub use adapters::driving::tauri_ipc::{
     self, AppState, clipboard_state, clipboard_toggle, download_cancel, download_count_by_state,
-    download_detail, download_list, download_pause, download_pause_all, download_remove,
-    download_resume, download_resume_all, download_retry, download_set_priority, download_start,
-    link_resolve, plugin_disable, plugin_enable, plugin_install, plugin_list, plugin_uninstall,
-    settings_get, settings_update, status_bar_get,
+    download_detail, download_list, download_logs, download_pause, download_pause_all,
+    download_remove, download_resume, download_resume_all, download_retry, download_set_priority,
+    download_start, link_resolve, plugin_disable, plugin_enable, plugin_install, plugin_list,
+    plugin_uninstall, settings_get, settings_update, status_bar_get,
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -109,6 +111,7 @@ pub fn run() {
                 Arc::new(TauriClipboardObserver::new(app_handle.clone()));
             let archive_extractor: Arc<dyn ArchiveExtractor> =
                 Arc::new(VortexArchiveExtractor::new(ExtractionConfig::default()));
+            let download_log_store = Arc::new(DownloadLogStore::new(256));
 
             // ── SQLite repositories ─────────────────────────────────
             let download_repo: Arc<dyn DownloadRepository> =
@@ -172,6 +175,7 @@ pub fn run() {
             app.manage(AppState {
                 command_bus,
                 query_bus,
+                download_log_store: download_log_store.clone(),
             });
 
             // ── System tray ─────────────────────────────────────────
@@ -182,6 +186,7 @@ pub fn run() {
             // ── Event bridges (domain events → frontend + desktop) ──
             spawn_tauri_event_bridge(app_handle.clone(), event_bus.as_ref());
             spawn_notification_bridge(app_handle, event_bus.as_ref());
+            spawn_download_log_bridge(event_bus.as_ref(), download_log_store);
 
             // ── Queue manager event listener ────────────────────────
             queue_manager.clone().start_listening();
@@ -212,6 +217,7 @@ pub fn run() {
             download_remove,
             download_list,
             download_detail,
+            download_logs,
             download_count_by_state,
             plugin_install,
             plugin_uninstall,

--- a/src/views/DownloadDetailsPanel/LogsSection.tsx
+++ b/src/views/DownloadDetailsPanel/LogsSection.tsx
@@ -7,10 +7,11 @@ interface LogsSectionProps {
 
 export function LogsSection({ downloadId }: LogsSectionProps) {
   const { data: logs, isLoading } = useTauriQuery<string[]>(
-    'query_download_logs',
-    { id: downloadId, limit: 20 },
-    { queryKey: ['query_download_logs', downloadId], staleTime: 2000 },
+    'download_logs',
+    { id: Number(downloadId), limit: 20 },
+    { queryKey: ['download_logs', downloadId], staleTime: 2000 },
   );
+  const lineOccurrences = new Map<string, number>();
 
   return (
     <section className="space-y-3">
@@ -21,14 +22,19 @@ export function LogsSection({ downloadId }: LogsSectionProps) {
       ) : !logs || logs.length === 0 ? (
         <div className="text-muted-foreground text-xs">No logs</div>
       ) : (
-        logs.map((line, index) => (
-          <div
-            key={index}
-            className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words"
-          >
-            {line}
-          </div>
-        ))
+        logs.map((line) => {
+          const occurrence = lineOccurrences.get(line) ?? 0;
+          lineOccurrences.set(line, occurrence + 1);
+
+          return (
+            <div
+              key={`${downloadId}:${line}:${occurrence}`}
+              className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words"
+            >
+              {line}
+            </div>
+          );
+        })
       )}
       </ScrollArea>
     </section>

--- a/src/views/DownloadDetailsPanel/LogsSection.tsx
+++ b/src/views/DownloadDetailsPanel/LogsSection.tsx
@@ -9,9 +9,12 @@ export function LogsSection({ downloadId }: LogsSectionProps) {
   const { data: logs, isLoading } = useTauriQuery<string[]>(
     'download_logs',
     { id: Number(downloadId), limit: 20 },
-    { queryKey: ['download_logs', downloadId], staleTime: 2000 },
+    {
+      queryKey: ['download_logs', downloadId],
+      staleTime: 2000,
+      refetchInterval: 2000,
+    },
   );
-  const lineOccurrences = new Map<string, number>();
 
   return (
     <section className="space-y-3">
@@ -22,19 +25,23 @@ export function LogsSection({ downloadId }: LogsSectionProps) {
       ) : !logs || logs.length === 0 ? (
         <div className="text-muted-foreground text-xs">No logs</div>
       ) : (
-        logs.map((line) => {
-          const occurrence = lineOccurrences.get(line) ?? 0;
-          lineOccurrences.set(line, occurrence + 1);
+        (() => {
+          const lineOccurrences = new Map<string, number>();
 
-          return (
-            <div
-              key={`${downloadId}:${line}:${occurrence}`}
-              className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words"
-            >
-              {line}
-            </div>
-          );
-        })
+          return logs.map((line) => {
+            const occurrence = lineOccurrences.get(line) ?? 0;
+            lineOccurrences.set(line, occurrence + 1);
+
+            return (
+              <div
+                key={`${downloadId}:${line}:${occurrence}`}
+                className="font-mono text-xs text-muted-foreground whitespace-pre-wrap break-words"
+              >
+                {line}
+              </div>
+            );
+          });
+        })()
       )}
       </ScrollArea>
     </section>

--- a/src/views/DownloadDetailsPanel/__tests__/LogsSection.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/LogsSection.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { LogsSection } from '../LogsSection';
 
@@ -32,7 +32,11 @@ describe('LogsSection', () => {
       '[INFO] Connected to server',
     ]);
 
-    renderWithProviders(<LogsSection downloadId="dl-1" />);
+    renderWithProviders(<LogsSection downloadId="1" />);
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith('download_logs', { id: 1, limit: 20 });
+    });
 
     expect(await screen.findByText('[INFO] Download started')).toBeInTheDocument();
     expect(screen.getByText('[INFO] Connected to server')).toBeInTheDocument();
@@ -42,7 +46,7 @@ describe('LogsSection', () => {
     const { invoke } = await import('@tauri-apps/api/core');
     vi.mocked(invoke).mockResolvedValue([]);
 
-    renderWithProviders(<LogsSection downloadId="dl-1" />);
+    renderWithProviders(<LogsSection downloadId="1" />);
 
     expect(await screen.findByText('No logs')).toBeInTheDocument();
   });

--- a/src/views/DownloadDetailsPanel/__tests__/LogsSection.test.tsx
+++ b/src/views/DownloadDetailsPanel/__tests__/LogsSection.test.tsx
@@ -50,4 +50,23 @@ describe('LogsSection', () => {
 
     expect(await screen.findByText('No logs')).toBeInTheDocument();
   });
+
+  it('should refetch logs while the panel stays open', async () => {
+    const { invoke } = await import('@tauri-apps/api/core');
+    vi.mocked(invoke)
+      .mockResolvedValueOnce(['[INFO] Download started'])
+      .mockResolvedValueOnce(['[INFO] Download started', '[INFO] Segment 1 completed']);
+
+    renderWithProviders(<LogsSection downloadId="1" />);
+
+    expect(await screen.findByText('[INFO] Download started')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledTimes(2);
+    }, { timeout: 3000 });
+
+    expect(
+      await screen.findByText('[INFO] Segment 1 completed'),
+    ).toBeInTheDocument();
+  }, 7000);
 });


### PR DESCRIPTION
## Summary

Closes #47.

This PR fixes the download details logs panel by wiring it to a real Tauri IPC command and a backend log source scoped by `download_id`.

## Root Cause

`LogsSection` was invoking a non-existent IPC command, `query_download_logs`, and was passing the download id as a string. As a result, the panel always fell back to `No logs`.

## What Changed

- renamed the frontend IPC call to `download_logs`
- converted `downloadId` to a numeric `id` before invoking Tauri
- added a lightweight per-download in-memory log store in Rust
- added an event bridge that records log lines from `DomainEvent`s for each download
- exposed a new `download_logs(id, limit)` Tauri command
- added regression tests for the frontend IPC contract and Rust log-store behavior

## Impact

The logs section in the details panel now shows actual lines for the selected download during the current app session instead of always rendering `No logs`.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test -- src/views/DownloadDetailsPanel/__tests__/LogsSection.test.tsx`
- `cargo fmt --check --manifest-path src-tauri/Cargo.toml`
- `cargo test --manifest-path src-tauri/Cargo.toml download_log_`
- pre-push hooks:
  - Rust test suite
  - TypeScript typecheck
  - TypeScript test suite
- `rtk proxy npx -y react-doctor@latest . --verbose --diff`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Download Details logs panel by wiring `LogsSection` to a real IPC and a per‑download in‑memory log store, so it shows logs for the selected download, auto‑refreshes, and clears when a download is removed. Addresses issue #47 by scoping log retrieval to `download_id`.

- **Bug Fixes**
  - Frontend: call `download_logs` with `{ id: Number(downloadId), limit }`, set stable query keys, add `refetchInterval`, and use stable keys for duplicate lines.
  - Backend: add `DownloadLogStore` (per‑download ring buffer) and log bridge to record lines from `DomainEvent`s; introduce `DownloadRemoved` and publish it from cancel/remove so logs purge on removal.
  - IPC/App: expose `download_logs(id, limit)` via Tauri, include `download_log_store` in `AppState`, and forward `download-removed` events; add tests for IPC invocation, event mapping/removal purge, and panel refetch.

<sup>Written for commit acc3d2958ca05c19d8c0e1ae3124dc8f7faa0361. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-download activity logs capturing lifecycle and segment events (start, pause, resume, retry, complete, fail, etc.).
  * Logs can be fetched via the app and are shown in the Download Details panel with periodic auto-refresh while open.
* **Behavior**
  * Removing a download clears its stored logs.
* **Tests**
  * Added tests for log entry formatting, no-ops for unrelated events, log-clearing on removal, and UI refetch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->