### PR TITLE
Fix theme settings dark mode sync

### DIFF
--- a/src/views/SettingsView/AppearanceSection.tsx
+++ b/src/views/SettingsView/AppearanceSection.tsx
@@ -41,6 +41,12 @@ export function AppearanceSection({ config }: AppearanceSectionProps) {
   const { setTheme } = useTheme();
   const { mutate } = useTauriMutation<AppConfig, { patch: AppConfigPatch }>('settings_update', {
     invalidateKeys: [['settings_get']],
+    onSuccess: (_data, variables) => {
+      const nextTheme = variables.patch.theme;
+      if (nextTheme === 'light' || nextTheme === 'dark' || nextTheme === 'auto') {
+        setTheme(nextTheme);
+      }
+    },
   });
 
   const [hexDraft, setHexDraft] = useState('');
@@ -48,9 +54,6 @@ export function AppearanceSection({ config }: AppearanceSectionProps) {
 
   const handleChange = <K extends keyof AppConfig>(key: K, value: AppConfig[K]) => {
     mutate({ patch: { [key]: value } as AppConfigPatch });
-    if (key === 'theme') {
-      setTheme(value as AppConfig['theme']);
-    }
   };
 
   const handleHexChange = (value: string) => {

--- a/src/views/SettingsView/AppearanceSection.tsx
+++ b/src/views/SettingsView/AppearanceSection.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Input } from '@/components/ui/input';
+import { useTheme } from '@/theme/useTheme';
 import { SettingToggle } from './SettingField';
 import { useLanguage, type Language } from '@/hooks/useLanguage';
 
@@ -37,6 +38,7 @@ function normalizeHex(value: string): string {
 export function AppearanceSection({ config }: AppearanceSectionProps) {
   const { t } = useTranslation();
   const { setLanguage, availableLanguages } = useLanguage();
+  const { setTheme } = useTheme();
   const { mutate } = useTauriMutation<AppConfig, { patch: AppConfigPatch }>('settings_update', {
     invalidateKeys: [['settings_get']],
   });
@@ -46,6 +48,9 @@ export function AppearanceSection({ config }: AppearanceSectionProps) {
 
   const handleChange = <K extends keyof AppConfig>(key: K, value: AppConfig[K]) => {
     mutate({ patch: { [key]: value } as AppConfigPatch });
+    if (key === 'theme') {
+      setTheme(value as AppConfig['theme']);
+    }
   };
 
   const handleHexChange = (value: string) => {

--- a/src/views/SettingsView/__tests__/Sections.test.tsx
+++ b/src/views/SettingsView/__tests__/Sections.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GeneralSection } from '../GeneralSection';
@@ -11,8 +11,10 @@ import { AppearanceSection } from '../AppearanceSection';
 import type { AppConfig } from '@/types/settings';
 import { ThemeProvider } from '@/theme/theme-provider';
 
+const mockInvoke = vi.hoisted(() => vi.fn());
+
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn().mockResolvedValue(null),
+  invoke: mockInvoke,
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({
@@ -81,6 +83,7 @@ function renderWithTheme(children: React.ReactNode) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockInvoke.mockResolvedValue(null);
   localStorage.clear();
   document.documentElement.classList.remove('dark');
 });
@@ -226,8 +229,27 @@ describe('AppearanceSection', () => {
     await user.click(screen.getByRole('combobox', { name: 'Theme' }));
     await user.click(await screen.findByRole('option', { name: 'Dark' }));
 
-    expect(localStorage.getItem('vortex-theme')).toBe('dark');
-    expect(document.documentElement).toHaveClass('dark');
+    await waitFor(() => {
+      expect(localStorage.getItem('vortex-theme')).toBe('dark');
+      expect(document.documentElement).toHaveClass('dark');
+    });
+  });
+
+  it('should keep the current theme when the theme mutation fails', async () => {
+    const user = userEvent.setup();
+    mockInvoke.mockRejectedValueOnce(new Error('config store unavailable'));
+
+    renderWithTheme(<AppearanceSection config={mockConfig} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Theme' }));
+    await user.click(await screen.findByRole('option', { name: 'Dark' }));
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('settings_update', { patch: { theme: 'dark' } });
+    });
+
+    expect(localStorage.getItem('vortex-theme')).toBe('auto');
+    expect(document.documentElement).not.toHaveClass('dark');
   });
 
   it('should render 6 accent color buttons', () => {

--- a/src/views/SettingsView/__tests__/Sections.test.tsx
+++ b/src/views/SettingsView/__tests__/Sections.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -9,6 +9,7 @@ import { RemoteAccessSection } from '../RemoteAccessSection';
 import { BrowserSection } from '../BrowserSection';
 import { AppearanceSection } from '../AppearanceSection';
 import type { AppConfig } from '@/types/settings';
+import { ThemeProvider } from '@/theme/theme-provider';
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn().mockResolvedValue(null),
@@ -17,6 +18,13 @@ vi.mock('@tauri-apps/api/core', () => ({
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn().mockResolvedValue(vi.fn()),
 }));
+
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  Element.prototype.scrollIntoView = vi.fn();
+});
 
 const mockConfig: AppConfig = {
   downloadDir: '/tmp/downloads',
@@ -67,8 +75,14 @@ function renderWithQuery(children: React.ReactNode) {
   );
 }
 
+function renderWithTheme(children: React.ReactNode) {
+  return renderWithQuery(<ThemeProvider>{children}</ThemeProvider>);
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
+  document.documentElement.classList.remove('dark');
 });
 
 describe('GeneralSection', () => {
@@ -200,12 +214,24 @@ describe('BrowserSection', () => {
 
 describe('AppearanceSection', () => {
   it('should render theme selector', () => {
-    renderWithQuery(<AppearanceSection config={mockConfig} />);
+    renderWithTheme(<AppearanceSection config={mockConfig} />);
     expect(screen.getByText('Theme')).toBeInTheDocument();
   });
 
+  it('should apply dark theme immediately when dark is selected', async () => {
+    const user = userEvent.setup();
+
+    renderWithTheme(<AppearanceSection config={mockConfig} />);
+
+    await user.click(screen.getByRole('combobox', { name: 'Theme' }));
+    await user.click(await screen.findByRole('option', { name: 'Dark' }));
+
+    expect(localStorage.getItem('vortex-theme')).toBe('dark');
+    expect(document.documentElement).toHaveClass('dark');
+  });
+
   it('should render 6 accent color buttons', () => {
-    renderWithQuery(<AppearanceSection config={mockConfig} />);
+    renderWithTheme(<AppearanceSection config={mockConfig} />);
     expect(screen.getByLabelText('Indigo')).toBeInTheDocument();
     expect(screen.getByLabelText('Blue')).toBeInTheDocument();
     expect(screen.getByLabelText('Purple')).toBeInTheDocument();
@@ -215,12 +241,12 @@ describe('AppearanceSection', () => {
   });
 
   it('should render compact mode toggle', () => {
-    renderWithQuery(<AppearanceSection config={mockConfig} />);
+    renderWithTheme(<AppearanceSection config={mockConfig} />);
     expect(screen.getByText('Compact mode')).toBeInTheDocument();
   });
 
   it('should render language selector', () => {
-    renderWithQuery(<AppearanceSection config={mockConfig} />);
+    renderWithTheme(<AppearanceSection config={mockConfig} />);
     expect(screen.getByText('Language')).toBeInTheDocument();
   });
 });

--- a/src/views/SettingsView/__tests__/SettingsView.test.tsx
+++ b/src/views/SettingsView/__tests__/SettingsView.test.tsx
@@ -72,6 +72,8 @@ describe('SettingsView', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockInvoke.mockResolvedValue(mockConfig);
+    localStorage.clear();
+    document.documentElement.classList.remove('dark');
   });
 
   it('should render all 6 tab buttons', async () => {

--- a/src/views/SettingsView/__tests__/SettingsView.test.tsx
+++ b/src/views/SettingsView/__tests__/SettingsView.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SettingsView } from '../SettingsView';
 import type { AppConfig } from '@/types/settings';
+import { ThemeProvider } from '@/theme/theme-provider';
 
 const mockInvoke = vi.hoisted(() => vi.fn());
 const mockListen = vi.hoisted(() => vi.fn().mockResolvedValue(vi.fn()));
@@ -60,7 +61,9 @@ function renderWithProviders() {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <SettingsView />
+      <ThemeProvider>
+        <SettingsView />
+      </ThemeProvider>
     </QueryClientProvider>,
   );
 }
@@ -148,7 +151,9 @@ describe('SettingsView', () => {
 
     const { container } = render(
       <QueryClientProvider client={queryClient}>
-        <SettingsView />
+        <ThemeProvider>
+          <SettingsView />
+        </ThemeProvider>
       </QueryClientProvider>,
     );
 


### PR DESCRIPTION
## Summary

• Sync the Settings > Appearance theme selector with `ThemeProvider` so dark mode updates the DOM immediately
• Add a regression test for selecting the dark theme and persist the theme through `localStorage`
• Wrap `SettingsView` test renders in `ThemeProvider` to match the real app tree and keep the suite green

## Type

fix

## Why

Issue #55 found that `settings_update` persisted `theme: "dark"`, but the UI never switched because the settings form did not call into the theme context that owns the DOM `.dark` class.

## Validation

• `npm test -- src/views/SettingsView/__tests__/SettingsView.test.tsx src/views/SettingsView/__tests__/Sections.test.tsx src/theme/__tests__/theme-provider.test.tsx`
• `npm run typecheck`
• Pre-push hooks passed: `ts-typecheck`, `ts-test`, `rust-test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync the Settings > Appearance theme selector with the theme context so dark mode applies instantly and persists across reloads. Fixes #55 where selecting “dark” didn’t update the DOM; also prevents DOM changes when saving settings fails.

- **Bug Fixes**
  - Call `useTheme().setTheme` in `AppearanceSection` only after a successful `settings_update` to toggle `.dark`.
  - Persist theme in `localStorage` (`vortex-theme`) and add tests for immediate apply and failed mutation behavior.
  - Wrap `SettingsView` and section tests in `ThemeProvider` and add minimal DOM API mocks for stability.

<sup>Written for commit d77973d267b2c1310c4ab516e8d3b7395b623006. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Theme selection in Appearance settings now applies immediately across the app.

* **Tests**
  * Expanded tests for theme switching, including persistence and visual application for Dark/Auto/Light.
  * Added tests covering failed theme updates to ensure the app preserves prior theme state.
  * Test harness updated to ensure consistent theme-related DOM state between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->