### PR TITLE
fix(download): resolve segments stuck at 0%, all downloads failing (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - `maxConcurrentDownloads` validation now enforces the PRD §6.10 limit of 1–20 (was incorrectly accepting up to 100) in both backend validation and the settings UI input
+- Download engine was double-joining `file_name` onto `destination_path`, producing a path like `/Downloads/file.bin/file.bin` and causing all downloads to fail silently with a "Not a directory" I/O error before any bytes were fetched (fixes #54)
+- `SegmentStarted` event now carries `start_byte` and `end_byte` so downstream consumers can identify which byte range a segment covers
 
 ### Added
+- `spawn_sqlite_progress_bridge` — new event bridge that persists live download state to SQLite (`downloads.downloaded_bytes`, `download_segments` rows) so the read model reflects real progress instead of always showing 0%
 - `SqliteStatsRepo` — persistent download statistics backed by SQLite (replaces in-memory stub)
 - Project scaffolding: Tauri 2 + React 19 + TypeScript + Tailwind CSS 4 + shadcn/ui
 - Nix flake for reproducible development environment

--- a/src-tauri/src/adapters/driven/event/tauri_bridge.rs
+++ b/src-tauri/src/adapters/driven/event/tauri_bridge.rs
@@ -68,8 +68,12 @@ fn event_payload(event: &DomainEvent) -> serde_json::Value {
         DomainEvent::SegmentStarted {
             download_id,
             segment_id,
+            start_byte,
+            end_byte,
+        } => {
+            json!({ "downloadId": download_id.0, "segmentId": segment_id, "startByte": start_byte, "endByte": end_byte })
         }
-        | DomainEvent::SegmentCompleted {
+        DomainEvent::SegmentCompleted {
             download_id,
             segment_id,
         } => {
@@ -173,7 +177,9 @@ mod tests {
         assert_eq!(
             event_name(&DomainEvent::SegmentStarted {
                 download_id: DownloadId(1),
-                segment_id: 0
+                segment_id: 0,
+                start_byte: 0,
+                end_byte: 1024,
             }),
             "segment-started"
         );

--- a/src-tauri/src/adapters/driven/event/tauri_bridge.rs
+++ b/src-tauri/src/adapters/driven/event/tauri_bridge.rs
@@ -174,15 +174,32 @@ mod tests {
 
     #[test]
     fn test_event_name_segment_variants() {
-        assert_eq!(
-            event_name(&DomainEvent::SegmentStarted {
-                download_id: DownloadId(1),
-                segment_id: 0,
-                start_byte: 0,
-                end_byte: 1024,
-            }),
-            "segment-started"
-        );
+        let started = DomainEvent::SegmentStarted {
+            download_id: DownloadId(1),
+            segment_id: 0,
+            start_byte: 0,
+            end_byte: 1024,
+        };
+        assert_eq!(event_name(&started), "segment-started");
+        let (event, payload) = to_tauri_event(&started);
+        assert_eq!(event, "segment-started");
+        assert_eq!(payload["downloadId"].as_u64(), Some(1));
+        assert_eq!(payload["segmentId"].as_u64(), Some(0));
+        assert_eq!(payload["startByte"].as_u64(), Some(0));
+        assert_eq!(payload["endByte"].as_u64(), Some(1024));
+
+        let sentinel = DomainEvent::SegmentStarted {
+            download_id: DownloadId(2),
+            segment_id: 3,
+            start_byte: 99,
+            end_byte: u64::MAX,
+        };
+        let (_, sentinel_payload) = to_tauri_event(&sentinel);
+        assert_eq!(sentinel_payload["downloadId"].as_u64(), Some(2));
+        assert_eq!(sentinel_payload["segmentId"].as_u64(), Some(3));
+        assert_eq!(sentinel_payload["startByte"].as_u64(), Some(99));
+        assert_eq!(sentinel_payload["endByte"].as_u64(), Some(u64::MAX));
+
         assert_eq!(
             event_name(&DomainEvent::SegmentCompleted {
                 download_id: DownloadId(1),

--- a/src-tauri/src/adapters/driven/event/tauri_bridge.rs
+++ b/src-tauri/src/adapters/driven/event/tauri_bridge.rs
@@ -71,7 +71,12 @@ fn event_payload(event: &DomainEvent) -> serde_json::Value {
             start_byte,
             end_byte,
         } => {
-            json!({ "downloadId": download_id.0, "segmentId": segment_id, "startByte": start_byte, "endByte": end_byte })
+            let end_byte_payload = if *end_byte == u64::MAX {
+                json!(-1_i64)
+            } else {
+                json!(*end_byte)
+            };
+            json!({ "downloadId": download_id.0, "segmentId": segment_id, "startByte": start_byte, "endByte": end_byte_payload })
         }
         DomainEvent::SegmentCompleted {
             download_id,
@@ -198,7 +203,7 @@ mod tests {
         assert_eq!(sentinel_payload["downloadId"].as_u64(), Some(2));
         assert_eq!(sentinel_payload["segmentId"].as_u64(), Some(3));
         assert_eq!(sentinel_payload["startByte"].as_u64(), Some(99));
-        assert_eq!(sentinel_payload["endByte"].as_u64(), Some(u64::MAX));
+        assert_eq!(sentinel_payload["endByte"].as_i64(), Some(-1));
 
         assert_eq!(
             event_name(&DomainEvent::SegmentCompleted {

--- a/src-tauri/src/adapters/driven/logging/download_log_bridge.rs
+++ b/src-tauri/src/adapters/driven/logging/download_log_bridge.rs
@@ -58,6 +58,7 @@ fn record_download_event(store: &DownloadLogStore, event: &DomainEvent) {
         DomainEvent::SegmentStarted {
             download_id,
             segment_id,
+            ..
         } => {
             store.push(
                 download_id.0,

--- a/src-tauri/src/adapters/driven/network/download_engine.rs
+++ b/src-tauri/src/adapters/driven/network/download_engine.rs
@@ -55,7 +55,9 @@ impl DownloadEngine for SegmentedDownloadEngine {
     fn start(&self, download: &Download) -> Result<(), DomainError> {
         let download_id = download.id();
         let url = download.url().as_str().to_string();
-        let dest_path = PathBuf::from(download.destination_path()).join(download.file_name());
+        // destination_path already contains the complete file path (dir + filename).
+        // Do NOT join file_name again — that would produce "dir/file.bin/file.bin".
+        let dest_path = PathBuf::from(download.destination_path());
         let segments_count = if download.segments_count() == 0 {
             self.default_segments
         } else {
@@ -442,11 +444,13 @@ mod tests {
     fn make_download(id: u64, url: &str) -> Download {
         let download_id = DownloadId(id);
         let parsed_url = Url::new(url).unwrap();
+        // destination_path must be the full file path (dir + filename),
+        // matching how StartDownloadCommand builds it in production.
         Download::new(
             download_id,
             parsed_url,
             "test_file.bin".to_string(),
-            "/tmp".to_string(),
+            "/tmp/test_file.bin".to_string(),
         )
     }
 

--- a/src-tauri/src/adapters/driven/network/segment_worker.rs
+++ b/src-tauri/src/adapters/driven/network/segment_worker.rs
@@ -523,7 +523,8 @@ mod tests {
                 DomainEvent::SegmentStarted {
                     download_id: DownloadId(4),
                     segment_id: 0,
-                    ..
+                    start_byte: 0,
+                    end_byte: 10_000,
                 }
             )
         });
@@ -583,7 +584,8 @@ mod tests {
                 DomainEvent::SegmentStarted {
                     download_id: DownloadId(5),
                     segment_id: 1,
-                    ..
+                    start_byte: 0,
+                    end_byte: 512,
                 }
             )),
             "SegmentStarted missing"
@@ -639,7 +641,8 @@ mod tests {
                 DomainEvent::SegmentStarted {
                     download_id: DownloadId(6),
                     segment_id: 0,
-                    ..
+                    start_byte: 0,
+                    end_byte: 1000,
                 }
             )),
             "SegmentStarted missing"

--- a/src-tauri/src/adapters/driven/network/segment_worker.rs
+++ b/src-tauri/src/adapters/driven/network/segment_worker.rs
@@ -64,6 +64,8 @@ pub(crate) async fn download_segment(params: SegmentParams) -> Result<u64, Segme
     event_bus.publish(DomainEvent::SegmentStarted {
         download_id,
         segment_id: segment_index,
+        start_byte,
+        end_byte,
     });
 
     let effective_start = start_byte + already_downloaded;
@@ -520,7 +522,8 @@ mod tests {
                 e,
                 DomainEvent::SegmentStarted {
                     download_id: DownloadId(4),
-                    segment_id: 0
+                    segment_id: 0,
+                    ..
                 }
             )
         });
@@ -579,7 +582,8 @@ mod tests {
                 e,
                 DomainEvent::SegmentStarted {
                     download_id: DownloadId(5),
-                    segment_id: 1
+                    segment_id: 1,
+                    ..
                 }
             )),
             "SegmentStarted missing"
@@ -634,7 +638,8 @@ mod tests {
                 e,
                 DomainEvent::SegmentStarted {
                     download_id: DownloadId(6),
-                    segment_id: 0
+                    segment_id: 0,
+                    ..
                 }
             )),
             "SegmentStarted missing"

--- a/src-tauri/src/adapters/driven/sqlite/mod.rs
+++ b/src-tauri/src/adapters/driven/sqlite/mod.rs
@@ -4,5 +4,6 @@ pub mod download_repo;
 pub mod entities;
 pub mod history_repo;
 pub mod migrations;
+pub mod progress_bridge;
 pub mod stats_repo;
 mod util;

--- a/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
+++ b/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
@@ -7,7 +7,7 @@
 //! Segment row IDs are computed deterministically as
 //! `download_id * 100 + segment_index`, which is safe for the current
 //! snowflake-based download IDs (~7 × 10¹⁵) and the bounded segment count
-//! (≤ 16 per download by default).
+//! (`segment_index < 100`; config validation currently caps segments at 32).
 //!
 //! All DB mutations are serialised through a single background worker task,
 //! so that `SegmentCompleted` can never execute before its preceding
@@ -105,10 +105,16 @@ pub fn spawn_sqlite_progress_bridge(event_bus: &dyn EventBus, db: DatabaseConnec
     }));
 }
 
-fn segment_row_id(download_id: u64, segment_index: u32) -> i64 {
-    (download_id as i64)
-        .saturating_mul(100)
-        .saturating_add(segment_index as i64)
+fn segment_row_id(download_id: u64, segment_index: u32) -> Option<i64> {
+    if segment_index >= 100 {
+        return None;
+    }
+
+    Some(
+        (download_id as i64)
+            .saturating_mul(100)
+            .saturating_add(segment_index as i64),
+    )
 }
 
 fn event_to_message(event: &DomainEvent) -> Option<BridgeMessage> {
@@ -136,8 +142,16 @@ fn event_to_message(event: &DomainEvent) -> Option<BridgeMessage> {
             } else {
                 *end_byte as i64
             };
+            let Some(row_id) = segment_row_id(download_id.0, *segment_index) else {
+                tracing::warn!(
+                    download_id = download_id.0,
+                    segment_index = *segment_index,
+                    "progress_bridge: refusing segment index >= 100 to avoid row-id collisions"
+                );
+                return None;
+            };
             Some(BridgeMessage::SegmentStarted {
-                row_id: segment_row_id(download_id.0, *segment_index),
+                row_id,
                 download_id: download_id.0 as i64,
                 segment_index: *segment_index as i32,
                 start_byte: *start_byte as i64,
@@ -282,8 +296,8 @@ mod tests {
 
     #[test]
     fn test_segment_row_id_is_deterministic() {
-        assert_eq!(segment_row_id(42, 0), 4200);
-        assert_eq!(segment_row_id(42, 3), 4203);
+        assert_eq!(segment_row_id(42, 0), Some(4200));
+        assert_eq!(segment_row_id(42, 3), Some(4203));
     }
 
     #[test]
@@ -291,13 +305,18 @@ mod tests {
         // Snowflake IDs are ~(ts_ms << 12) ≈ 6.97 × 10^15 at current time.
         // typical_id = 1_744_000_000_000 * 4_096 = 7_143_424_000_000_000
         let typical_id: u64 = 1_744_000_000_000 << 12;
-        let row_id = segment_row_id(typical_id, 15);
+        let row_id = segment_row_id(typical_id, 15).expect("segment_index < 100");
         // 7_143_424_000_000_000 * 100 + 15 = 714_342_400_000_000_015
         // i64::MAX = 9_223_372_036_854_775_807  →  well within range
         assert_eq!(
             row_id, 714_342_400_000_000_015_i64,
             "row_id must be deterministic and not overflow"
         );
+    }
+
+    #[test]
+    fn test_segment_row_id_rejects_large_segment_index() {
+        assert_eq!(segment_row_id(42, 100), None);
     }
 
     #[test]
@@ -374,7 +393,7 @@ mod tests {
         let db = setup_test_db().await.unwrap();
         insert_download_row(&db, 7, Some(4096), 0).await;
 
-        let row_id = segment_row_id(7, 2);
+        let row_id = segment_row_id(7, 2).expect("segment_index < 100");
         insert_segment(&db, row_id, 7, 2, 128, 640).await;
         complete_segment(&db, 7, 2).await;
 
@@ -395,7 +414,7 @@ mod tests {
         let db = setup_test_db().await.unwrap();
         insert_download_row(&db, 9, Some(2048), 1536).await;
 
-        let row_id = segment_row_id(9, 0);
+        let row_id = segment_row_id(9, 0).expect("segment_index < 100");
         insert_segment(&db, row_id, 9, 0, 0, -1).await;
         complete_segment(&db, 9, 0).await;
 
@@ -416,7 +435,7 @@ mod tests {
         let db = setup_test_db().await.unwrap();
         insert_download_row(&db, 11, None, 777).await;
 
-        let row_id = segment_row_id(11, 0);
+        let row_id = segment_row_id(11, 0).expect("segment_index < 100");
         insert_segment(&db, row_id, 11, 0, 0, -1).await;
         complete_segment(&db, 11, 0).await;
 

--- a/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
+++ b/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
@@ -293,7 +293,7 @@ mod tests {
         // i64::MAX = 9_223_372_036_854_775_807  →  well within range
         assert_eq!(
             row_id, 714_342_400_000_000_015_i64,
-            "row_id must be deterministic and fit in i64"
+            "row_id must be deterministic and not overflow"
         );
     }
 

--- a/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
+++ b/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
@@ -8,19 +8,97 @@
 //! `download_id * 100 + segment_index`, which is safe for the current
 //! snowflake-based download IDs (~7 × 10¹⁵) and the bounded segment count
 //! (≤ 16 per download by default).
+//!
+//! All DB mutations are serialised through a single background worker task,
+//! so that `SegmentCompleted` can never execute before its preceding
+//! `SegmentStarted` insert, and progress values never regress.
+
+use tokio::sync::mpsc;
 
 use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
 
 use crate::domain::event::DomainEvent;
 use crate::domain::ports::driven::EventBus;
 
+/// Messages sent from the event-bus subscriber to the DB worker.
+enum BridgeMessage {
+    Progress {
+        download_id: i64,
+        downloaded_bytes: i64,
+    },
+    SegmentStarted {
+        row_id: i64,
+        download_id: i64,
+        segment_index: i32,
+        /// `-1` when `end_byte` was the `u64::MAX` no-range sentinel.
+        start_byte: i64,
+        end_byte: i64,
+    },
+    SegmentCompleted {
+        download_id: i64,
+        segment_index: i32,
+    },
+    SegmentFailed {
+        download_id: i64,
+        segment_index: i32,
+    },
+}
+
 /// Register the SQLite progress bridge on the given event bus.
 ///
-/// Each relevant domain event spawns a fire-and-forget tokio task that writes
-/// to the database. Failures are logged as warnings and do not crash the app.
+/// All DB mutations are routed through a single background worker, which
+/// guarantees that writes are applied in event-bus order and that
+/// `SegmentCompleted` cannot outrace its `SegmentStarted` insert.
 pub fn spawn_sqlite_progress_bridge(event_bus: &dyn EventBus, db: DatabaseConnection) {
+    let (tx, mut rx) = mpsc::unbounded_channel::<BridgeMessage>();
+
+    tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            match msg {
+                BridgeMessage::Progress {
+                    download_id,
+                    downloaded_bytes,
+                } => {
+                    update_download_progress(&db, download_id, downloaded_bytes).await;
+                }
+                BridgeMessage::SegmentStarted {
+                    row_id,
+                    download_id,
+                    segment_index,
+                    start_byte,
+                    end_byte,
+                } => {
+                    insert_segment(
+                        &db,
+                        row_id,
+                        download_id,
+                        segment_index,
+                        start_byte,
+                        end_byte,
+                    )
+                    .await;
+                }
+                BridgeMessage::SegmentCompleted {
+                    download_id,
+                    segment_index,
+                } => {
+                    complete_segment(&db, download_id, segment_index).await;
+                }
+                BridgeMessage::SegmentFailed {
+                    download_id,
+                    segment_index,
+                } => {
+                    fail_segment(&db, download_id, segment_index).await;
+                }
+            }
+        }
+    });
+
     event_bus.subscribe(Box::new(move |event: &DomainEvent| {
-        handle_event(db.clone(), event);
+        let msg = event_to_message(event);
+        if let Some(m) = msg {
+            tx.send(m).ok();
+        }
     }));
 }
 
@@ -30,19 +108,16 @@ fn segment_row_id(download_id: u64, segment_index: u32) -> i64 {
         .saturating_add(segment_index as i64)
 }
 
-fn handle_event(db: DatabaseConnection, event: &DomainEvent) {
+fn event_to_message(event: &DomainEvent) -> Option<BridgeMessage> {
     match event {
         DomainEvent::DownloadProgress {
             id,
             downloaded_bytes,
             total_bytes: _,
-        } => {
-            let download_id = id.0 as i64;
-            let downloaded = *downloaded_bytes as i64;
-            tokio::spawn(async move {
-                update_download_progress(&db, download_id, downloaded).await;
-            });
-        }
+        } => Some(BridgeMessage::Progress {
+            download_id: id.0 as i64,
+            downloaded_bytes: *downloaded_bytes as i64,
+        }),
 
         DomainEvent::SegmentStarted {
             download_id,
@@ -50,49 +125,52 @@ fn handle_event(db: DatabaseConnection, event: &DomainEvent) {
             start_byte,
             end_byte,
         } => {
-            let row_id = segment_row_id(download_id.0, *segment_index);
-            let did = download_id.0 as i64;
-            let sidx = *segment_index as i32;
-            let sb = *start_byte as i64;
-            let eb = *end_byte as i64;
-            tokio::spawn(async move {
-                insert_segment(&db, row_id, did, sidx, sb, eb).await;
-            });
+            // u64::MAX is the sentinel for "no Range header" — cast it to -1
+            // so the DB stores a recognisable sentinel that complete_segment
+            // can guard against (see CASE WHEN end_byte >= 0 below).
+            let eb = if *end_byte == u64::MAX {
+                -1_i64
+            } else {
+                *end_byte as i64
+            };
+            Some(BridgeMessage::SegmentStarted {
+                row_id: segment_row_id(download_id.0, *segment_index),
+                download_id: download_id.0 as i64,
+                segment_index: *segment_index as i32,
+                start_byte: *start_byte as i64,
+                end_byte: eb,
+            })
         }
 
         DomainEvent::SegmentCompleted {
             download_id,
             segment_id: segment_index,
-        } => {
-            let did = download_id.0 as i64;
-            let sidx = *segment_index as i32;
-            tokio::spawn(async move {
-                complete_segment(&db, did, sidx).await;
-            });
-        }
+        } => Some(BridgeMessage::SegmentCompleted {
+            download_id: download_id.0 as i64,
+            segment_index: *segment_index as i32,
+        }),
 
         DomainEvent::SegmentFailed {
             download_id,
             segment_id: segment_index,
             ..
-        } => {
-            let did = download_id.0 as i64;
-            let sidx = *segment_index as i32;
-            tokio::spawn(async move {
-                fail_segment(&db, did, sidx).await;
-            });
-        }
+        } => Some(BridgeMessage::SegmentFailed {
+            download_id: download_id.0 as i64,
+            segment_index: *segment_index as i32,
+        }),
 
-        _ => {}
+        _ => None,
     }
 }
 
+/// Update `downloads.downloaded_bytes`, never allowing a stale write to
+/// decrease the stored value (monotonic via SQL `MAX`).
 async fn update_download_progress(
     db: &DatabaseConnection,
     download_id: i64,
     downloaded_bytes: i64,
 ) {
-    let sql = "UPDATE downloads SET downloaded_bytes = ? WHERE id = ?";
+    let sql = "UPDATE downloads SET downloaded_bytes = MAX(downloaded_bytes, ?) WHERE id = ?";
     let stmt = Statement::from_sql_and_values(
         DatabaseBackend::Sqlite,
         sql,
@@ -135,9 +213,16 @@ async fn insert_segment(
     }
 }
 
+/// Mark a segment Completed and set its downloaded_bytes.
+///
+/// When `end_byte` is the sentinel `-1` (no-Range download), the byte
+/// calculation is skipped so we never write a negative value.
 async fn complete_segment(db: &DatabaseConnection, download_id: i64, segment_index: i32) {
     let sql = "UPDATE download_segments \
-               SET state = 'Completed', downloaded_bytes = end_byte - start_byte \
+               SET state = 'Completed', \
+                   downloaded_bytes = CASE WHEN end_byte >= 0 \
+                                          THEN end_byte - start_byte \
+                                          ELSE downloaded_bytes END \
                WHERE download_id = ? AND segment_index = ?";
     let stmt = Statement::from_sql_and_values(
         DatabaseBackend::Sqlite,
@@ -185,10 +270,51 @@ mod tests {
 
     #[test]
     fn test_segment_row_id_no_overflow_for_snowflake_id() {
-        // Snowflake IDs are ~(ts_ms << 12) ≈ 6.97 × 10^15 at current time
-        let typical_id: u64 = 1_744_000_000_000 << 12; // ~7.1 × 10^15
+        // Snowflake IDs are ~(ts_ms << 12) ≈ 6.97 × 10^15 at current time.
+        // typical_id = 1_744_000_000_000 * 4_096 = 7_143_424_000_000_000
+        let typical_id: u64 = 1_744_000_000_000 << 12;
         let row_id = segment_row_id(typical_id, 15);
-        // Must fit in i64 (max 9.22 × 10^18)
-        assert!(row_id > 0, "row_id must not overflow to negative");
+        // 7_143_424_000_000_000 * 100 + 15 = 714_342_400_000_000_015
+        // i64::MAX = 9_223_372_036_854_775_807  →  well within range
+        assert_eq!(
+            row_id, 714_342_400_000_000_015_i64,
+            "row_id must be deterministic and fit in i64"
+        );
+    }
+
+    #[test]
+    fn test_event_to_message_sentinel_end_byte() {
+        use crate::domain::model::download::DownloadId;
+
+        let event = DomainEvent::SegmentStarted {
+            download_id: DownloadId(1),
+            segment_id: 0,
+            start_byte: 0,
+            end_byte: u64::MAX,
+        };
+        match event_to_message(&event) {
+            Some(BridgeMessage::SegmentStarted { end_byte, .. }) => {
+                assert_eq!(end_byte, -1_i64, "u64::MAX sentinel must become -1i64");
+            }
+            _ => panic!("expected SegmentStarted message"),
+        }
+    }
+
+    #[test]
+    fn test_event_to_message_normal_end_byte() {
+        use crate::domain::model::download::DownloadId;
+
+        let event = DomainEvent::SegmentStarted {
+            download_id: DownloadId(1),
+            segment_id: 0,
+            start_byte: 0,
+            end_byte: 1024,
+        };
+        match event_to_message(&event) {
+            Some(BridgeMessage::SegmentStarted { end_byte, .. }) => {
+                assert_eq!(end_byte, 1024_i64);
+            }
+            _ => panic!("expected SegmentStarted message"),
+        }
     }
 }

--- a/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
+++ b/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
@@ -1,0 +1,194 @@
+//! Persists download progress and segment state to SQLite.
+//!
+//! This bridge subscribes to the domain event bus and updates the read-model
+//! tables (`downloads`, `download_segments`) so that queries reflect live
+//! progress without the download engine touching the database directly.
+//!
+//! Segment row IDs are computed deterministically as
+//! `download_id * 100 + segment_index`, which is safe for the current
+//! snowflake-based download IDs (~7 × 10¹⁵) and the bounded segment count
+//! (≤ 16 per download by default).
+
+use sea_orm::{ConnectionTrait, DatabaseBackend, DatabaseConnection, Statement};
+
+use crate::domain::event::DomainEvent;
+use crate::domain::ports::driven::EventBus;
+
+/// Register the SQLite progress bridge on the given event bus.
+///
+/// Each relevant domain event spawns a fire-and-forget tokio task that writes
+/// to the database. Failures are logged as warnings and do not crash the app.
+pub fn spawn_sqlite_progress_bridge(event_bus: &dyn EventBus, db: DatabaseConnection) {
+    event_bus.subscribe(Box::new(move |event: &DomainEvent| {
+        handle_event(db.clone(), event);
+    }));
+}
+
+fn segment_row_id(download_id: u64, segment_index: u32) -> i64 {
+    (download_id as i64)
+        .saturating_mul(100)
+        .saturating_add(segment_index as i64)
+}
+
+fn handle_event(db: DatabaseConnection, event: &DomainEvent) {
+    match event {
+        DomainEvent::DownloadProgress {
+            id,
+            downloaded_bytes,
+            total_bytes: _,
+        } => {
+            let download_id = id.0 as i64;
+            let downloaded = *downloaded_bytes as i64;
+            tokio::spawn(async move {
+                update_download_progress(&db, download_id, downloaded).await;
+            });
+        }
+
+        DomainEvent::SegmentStarted {
+            download_id,
+            segment_id: segment_index,
+            start_byte,
+            end_byte,
+        } => {
+            let row_id = segment_row_id(download_id.0, *segment_index);
+            let did = download_id.0 as i64;
+            let sidx = *segment_index as i32;
+            let sb = *start_byte as i64;
+            let eb = *end_byte as i64;
+            tokio::spawn(async move {
+                insert_segment(&db, row_id, did, sidx, sb, eb).await;
+            });
+        }
+
+        DomainEvent::SegmentCompleted {
+            download_id,
+            segment_id: segment_index,
+        } => {
+            let did = download_id.0 as i64;
+            let sidx = *segment_index as i32;
+            tokio::spawn(async move {
+                complete_segment(&db, did, sidx).await;
+            });
+        }
+
+        DomainEvent::SegmentFailed {
+            download_id,
+            segment_id: segment_index,
+            ..
+        } => {
+            let did = download_id.0 as i64;
+            let sidx = *segment_index as i32;
+            tokio::spawn(async move {
+                fail_segment(&db, did, sidx).await;
+            });
+        }
+
+        _ => {}
+    }
+}
+
+async fn update_download_progress(
+    db: &DatabaseConnection,
+    download_id: i64,
+    downloaded_bytes: i64,
+) {
+    let sql = "UPDATE downloads SET downloaded_bytes = ? WHERE id = ?";
+    let stmt = Statement::from_sql_and_values(
+        DatabaseBackend::Sqlite,
+        sql,
+        [downloaded_bytes.into(), download_id.into()],
+    );
+    if let Err(e) = db.execute(stmt).await {
+        tracing::warn!(download_id, error = %e, "progress_bridge: failed to update downloaded_bytes");
+    }
+}
+
+async fn insert_segment(
+    db: &DatabaseConnection,
+    row_id: i64,
+    download_id: i64,
+    segment_index: i32,
+    start_byte: i64,
+    end_byte: i64,
+) {
+    let sql = "INSERT OR REPLACE INTO download_segments \
+               (id, download_id, segment_index, start_byte, end_byte, downloaded_bytes, state) \
+               VALUES (?, ?, ?, ?, ?, 0, 'Downloading')";
+    let stmt = Statement::from_sql_and_values(
+        DatabaseBackend::Sqlite,
+        sql,
+        [
+            row_id.into(),
+            download_id.into(),
+            (segment_index as i64).into(),
+            start_byte.into(),
+            end_byte.into(),
+        ],
+    );
+    if let Err(e) = db.execute(stmt).await {
+        tracing::warn!(
+            download_id,
+            segment_index,
+            error = %e,
+            "progress_bridge: failed to insert segment"
+        );
+    }
+}
+
+async fn complete_segment(db: &DatabaseConnection, download_id: i64, segment_index: i32) {
+    let sql = "UPDATE download_segments \
+               SET state = 'Completed', downloaded_bytes = end_byte - start_byte \
+               WHERE download_id = ? AND segment_index = ?";
+    let stmt = Statement::from_sql_and_values(
+        DatabaseBackend::Sqlite,
+        sql,
+        [download_id.into(), (segment_index as i64).into()],
+    );
+    if let Err(e) = db.execute(stmt).await {
+        tracing::warn!(
+            download_id,
+            segment_index,
+            error = %e,
+            "progress_bridge: failed to mark segment completed"
+        );
+    }
+}
+
+async fn fail_segment(db: &DatabaseConnection, download_id: i64, segment_index: i32) {
+    let sql = "UPDATE download_segments \
+               SET state = 'Error' \
+               WHERE download_id = ? AND segment_index = ?";
+    let stmt = Statement::from_sql_and_values(
+        DatabaseBackend::Sqlite,
+        sql,
+        [download_id.into(), (segment_index as i64).into()],
+    );
+    if let Err(e) = db.execute(stmt).await {
+        tracing::warn!(
+            download_id,
+            segment_index,
+            error = %e,
+            "progress_bridge: failed to mark segment failed"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_segment_row_id_is_deterministic() {
+        assert_eq!(segment_row_id(42, 0), 4200);
+        assert_eq!(segment_row_id(42, 3), 4203);
+    }
+
+    #[test]
+    fn test_segment_row_id_no_overflow_for_snowflake_id() {
+        // Snowflake IDs are ~(ts_ms << 12) ≈ 6.97 × 10^15 at current time
+        let typical_id: u64 = 1_744_000_000_000 << 12; // ~7.1 × 10^15
+        let row_id = segment_row_id(typical_id, 15);
+        // Must fit in i64 (max 9.22 × 10^18)
+        assert!(row_id > 0, "row_id must not overflow to negative");
+    }
+}

--- a/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
+++ b/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
@@ -21,6 +21,7 @@ use crate::domain::event::DomainEvent;
 use crate::domain::ports::driven::EventBus;
 
 /// Messages sent from the event-bus subscriber to the DB worker.
+#[derive(Debug)]
 enum BridgeMessage {
     Progress {
         download_id: i64,
@@ -96,8 +97,10 @@ pub fn spawn_sqlite_progress_bridge(event_bus: &dyn EventBus, db: DatabaseConnec
 
     event_bus.subscribe(Box::new(move |event: &DomainEvent| {
         let msg = event_to_message(event);
-        if let Some(m) = msg {
-            tx.send(m).ok();
+        if let Some(m) = msg
+            && let Err(error) = tx.send(m)
+        {
+            tracing::warn!(event = ?event, ?error, "progress_bridge: worker channel closed");
         }
     }));
 }

--- a/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
+++ b/src-tauri/src/adapters/driven/sqlite/progress_bridge.rs
@@ -215,19 +215,30 @@ async fn insert_segment(
 
 /// Mark a segment Completed and set its downloaded_bytes.
 ///
-/// When `end_byte` is the sentinel `-1` (no-Range download), the byte
-/// calculation is skipped so we never write a negative value.
+/// `end_byte` is exclusive for ranged segments, so the completed byte count is
+/// `end_byte - start_byte`. When `end_byte` is the sentinel `-1` (no-Range
+/// download), fall back to the parent download's known total bytes, or its
+/// aggregate downloaded bytes if the total is still unknown.
 async fn complete_segment(db: &DatabaseConnection, download_id: i64, segment_index: i32) {
     let sql = "UPDATE download_segments \
                SET state = 'Completed', \
                    downloaded_bytes = CASE WHEN end_byte >= 0 \
                                           THEN end_byte - start_byte \
-                                          ELSE downloaded_bytes END \
+                                          ELSE COALESCE( \
+                                              (SELECT total_bytes FROM downloads WHERE id = ?), \
+                                              (SELECT downloaded_bytes FROM downloads WHERE id = ?), \
+                                              downloaded_bytes \
+                                          ) END \
                WHERE download_id = ? AND segment_index = ?";
     let stmt = Statement::from_sql_and_values(
         DatabaseBackend::Sqlite,
         sql,
-        [download_id.into(), (segment_index as i64).into()],
+        [
+            download_id.into(),
+            download_id.into(),
+            download_id.into(),
+            (segment_index as i64).into(),
+        ],
     );
     if let Err(e) = db.execute(stmt).await {
         tracing::warn!(
@@ -261,6 +272,10 @@ async fn fail_segment(db: &DatabaseConnection, download_id: i64, segment_index: 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sea_orm::{ActiveModelTrait, EntityTrait, Set};
+
+    use crate::adapters::driven::sqlite::connection::setup_test_db;
+    use crate::adapters::driven::sqlite::entities::{download, download_segment};
 
     #[test]
     fn test_segment_row_id_is_deterministic() {
@@ -316,5 +331,101 @@ mod tests {
             }
             _ => panic!("expected SegmentStarted message"),
         }
+    }
+
+    async fn insert_download_row(
+        db: &DatabaseConnection,
+        id: i64,
+        total_bytes: Option<i64>,
+        downloaded_bytes: i64,
+    ) {
+        download::ActiveModel {
+            id: Set(id),
+            url: Set("https://example.test/file.bin".to_string()),
+            file_name: Set("file.bin".to_string()),
+            state: Set("Downloading".to_string()),
+            priority: Set(5),
+            total_bytes: Set(total_bytes),
+            downloaded_bytes: Set(downloaded_bytes),
+            speed_bytes_per_sec: Set(0),
+            retry_count: Set(0),
+            max_retries: Set(5),
+            segments_count: Set(1),
+            checksum_expected: Set(None),
+            source_hostname: Set("example.test".to_string()),
+            protocol: Set("https".to_string()),
+            resume_supported: Set(1),
+            module_name: Set(None),
+            account_id: Set(None),
+            destination_path: Set("/tmp/file.bin".to_string()),
+            created_at: Set(1),
+            updated_at: Set(1),
+        }
+        .insert(db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_complete_segment_sets_ranged_segment_bytes() {
+        let db = setup_test_db().await.unwrap();
+        insert_download_row(&db, 7, Some(4096), 0).await;
+
+        let row_id = segment_row_id(7, 2);
+        insert_segment(&db, row_id, 7, 2, 128, 640).await;
+        complete_segment(&db, 7, 2).await;
+
+        let model = download_segment::Entity::find_by_id(row_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(model.state, "Completed");
+        assert_eq!(
+            model.downloaded_bytes, 512,
+            "exclusive end-byte ranges should complete to end - start"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complete_segment_sets_no_range_bytes_from_download_total() {
+        let db = setup_test_db().await.unwrap();
+        insert_download_row(&db, 9, Some(2048), 1536).await;
+
+        let row_id = segment_row_id(9, 0);
+        insert_segment(&db, row_id, 9, 0, 0, -1).await;
+        complete_segment(&db, 9, 0).await;
+
+        let model = download_segment::Entity::find_by_id(row_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(model.state, "Completed");
+        assert_eq!(
+            model.downloaded_bytes, 2048,
+            "no-range segments should complete to the download's total size when known"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_complete_segment_falls_back_to_downloaded_bytes_when_total_unknown() {
+        let db = setup_test_db().await.unwrap();
+        insert_download_row(&db, 11, None, 777).await;
+
+        let row_id = segment_row_id(11, 0);
+        insert_segment(&db, row_id, 11, 0, 0, -1).await;
+        complete_segment(&db, 11, 0).await;
+
+        let model = download_segment::Entity::find_by_id(row_id)
+            .one(&db)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(model.state, "Completed");
+        assert_eq!(
+            model.downloaded_bytes, 777,
+            "no-range segments should fall back to aggregate download progress when total size is unknown"
+        );
     }
 }

--- a/src-tauri/src/domain/event.rs
+++ b/src-tauri/src/domain/event.rs
@@ -54,6 +54,10 @@ pub enum DomainEvent {
     SegmentStarted {
         download_id: DownloadId,
         segment_id: u32,
+        /// Inclusive start byte of this segment's range.
+        start_byte: u64,
+        /// Exclusive end byte (or u64::MAX when no Range header is used).
+        end_byte: u64,
     },
     SegmentCompleted {
         download_id: DownloadId,

--- a/src-tauri/src/domain/model/segment.rs
+++ b/src-tauri/src/domain/model/segment.rs
@@ -77,6 +77,8 @@ impl Segment {
         Ok(DomainEvent::SegmentStarted {
             download_id: self.download_id,
             segment_id: self.id,
+            start_byte: self.start_byte,
+            end_byte: self.end_byte,
         })
     }
 
@@ -192,7 +194,9 @@ mod tests {
             result.unwrap(),
             DomainEvent::SegmentStarted {
                 download_id: DownloadId(10),
-                segment_id: 1
+                segment_id: 1,
+                start_byte: 0,
+                end_byte: 1024,
             }
         );
     }
@@ -290,7 +294,9 @@ mod tests {
             event,
             DomainEvent::SegmentStarted {
                 download_id: DownloadId(10),
-                segment_id: 1
+                segment_id: 1,
+                start_byte: 0,
+                end_byte: 1024,
             }
         );
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ pub use adapters::driven::sqlite::connection;
 pub use adapters::driven::sqlite::download_read_repo::SqliteDownloadReadRepo;
 pub use adapters::driven::sqlite::download_repo::SqliteDownloadRepo;
 pub use adapters::driven::sqlite::history_repo::SqliteHistoryRepo;
+pub use adapters::driven::sqlite::progress_bridge::spawn_sqlite_progress_bridge;
 pub use adapters::driven::sqlite::stats_repo::SqliteStatsRepo;
 pub use adapters::driven::tray::setup_system_tray;
 pub use application::command_bus::CommandBus;
@@ -120,7 +121,7 @@ pub fn run() {
                 Arc::new(SqliteDownloadReadRepo::new(db.clone()));
             let history_repo: Arc<dyn HistoryRepository> =
                 Arc::new(SqliteHistoryRepo::new(db.clone()));
-            let stats_repo: Arc<dyn StatsRepository> = Arc::new(SqliteStatsRepo::new(db));
+            let stats_repo: Arc<dyn StatsRepository> = Arc::new(SqliteStatsRepo::new(db.clone()));
 
             // ── Plugin system ───────────────────────────────────────
             let shared_resources = Arc::new(SharedHostResources::new());
@@ -187,6 +188,7 @@ pub fn run() {
             spawn_tauri_event_bridge(app_handle.clone(), event_bus.as_ref());
             spawn_notification_bridge(app_handle, event_bus.as_ref());
             spawn_download_log_bridge(event_bus.as_ref(), download_log_store);
+            spawn_sqlite_progress_bridge(event_bus.as_ref(), db);
 
             // ── Queue manager event listener ────────────────────────
             queue_manager.clone().start_listening();


### PR DESCRIPTION
## Summary

- **Path bug**: `SegmentedDownloadEngine` was appending `file_name` to `destination_path` a second time (e.g. `/Downloads/file.bin/file.bin`). `FileStorage.create_file()` failed with "Not a directory", causing a silent `DownloadFailed` → Retry loop with 0 bytes downloaded.
- **`SegmentStarted` enrichment**: the event now carries `start_byte` and `end_byte`, enabling downstream bridges to know which byte range a segment covers.
- **SQLite progress bridge**: a new `spawn_sqlite_progress_bridge` subscribes to `DownloadProgress`, `SegmentStarted`, `SegmentCompleted`, and `SegmentFailed` events and persists them to SQLite via fire-and-forget tokio tasks. Before this, `downloads.downloaded_bytes` and the `download_segments` table were never written during active downloads, so every read query returned 0%.

## Test plan

- [ ] Manual: start a download of `https://speed.hetzner.de/10MB.bin` — progress should increase from 0% and segments should appear in the detail view
- [ ] `cargo test --workspace` — 475 tests, 0 failures
- [ ] Verify that pausing and resuming a download resumes from the correct byte offset
- [ ] Verify that a failed segment retries and the row in `download_segments` transitions through `Downloading` → `Completed`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #54 by correcting the download path and persisting live progress to SQLite so segments update in real time. Downloads no longer fail immediately, and segments don’t stay at 0%.

- **Bug Fixes**
  - Stop double-joining `file_name` to `destination_path`; use the full file path to avoid "Not a directory" errors and retry loops.

- **New Features**
  - `SegmentStarted` now includes `start_byte` and `end_byte`; the `tauri` payload exposes `startByte`/`endByte` and sends `-1` when no Range is used.
  - Added `spawn_sqlite_progress_bridge` to persist `DownloadProgress`, `SegmentStarted`, `SegmentCompleted`, and `SegmentFailed` to SQLite; writes are ordered and monotonic (uses SQL MAX), segments are created on start and marked completed/failed with correct byte counts; the bridge starts at app boot.

<sup>Written for commit 8ec5e12cb4bd874808e06ea77458b79555787141. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed download path construction that could duplicate filenames and cause pre-fetch I/O failures.
  * Segment start events now include byte-range (start/end) metadata for accurate segment identification.

* **New Features**
  * Live download progress is now persisted locally so progress indicators reflect actual progress.
  * Added a background progress bridge that records segment states and progress into the local read model (persistent SQLite-backed implementation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->