### PR TITLE
fix: restore download detail timestamps

### DIFF
--- a/src-tauri/src/adapters/driven/sqlite/download_read_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/download_read_repo.rs
@@ -23,6 +23,22 @@ impl SqliteDownloadReadRepo {
     }
 }
 
+fn infer_timestamp_ms_from_download_id(raw_id: i64) -> Option<u64> {
+    const MIN_PLAUSIBLE_UNIX_MS: u64 = 946_684_800_000;
+
+    let ts = safe_u64(raw_id) >> 12;
+    (ts >= MIN_PLAUSIBLE_UNIX_MS).then_some(ts)
+}
+
+fn read_created_at(model: &download::Model) -> u64 {
+    let created_at = safe_u64(model.created_at);
+    if created_at > 0 {
+        created_at
+    } else {
+        infer_timestamp_ms_from_download_id(model.id).unwrap_or(0)
+    }
+}
+
 fn model_to_view(
     model: &download::Model,
     segments_active: u32,
@@ -60,7 +76,7 @@ fn model_to_view(
         segments_total,
         module_name: model.module_name.clone(),
         account_name: None, // Resolved when accounts table is implemented
-        created_at: safe_u64(model.created_at),
+        created_at: read_created_at(model),
     })
 }
 
@@ -207,6 +223,11 @@ impl DownloadReadRepository for SqliteDownloadReadRepo {
             let state = model.state.parse().map_err(|_| {
                 DomainError::StorageError(format!("invalid download state in DB: {}", model.state))
             })?;
+            let created_at = read_created_at(&model);
+            let updated_at = {
+                let stored = safe_u64(model.updated_at);
+                if stored > 0 { stored } else { created_at }
+            };
 
             let detail = DownloadDetailView {
                 id: DownloadId(safe_u64(model.id)),
@@ -226,8 +247,8 @@ impl DownloadReadRepository for SqliteDownloadReadRepo {
                 resume_supported: model.resume_supported != 0,
                 retry_count: safe_u32(model.retry_count as i64),
                 max_retries: safe_u32(model.max_retries as i64),
-                created_at: safe_u64(model.created_at),
-                updated_at: safe_u64(model.updated_at),
+                created_at,
+                updated_at,
             };
 
             Ok(Some(detail))
@@ -271,7 +292,10 @@ impl DownloadReadRepository for SqliteDownloadReadRepo {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::adapters::driven::sqlite::download_repo::SqliteDownloadRepo;
+    use crate::domain::model::download::{Download, Url};
     use crate::domain::model::segment::SegmentState;
+    use crate::domain::ports::driven::download_repository::DownloadRepository;
     use sea_orm::ActiveValue::Set;
     use sea_orm::{ActiveModelTrait, DatabaseConnection};
 
@@ -365,6 +389,71 @@ mod tests {
         assert!(detail.resume_supported);
         assert_eq!(detail.retry_count, 0);
         assert_eq!(detail.max_retries, 5);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_find_download_detail_populates_timestamps_for_saved_downloads() {
+        let db = setup().await;
+        let write_repo = SqliteDownloadRepo::new(db.clone());
+        let read_repo = SqliteDownloadReadRepo::new(db);
+
+        let download = Download::new(
+            DownloadId(1),
+            Url::new("https://example.com/file1.zip").unwrap(),
+            "file1.zip".to_string(),
+            "/tmp/downloads/file1.zip".to_string(),
+        );
+
+        write_repo.save(&download).unwrap();
+
+        let detail = read_repo
+            .find_download_detail(DownloadId(1))
+            .unwrap()
+            .expect("Should find download");
+
+        assert!(detail.created_at > 0);
+        assert!(detail.updated_at > 0);
+        assert_eq!(detail.created_at, detail.updated_at);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_find_download_detail_infers_timestamps_for_legacy_zero_rows() {
+        let db = setup().await;
+        let created_at = 1_700_000_000_000_u64;
+        let id = ((created_at << 12) | 7) as i64;
+
+        let model = download::ActiveModel {
+            id: Set(id),
+            url: Set("https://example.com/file1.zip".to_string()),
+            file_name: Set("file1.zip".to_string()),
+            state: Set("Downloading".to_string()),
+            priority: Set(5),
+            total_bytes: Set(Some(1000)),
+            downloaded_bytes: Set(500),
+            speed_bytes_per_sec: Set(100),
+            retry_count: Set(0),
+            max_retries: Set(5),
+            segments_count: Set(1),
+            checksum_expected: Set(None),
+            source_hostname: Set("example.com".to_string()),
+            protocol: Set("https".to_string()),
+            resume_supported: Set(1),
+            module_name: Set(None),
+            account_id: Set(None),
+            destination_path: Set("/tmp/downloads/file1.zip".to_string()),
+            created_at: Set(0),
+            updated_at: Set(0),
+        };
+        model.insert(&db).await.expect("Failed to insert download");
+
+        let repo = SqliteDownloadReadRepo::new(db);
+        let detail = repo
+            .find_download_detail(DownloadId(id as u64))
+            .unwrap()
+            .expect("Should find download");
+
+        assert_eq!(detail.created_at, created_at);
+        assert_eq!(detail.updated_at, created_at);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/src/adapters/driven/sqlite/download_read_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/download_read_repo.rs
@@ -12,8 +12,8 @@ use crate::domain::ports::driven::download_read_repository::DownloadReadReposito
 
 use super::entities::{download, download_segment};
 use super::util::{
-    block_on, infer_timestamp_ms_from_download_id, inferred_download_created_at_order_expr,
-    map_db_err, safe_u32, safe_u64,
+    block_on, current_timestamp_ms, infer_timestamp_ms_from_download_id,
+    inferred_download_created_at_order_expr, map_db_err, safe_u32, safe_u64,
 };
 
 pub struct SqliteDownloadReadRepo {
@@ -31,7 +31,7 @@ fn read_created_at(model: &download::Model) -> u64 {
     if created_at > 0 {
         created_at
     } else {
-        infer_timestamp_ms_from_download_id(model.id).unwrap_or(0)
+        infer_timestamp_ms_from_download_id(model.id).unwrap_or_else(current_timestamp_ms)
     }
 }
 
@@ -477,6 +477,46 @@ mod tests {
 
         assert_eq!(detail.created_at, created_at);
         assert_eq!(detail.updated_at, created_at);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_find_download_detail_falls_back_to_current_time_for_undecodable_legacy_rows() {
+        let db = setup().await;
+        let model = download::ActiveModel {
+            id: Set(1),
+            url: Set("https://example.com/file1.zip".to_string()),
+            file_name: Set("file1.zip".to_string()),
+            state: Set("Downloading".to_string()),
+            priority: Set(5),
+            total_bytes: Set(Some(1000)),
+            downloaded_bytes: Set(500),
+            speed_bytes_per_sec: Set(100),
+            retry_count: Set(0),
+            max_retries: Set(5),
+            segments_count: Set(1),
+            checksum_expected: Set(None),
+            source_hostname: Set("example.com".to_string()),
+            protocol: Set("https".to_string()),
+            resume_supported: Set(1),
+            module_name: Set(None),
+            account_id: Set(None),
+            destination_path: Set("/tmp/downloads/file1.zip".to_string()),
+            created_at: Set(0),
+            updated_at: Set(0),
+        };
+        model.insert(&db).await.expect("Failed to insert download");
+
+        let before = current_timestamp_ms();
+        let repo = SqliteDownloadReadRepo::new(db);
+        let detail = repo
+            .find_download_detail(DownloadId(1))
+            .unwrap()
+            .expect("Should find download");
+        let after = current_timestamp_ms();
+
+        assert!(detail.created_at >= before);
+        assert!(detail.created_at <= after);
+        assert_eq!(detail.updated_at, detail.created_at);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/src/adapters/driven/sqlite/download_read_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/download_read_repo.rs
@@ -11,7 +11,10 @@ use crate::domain::model::views::{
 use crate::domain::ports::driven::download_read_repository::DownloadReadRepository;
 
 use super::entities::{download, download_segment};
-use super::util::{block_on, map_db_err, safe_u32, safe_u64};
+use super::util::{
+    block_on, infer_timestamp_ms_from_download_id, inferred_download_created_at_order_expr,
+    map_db_err, safe_u32, safe_u64,
+};
 
 pub struct SqliteDownloadReadRepo {
     db: DatabaseConnection,
@@ -21,13 +24,6 @@ impl SqliteDownloadReadRepo {
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }
-}
-
-fn infer_timestamp_ms_from_download_id(raw_id: i64) -> Option<u64> {
-    const MIN_PLAUSIBLE_UNIX_MS: u64 = 946_684_800_000;
-
-    let ts = safe_u64(raw_id) >> 12;
-    (ts >= MIN_PLAUSIBLE_UNIX_MS).then_some(ts)
 }
 
 fn read_created_at(model: &download::Model) -> u64 {
@@ -121,20 +117,46 @@ impl DownloadReadRepository for SqliteDownloadReadRepo {
                 // Progress is a derived value (downloaded/total ratio), not a stored column.
                 // We approximate by sorting on downloaded_bytes — a true ratio sort would
                 // need a computed SQL expression, deferred to the UI layer for now.
-                let col = match s.field {
-                    SortField::CreatedAt => download::Column::CreatedAt,
-                    SortField::FileName => download::Column::FileName,
-                    SortField::FileSize => download::Column::TotalBytes,
-                    SortField::Progress => download::Column::DownloadedBytes,
-                    SortField::Speed => download::Column::SpeedBytesPerSec,
-                    SortField::State => download::Column::State,
-                };
-                query = match s.direction {
-                    SortDirection::Ascending => query.order_by_asc(col),
-                    SortDirection::Descending => query.order_by_desc(col),
+                query = match (s.field, s.direction) {
+                    (SortField::CreatedAt, SortDirection::Ascending) => {
+                        query.order_by_asc(inferred_download_created_at_order_expr())
+                    }
+                    (SortField::CreatedAt, SortDirection::Descending) => {
+                        query.order_by_desc(inferred_download_created_at_order_expr())
+                    }
+                    (SortField::FileName, SortDirection::Ascending) => {
+                        query.order_by_asc(download::Column::FileName)
+                    }
+                    (SortField::FileName, SortDirection::Descending) => {
+                        query.order_by_desc(download::Column::FileName)
+                    }
+                    (SortField::FileSize, SortDirection::Ascending) => {
+                        query.order_by_asc(download::Column::TotalBytes)
+                    }
+                    (SortField::FileSize, SortDirection::Descending) => {
+                        query.order_by_desc(download::Column::TotalBytes)
+                    }
+                    (SortField::Progress, SortDirection::Ascending) => {
+                        query.order_by_asc(download::Column::DownloadedBytes)
+                    }
+                    (SortField::Progress, SortDirection::Descending) => {
+                        query.order_by_desc(download::Column::DownloadedBytes)
+                    }
+                    (SortField::Speed, SortDirection::Ascending) => {
+                        query.order_by_asc(download::Column::SpeedBytesPerSec)
+                    }
+                    (SortField::Speed, SortDirection::Descending) => {
+                        query.order_by_desc(download::Column::SpeedBytesPerSec)
+                    }
+                    (SortField::State, SortDirection::Ascending) => {
+                        query.order_by_asc(download::Column::State)
+                    }
+                    (SortField::State, SortDirection::Descending) => {
+                        query.order_by_desc(download::Column::State)
+                    }
                 };
             } else {
-                query = query.order_by_desc(download::Column::CreatedAt);
+                query = query.order_by_desc(inferred_download_created_at_order_expr());
             }
 
             if let Some(o) = offset {
@@ -396,9 +418,11 @@ mod tests {
         let db = setup().await;
         let write_repo = SqliteDownloadRepo::new(db.clone());
         let read_repo = SqliteDownloadReadRepo::new(db);
+        let created_at = 1_700_000_000_000_u64;
+        let id = (created_at << 12) | 1;
 
         let download = Download::new(
-            DownloadId(1),
+            DownloadId(id),
             Url::new("https://example.com/file1.zip").unwrap(),
             "file1.zip".to_string(),
             "/tmp/downloads/file1.zip".to_string(),
@@ -407,13 +431,12 @@ mod tests {
         write_repo.save(&download).unwrap();
 
         let detail = read_repo
-            .find_download_detail(DownloadId(1))
+            .find_download_detail(DownloadId(id))
             .unwrap()
             .expect("Should find download");
 
-        assert!(detail.created_at > 0);
-        assert!(detail.updated_at > 0);
-        assert_eq!(detail.created_at, detail.updated_at);
+        assert_eq!(detail.created_at, created_at);
+        assert_eq!(detail.updated_at, created_at);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -454,6 +477,48 @@ mod tests {
 
         assert_eq!(detail.created_at, created_at);
         assert_eq!(detail.updated_at, created_at);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_find_downloads_sorts_by_inferred_created_at_for_legacy_rows() {
+        let db = setup().await;
+        let legacy_created_at = 1_700_000_000_000_u64;
+        let legacy_id = ((legacy_created_at << 12) | 7) as i64;
+
+        let legacy = download::ActiveModel {
+            id: Set(legacy_id),
+            url: Set("https://example.com/legacy.zip".to_string()),
+            file_name: Set("legacy.zip".to_string()),
+            state: Set("Queued".to_string()),
+            priority: Set(5),
+            total_bytes: Set(Some(1000)),
+            downloaded_bytes: Set(0),
+            speed_bytes_per_sec: Set(0),
+            retry_count: Set(0),
+            max_retries: Set(5),
+            segments_count: Set(1),
+            checksum_expected: Set(None),
+            source_hostname: Set("example.com".to_string()),
+            protocol: Set("https".to_string()),
+            resume_supported: Set(1),
+            module_name: Set(None),
+            account_id: Set(None),
+            destination_path: Set("/tmp/downloads/legacy.zip".to_string()),
+            created_at: Set(0),
+            updated_at: Set(0),
+        };
+        legacy
+            .insert(&db)
+            .await
+            .expect("Failed to insert legacy download");
+
+        insert_download(&db, 1, "Queued", "recent.zip").await;
+
+        let repo = SqliteDownloadReadRepo::new(db);
+        let views = repo.find_downloads(None, None, None, None).unwrap();
+
+        assert_eq!(views[0].file_name, "legacy.zip");
+        assert_eq!(views[0].created_at, legacy_created_at);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/src/adapters/driven/sqlite/download_read_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/download_read_repo.rs
@@ -12,7 +12,7 @@ use crate::domain::ports::driven::download_read_repository::DownloadReadReposito
 
 use super::entities::{download, download_segment};
 use super::util::{
-    block_on, current_timestamp_ms, infer_timestamp_ms_from_download_id,
+    MIN_PLAUSIBLE_UNIX_MS, block_on, infer_timestamp_ms_from_download_id,
     inferred_download_created_at_order_expr, map_db_err, safe_u32, safe_u64,
 };
 
@@ -30,8 +30,15 @@ fn read_created_at(model: &download::Model) -> u64 {
     let created_at = safe_u64(model.created_at);
     if created_at > 0 {
         created_at
+    } else if let Some(inferred) = infer_timestamp_ms_from_download_id(model.id) {
+        inferred
     } else {
-        infer_timestamp_ms_from_download_id(model.id).unwrap_or_else(current_timestamp_ms)
+        let updated_at = safe_u64(model.updated_at);
+        if updated_at > 0 {
+            updated_at
+        } else {
+            MIN_PLAUSIBLE_UNIX_MS
+        }
     }
 }
 
@@ -480,7 +487,45 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_find_download_detail_falls_back_to_current_time_for_undecodable_legacy_rows() {
+    async fn test_find_download_detail_uses_updated_at_for_undecodable_legacy_rows() {
+        let db = setup().await;
+        let model = download::ActiveModel {
+            id: Set(1),
+            url: Set("https://example.com/file1.zip".to_string()),
+            file_name: Set("file1.zip".to_string()),
+            state: Set("Downloading".to_string()),
+            priority: Set(5),
+            total_bytes: Set(Some(1000)),
+            downloaded_bytes: Set(500),
+            speed_bytes_per_sec: Set(100),
+            retry_count: Set(0),
+            max_retries: Set(5),
+            segments_count: Set(1),
+            checksum_expected: Set(None),
+            source_hostname: Set("example.com".to_string()),
+            protocol: Set("https".to_string()),
+            resume_supported: Set(1),
+            module_name: Set(None),
+            account_id: Set(None),
+            destination_path: Set("/tmp/downloads/file1.zip".to_string()),
+            created_at: Set(0),
+            updated_at: Set(1_700_000_000_123_i64),
+        };
+        model.insert(&db).await.expect("Failed to insert download");
+
+        let repo = SqliteDownloadReadRepo::new(db);
+        let detail = repo
+            .find_download_detail(DownloadId(1))
+            .unwrap()
+            .expect("Should find download");
+
+        assert_eq!(detail.created_at, 1_700_000_000_123_u64);
+        assert_eq!(detail.updated_at, 1_700_000_000_123_u64);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_find_download_detail_falls_back_to_min_plausible_time_for_undecodable_zero_rows()
+    {
         let db = setup().await;
         let model = download::ActiveModel {
             id: Set(1),
@@ -506,17 +551,14 @@ mod tests {
         };
         model.insert(&db).await.expect("Failed to insert download");
 
-        let before = current_timestamp_ms();
         let repo = SqliteDownloadReadRepo::new(db);
         let detail = repo
             .find_download_detail(DownloadId(1))
             .unwrap()
             .expect("Should find download");
-        let after = current_timestamp_ms();
 
-        assert!(detail.created_at >= before);
-        assert!(detail.created_at <= after);
-        assert_eq!(detail.updated_at, detail.created_at);
+        assert_eq!(detail.created_at, MIN_PLAUSIBLE_UNIX_MS);
+        assert_eq!(detail.updated_at, MIN_PLAUSIBLE_UNIX_MS);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/src/adapters/driven/sqlite/download_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/download_repo.rs
@@ -8,7 +8,7 @@ use crate::domain::model::download::{Download, DownloadId, DownloadState};
 use crate::domain::ports::driven::download_repository::DownloadRepository;
 
 use super::entities::download;
-use super::util::{block_on, map_db_err};
+use super::util::{block_on, infer_timestamp_ms_from_download_id, map_db_err};
 
 pub struct SqliteDownloadRepo {
     db: DatabaseConnection,
@@ -25,13 +25,6 @@ fn current_timestamp_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
-}
-
-fn infer_timestamp_ms_from_download_id(id: DownloadId) -> Option<u64> {
-    const MIN_PLAUSIBLE_UNIX_MS: u64 = 946_684_800_000;
-
-    let ts = id.0 >> 12;
-    (ts >= MIN_PLAUSIBLE_UNIX_MS).then_some(ts)
 }
 
 impl DownloadRepository for SqliteDownloadRepo {
@@ -52,16 +45,16 @@ impl DownloadRepository for SqliteDownloadRepo {
     fn save(&self, download: &Download) -> Result<(), DomainError> {
         block_on(async {
             let mut active_model = download::ActiveModel::from_domain(download);
+            let now = current_timestamp_ms();
             let created_at = if download.created_at() == 0 {
-                infer_timestamp_ms_from_download_id(download.id())
-                    .unwrap_or_else(current_timestamp_ms)
+                infer_timestamp_ms_from_download_id(download.id().0 as i64).unwrap_or(now)
             } else {
                 download.created_at()
             };
             let updated_at = if download.updated_at() == 0 {
                 created_at
             } else {
-                download.updated_at()
+                now.max(download.updated_at())
             };
 
             active_model.created_at = Set(created_at as i64);
@@ -89,7 +82,6 @@ impl DownloadRepository for SqliteDownloadRepo {
                             download::Column::ModuleName,
                             download::Column::AccountId,
                             download::Column::DestinationPath,
-                            download::Column::CreatedAt,
                             download::Column::UpdatedAt,
                         ])
                         .to_owned(),
@@ -132,6 +124,7 @@ mod tests {
     use crate::adapters::driven::sqlite::connection::setup_test_db;
     use crate::domain::model::download::Url;
     use crate::domain::model::queue::Priority;
+    use std::time::Duration;
 
     fn make_download(id: u64) -> Download {
         let url = Url::new("https://example.com/file.zip").expect("valid url");
@@ -173,6 +166,10 @@ mod tests {
 
         let download = make_download(1);
         repo.save(&download).expect("first save");
+        let first = repo
+            .find_by_id(DownloadId(1))
+            .expect("find_by_id")
+            .expect("should exist");
 
         // Modify and save again (upsert)
         let updated = Download::new(
@@ -189,6 +186,33 @@ mod tests {
             .expect("should exist");
         assert_eq!(found.file_name(), "updated.zip");
         assert_eq!(found.destination_path(), "/downloads");
+        assert_eq!(found.created_at(), first.created_at());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_save_refreshes_updated_at_for_existing_download() {
+        let db = setup_test_db().await.expect("test db");
+        let repo = SqliteDownloadRepo::new(db);
+
+        let download = make_download(1);
+        repo.save(&download).expect("first save");
+
+        let found = repo
+            .find_by_id(DownloadId(1))
+            .expect("find_by_id")
+            .expect("should exist");
+        let previous_updated_at = found.updated_at();
+
+        std::thread::sleep(Duration::from_millis(2));
+        repo.save(&found).expect("second save");
+
+        let reloaded = repo
+            .find_by_id(DownloadId(1))
+            .expect("find_by_id")
+            .expect("should exist");
+
+        assert!(reloaded.updated_at() > previous_updated_at);
+        assert_eq!(reloaded.created_at(), found.created_at());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/src/adapters/driven/sqlite/download_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/download_repo.rs
@@ -1,5 +1,6 @@
 //! SQLite implementation of the `DownloadRepository` (CQRS write side).
 
+use sea_orm::ActiveValue::Set;
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 
 use crate::domain::error::DomainError;
@@ -19,6 +20,20 @@ impl SqliteDownloadRepo {
     }
 }
 
+fn current_timestamp_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn infer_timestamp_ms_from_download_id(id: DownloadId) -> Option<u64> {
+    const MIN_PLAUSIBLE_UNIX_MS: u64 = 946_684_800_000;
+
+    let ts = id.0 >> 12;
+    (ts >= MIN_PLAUSIBLE_UNIX_MS).then_some(ts)
+}
+
 impl DownloadRepository for SqliteDownloadRepo {
     fn find_by_id(&self, id: DownloadId) -> Result<Option<Download>, DomainError> {
         block_on(async {
@@ -36,7 +51,21 @@ impl DownloadRepository for SqliteDownloadRepo {
 
     fn save(&self, download: &Download) -> Result<(), DomainError> {
         block_on(async {
-            let active_model = download::ActiveModel::from_domain(download);
+            let mut active_model = download::ActiveModel::from_domain(download);
+            let created_at = if download.created_at() == 0 {
+                infer_timestamp_ms_from_download_id(download.id())
+                    .unwrap_or_else(current_timestamp_ms)
+            } else {
+                download.created_at()
+            };
+            let updated_at = if download.updated_at() == 0 {
+                created_at
+            } else {
+                download.updated_at()
+            };
+
+            active_model.created_at = Set(created_at as i64);
+            active_model.updated_at = Set(updated_at as i64);
 
             download::Entity::insert(active_model)
                 .on_conflict(

--- a/src-tauri/src/adapters/driven/sqlite/download_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/download_repo.rs
@@ -1,6 +1,7 @@
 //! SQLite implementation of the `DownloadRepository` (CQRS write side).
 
 use sea_orm::ActiveValue::Set;
+use sea_orm::sea_query::Expr;
 use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
 
 use crate::domain::error::DomainError;
@@ -77,8 +78,14 @@ impl DownloadRepository for SqliteDownloadRepo {
                             download::Column::ModuleName,
                             download::Column::AccountId,
                             download::Column::DestinationPath,
-                            download::Column::UpdatedAt,
                         ])
+                        .value(
+                            download::Column::CreatedAt,
+                            Expr::cust(
+                                "CASE WHEN created_at > 0 THEN created_at ELSE excluded.created_at END",
+                            ),
+                        )
+                        .value(download::Column::UpdatedAt, now as i64)
                         .to_owned(),
                 )
                 .exec(&self.db)
@@ -117,8 +124,10 @@ impl DownloadRepository for SqliteDownloadRepo {
 mod tests {
     use super::*;
     use crate::adapters::driven::sqlite::connection::setup_test_db;
+    use crate::adapters::driven::sqlite::entities::download;
     use crate::domain::model::download::Url;
     use crate::domain::model::queue::Priority;
+    use sea_orm::ActiveModelTrait;
     use std::time::Duration;
 
     fn make_download(id: u64) -> Download {
@@ -158,17 +167,20 @@ mod tests {
     async fn test_save_upsert_updates_existing() {
         let db = setup_test_db().await.expect("test db");
         let repo = SqliteDownloadRepo::new(db);
+        let created_at = 1_700_000_000_000_u64;
+        let id = (created_at << 12) | 1;
 
-        let download = make_download(1);
+        let download = make_download(id);
         repo.save(&download).expect("first save");
         let first = repo
-            .find_by_id(DownloadId(1))
+            .find_by_id(DownloadId(id))
             .expect("find_by_id")
             .expect("should exist");
 
         // Modify and save again (upsert)
+        std::thread::sleep(Duration::from_millis(2));
         let updated = Download::new(
-            DownloadId(1),
+            DownloadId(id),
             Url::new("https://example.com/updated.zip").expect("valid url"),
             "updated.zip".to_string(),
             "/downloads".to_string(),
@@ -176,12 +188,13 @@ mod tests {
         repo.save(&updated).expect("upsert save");
 
         let found = repo
-            .find_by_id(DownloadId(1))
+            .find_by_id(DownloadId(id))
             .expect("find_by_id")
             .expect("should exist");
         assert_eq!(found.file_name(), "updated.zip");
         assert_eq!(found.destination_path(), "/downloads");
         assert_eq!(found.created_at(), first.created_at());
+        assert!(found.updated_at() > first.updated_at());
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -208,6 +221,54 @@ mod tests {
 
         assert!(reloaded.updated_at() > previous_updated_at);
         assert_eq!(reloaded.created_at(), found.created_at());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_save_heals_legacy_zero_created_at_on_upsert() {
+        let db = setup_test_db().await.expect("test db");
+        let repo = SqliteDownloadRepo::new(db.clone());
+        let created_at = 1_700_000_000_000_u64;
+        let id = ((created_at << 12) | 7) as i64;
+
+        let legacy = download::ActiveModel {
+            id: Set(id),
+            url: Set("https://example.com/file.zip".to_string()),
+            file_name: Set("file.zip".to_string()),
+            state: Set("Queued".to_string()),
+            priority: Set(5),
+            total_bytes: Set(None),
+            downloaded_bytes: Set(0),
+            speed_bytes_per_sec: Set(0),
+            retry_count: Set(0),
+            max_retries: Set(5),
+            segments_count: Set(1),
+            checksum_expected: Set(None),
+            source_hostname: Set("example.com".to_string()),
+            protocol: Set("https".to_string()),
+            resume_supported: Set(0),
+            module_name: Set(None),
+            account_id: Set(None),
+            destination_path: Set("/tmp".to_string()),
+            created_at: Set(0),
+            updated_at: Set(0),
+        };
+        legacy.insert(&db).await.expect("insert legacy row");
+
+        std::thread::sleep(Duration::from_millis(2));
+        let updated = Download::new(
+            DownloadId(id as u64),
+            Url::new("https://example.com/updated.zip").expect("valid url"),
+            "updated.zip".to_string(),
+            "/downloads".to_string(),
+        );
+        repo.save(&updated).expect("upsert save");
+
+        let found = repo
+            .find_by_id(DownloadId(id as u64))
+            .expect("find_by_id")
+            .expect("should exist");
+        assert_eq!(found.created_at(), created_at);
+        assert!(found.updated_at() > created_at);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/src-tauri/src/adapters/driven/sqlite/download_repo.rs
+++ b/src-tauri/src/adapters/driven/sqlite/download_repo.rs
@@ -8,7 +8,9 @@ use crate::domain::model::download::{Download, DownloadId, DownloadState};
 use crate::domain::ports::driven::download_repository::DownloadRepository;
 
 use super::entities::download;
-use super::util::{block_on, infer_timestamp_ms_from_download_id, map_db_err};
+use super::util::{
+    block_on, current_timestamp_ms, infer_timestamp_ms_from_download_id, map_db_err,
+};
 
 pub struct SqliteDownloadRepo {
     db: DatabaseConnection,
@@ -18,13 +20,6 @@ impl SqliteDownloadRepo {
     pub fn new(db: DatabaseConnection) -> Self {
         Self { db }
     }
-}
-
-fn current_timestamp_ms() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
 }
 
 impl DownloadRepository for SqliteDownloadRepo {

--- a/src-tauri/src/adapters/driven/sqlite/util.rs
+++ b/src-tauri/src/adapters/driven/sqlite/util.rs
@@ -2,9 +2,7 @@ use sea_orm::sea_query::{Expr, SimpleExpr};
 
 use crate::domain::error::DomainError;
 
-const MIN_PLAUSIBLE_UNIX_MS: u64 = 946_684_800_000;
-const SQLITE_CURRENT_TIMESTAMP_MS_EXPR: &str =
-    "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
+pub const MIN_PLAUSIBLE_UNIX_MS: u64 = 946_684_800_000;
 
 /// Bridge a sync trait method to async sea-orm by running on a dedicated thread.
 /// Uses `std::thread::scope` + `Handle::block_on` to work with both
@@ -43,12 +41,17 @@ pub fn infer_timestamp_ms_from_download_id(raw_id: i64) -> Option<u64> {
 pub fn current_timestamp_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_millis() as u64
+        .map(|duration| duration.as_millis().min(u64::MAX as u128) as u64)
+        .unwrap_or(MIN_PLAUSIBLE_UNIX_MS)
 }
 
 pub fn inferred_download_created_at_order_expr() -> SimpleExpr {
     Expr::cust(format!(
-        "CASE WHEN created_at > 0 THEN created_at WHEN ((id >> 12) >= {MIN_PLAUSIBLE_UNIX_MS}) THEN (id >> 12) ELSE {SQLITE_CURRENT_TIMESTAMP_MS_EXPR} END"
+        "CASE \
+            WHEN created_at > 0 THEN created_at \
+            WHEN ((id >> 12) >= {MIN_PLAUSIBLE_UNIX_MS}) THEN (id >> 12) \
+            WHEN updated_at > 0 THEN updated_at \
+            ELSE {MIN_PLAUSIBLE_UNIX_MS} \
+        END"
     ))
 }

--- a/src-tauri/src/adapters/driven/sqlite/util.rs
+++ b/src-tauri/src/adapters/driven/sqlite/util.rs
@@ -3,6 +3,8 @@ use sea_orm::sea_query::{Expr, SimpleExpr};
 use crate::domain::error::DomainError;
 
 const MIN_PLAUSIBLE_UNIX_MS: u64 = 946_684_800_000;
+const SQLITE_CURRENT_TIMESTAMP_MS_EXPR: &str =
+    "CAST((julianday('now') - 2440587.5) * 86400000 AS INTEGER)";
 
 /// Bridge a sync trait method to async sea-orm by running on a dedicated thread.
 /// Uses `std::thread::scope` + `Handle::block_on` to work with both
@@ -38,8 +40,15 @@ pub fn infer_timestamp_ms_from_download_id(raw_id: i64) -> Option<u64> {
     (ts >= MIN_PLAUSIBLE_UNIX_MS).then_some(ts)
 }
 
+pub fn current_timestamp_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
 pub fn inferred_download_created_at_order_expr() -> SimpleExpr {
     Expr::cust(format!(
-        "CASE WHEN created_at > 0 THEN created_at WHEN ((id >> 12) >= {MIN_PLAUSIBLE_UNIX_MS}) THEN (id >> 12) ELSE 0 END"
+        "CASE WHEN created_at > 0 THEN created_at WHEN ((id >> 12) >= {MIN_PLAUSIBLE_UNIX_MS}) THEN (id >> 12) ELSE {SQLITE_CURRENT_TIMESTAMP_MS_EXPR} END"
     ))
 }

--- a/src-tauri/src/adapters/driven/sqlite/util.rs
+++ b/src-tauri/src/adapters/driven/sqlite/util.rs
@@ -1,4 +1,8 @@
+use sea_orm::sea_query::{Expr, SimpleExpr};
+
 use crate::domain::error::DomainError;
+
+const MIN_PLAUSIBLE_UNIX_MS: u64 = 946_684_800_000;
 
 /// Bridge a sync trait method to async sea-orm by running on a dedicated thread.
 /// Uses `std::thread::scope` + `Handle::block_on` to work with both
@@ -27,4 +31,15 @@ pub fn safe_u64(val: i64) -> u64 {
 /// Safely convert an i64 from SQLite to u32, defaulting to 0 for out-of-range values.
 pub fn safe_u32(val: i64) -> u32 {
     u32::try_from(val).unwrap_or(0)
+}
+
+pub fn infer_timestamp_ms_from_download_id(raw_id: i64) -> Option<u64> {
+    let ts = safe_u64(raw_id) >> 12;
+    (ts >= MIN_PLAUSIBLE_UNIX_MS).then_some(ts)
+}
+
+pub fn inferred_download_created_at_order_expr() -> SimpleExpr {
+    Expr::cust(format!(
+        "CASE WHEN created_at > 0 THEN created_at WHEN ((id >> 12) >= {MIN_PLAUSIBLE_UNIX_MS}) THEN (id >> 12) ELSE 0 END"
+    ))
 }


### PR DESCRIPTION
## Summary

• initialize `created_at` and `updated_at` when persisting downloads to SQLite
• recover timestamps for legacy rows with zero values in `download_detail`
• add regression tests covering saved downloads and legacy zero-timestamp rows

Closes #48

## Type

fix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore `created_at`/`updated_at` in download details and fix CreatedAt sorting, including legacy rows. Stabilizes `created_at` on save and safely backfills timestamps on read. Addresses Linear #48.

- **Bug Fixes**
  - Save: set `created_at` from `DownloadId` or now; keep existing `created_at` on upsert; set `updated_at` to now on updates and to `created_at` on first insert.
  - Read and ordering: if `created_at` is zero, infer from `DownloadId`; if undecodable, use `updated_at` when present, else `MIN_PLAUSIBLE_UNIX_MS`; CreatedAt sorting (and default order) uses a CASE that prefers stored `created_at`, then `(id >> 12)` when plausible, then `updated_at`, else `MIN_PLAUSIBLE_UNIX_MS`.
  - Tests: added coverage for saved downloads, legacy zero-timestamp rows, undecodable-ID fallbacks (`updated_at`/min-plausible), CreatedAt sorting, `updated_at` refresh, `created_at` stability, and healing zero `created_at` on upsert.

<sup>Written for commit 5fce263c53bc8661175b8f66651912f325b95ab9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Repaired timestamp handling so downloads always have valid created/updated times; legacy records with missing timestamps are healed.
  * Saving/upserting downloads now preserves original creation times while reliably advancing update times.
  * Download listing now sorts by an inferred creation time when explicit timestamps are missing.

* **Tests**
  * Added tests covering timestamp population, legacy fallback behavior, and sorting by inferred creation time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->