### PR TITLE
fix(ui): restrict pause button to Downloading state (fixes #58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Pause button was shown for Queued state downloads, causing a silent IPC error since the backend only allows Downloading → Paused; button now correctly only shows for Downloading state (fixes #58)
+- Bulk toggle (Space shortcut) no longer attempts to pause Queued downloads, aligning with the domain state machine
 - Orphaned downloads from previous session (stuck in Downloading/Waiting/Checking/Extracting state) are now recovered to Error on startup so the user can retry; Queued/Retry downloads are re-scheduled automatically (fixes #57)
 - `maxConcurrentDownloads` validation now enforces the PRD §6.10 limit of 1–20 (was incorrectly accepting up to 100) in both backend validation and the settings UI input
 - Download engine was double-joining `file_name` onto `destination_path`, producing a path like `/Downloads/file.bin/file.bin` and causing all downloads to fail silently with a "Not a directory" I/O error before any bytes were fetched (fixes #54)

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -153,6 +153,9 @@
         "eta": "ETA"
       },
       "actions": {
+        "pause": "Pause",
+        "resume": "Resume",
+        "retry": "Retry",
         "setPriority": "Set Priority",
         "remove": "Remove"
       },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -153,6 +153,9 @@
         "eta": "Temps restant"
       },
       "actions": {
+        "pause": "Pause",
+        "resume": "Reprendre",
+        "retry": "Réessayer",
         "setPriority": "Définir la priorité",
         "remove": "Supprimer"
       },

--- a/src/views/DownloadsView/DownloadsTable.tsx
+++ b/src/views/DownloadsView/DownloadsTable.tsx
@@ -146,6 +146,7 @@ function ActionCell({ download, t }: ActionCellProps) {
           variant="ghost"
           size="icon"
           className="h-7 w-7"
+          aria-label={t('downloads.table.actions.pause')}
           onClick={(e) => {
             e.stopPropagation();
             actions.pause(download.id);
@@ -159,6 +160,7 @@ function ActionCell({ download, t }: ActionCellProps) {
           variant="ghost"
           size="icon"
           className="h-7 w-7"
+          aria-label={t('downloads.table.actions.resume')}
           onClick={(e) => {
             e.stopPropagation();
             actions.resume(download.id);
@@ -172,6 +174,7 @@ function ActionCell({ download, t }: ActionCellProps) {
           variant="ghost"
           size="icon"
           className="h-7 w-7"
+          aria-label={t('downloads.table.actions.retry')}
           onClick={(e) => {
             e.stopPropagation();
             actions.start(download.id);

--- a/src/views/DownloadsView/DownloadsTable.tsx
+++ b/src/views/DownloadsView/DownloadsTable.tsx
@@ -141,7 +141,7 @@ function ActionCell({ download, t }: ActionCellProps) {
 
   return (
     <div className="flex items-center gap-1">
-      {(download.state === 'Downloading' || download.state === 'Queued') && (
+      {download.state === 'Downloading' && (
         <Button
           variant="ghost"
           size="icon"

--- a/src/views/DownloadsView/DownloadsView.tsx
+++ b/src/views/DownloadsView/DownloadsView.tsx
@@ -103,9 +103,7 @@ export function DownloadsView() {
 
     const tasks = [
       ...visibleSelectedDownloads
-        .filter((download) =>
-          download.state === 'Downloading' || download.state === 'Queued',
-        )
+        .filter((download) => download.state === 'Downloading')
         .map((download) => pauseMut.mutateAsync({ id: Number(download.id) })),
       ...visibleSelectedDownloads
         .filter((download) => download.state === 'Paused')

--- a/src/views/DownloadsView/__tests__/DownloadsTable.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsTable.test.tsx
@@ -218,4 +218,58 @@ describe('DownloadsTable', () => {
     expect(useUiStore.getState().selectedDownloadId).toBe('1');
     expect(useUiStore.getState().selectedDownloadIds).toEqual(['1']);
   });
+
+  describe('action button visibility per download state', () => {
+    function makeDownload(overrides: Partial<DownloadView>): DownloadView {
+      return {
+        id: '99',
+        fileName: 'test-file.zip',
+        url: 'https://example.com/test-file.zip',
+        state: 'Downloading',
+        progressPercent: 50,
+        speedBytesPerSec: 1024,
+        downloadedBytes: 5000,
+        totalBytes: 10000,
+        etaSeconds: 5,
+        segmentsActive: 1,
+        segmentsTotal: 2,
+        moduleName: null,
+        accountName: null,
+        createdAt: Date.now(),
+        ...overrides,
+      };
+    }
+
+    it('should show pause button for Downloading state', () => {
+      const { container } = renderTable({ downloads: [makeDownload({ state: 'Downloading' })] });
+      expect(container.querySelector('.lucide-pause')).toBeTruthy();
+    });
+
+    it('should not show pause button for Queued state', () => {
+      const { container } = renderTable({ downloads: [makeDownload({ state: 'Queued' })] });
+      expect(container.querySelector('.lucide-pause')).toBeNull();
+    });
+
+    it('should not show pause button for Retry state', () => {
+      const { container } = renderTable({ downloads: [makeDownload({ state: 'Retry' })] });
+      expect(container.querySelector('.lucide-pause')).toBeNull();
+    });
+
+    it('should show retry button for Retry state', () => {
+      const { container } = renderTable({ downloads: [makeDownload({ state: 'Retry' })] });
+      expect(container.querySelector('.lucide-rotate-ccw')).toBeTruthy();
+    });
+
+    it('should show resume button for Paused state', () => {
+      const { container } = renderTable({ downloads: [makeDownload({ state: 'Paused' })] });
+      expect(container.querySelector('.lucide-play')).toBeTruthy();
+    });
+
+    it('should not show any action button for Completed state', () => {
+      const { container } = renderTable({ downloads: [makeDownload({ state: 'Completed' })] });
+      expect(container.querySelector('.lucide-pause')).toBeNull();
+      expect(container.querySelector('.lucide-play')).toBeNull();
+      expect(container.querySelector('.lucide-rotate-ccw')).toBeNull();
+    });
+  });
 });

--- a/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
@@ -481,7 +481,7 @@ describe('DownloadsView', () => {
     await waitFor(() => {
       expect(mockInvoke).toHaveBeenCalledWith('download_pause', { id: 1 });
       expect(mockInvoke).toHaveBeenCalledWith('download_resume', { id: 2 });
+      expect(mockInvoke).not.toHaveBeenCalledWith('download_pause', { id: 3 });
     });
-    expect(mockInvoke).not.toHaveBeenCalledWith('download_pause', { id: 3 });
   });
 });

--- a/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
+++ b/src/views/DownloadsView/__tests__/DownloadsView.test.tsx
@@ -56,6 +56,22 @@ const mockDownloads: DownloadView[] = [
     accountName: null,
     createdAt: Date.now(),
   },
+  {
+    id: '3',
+    fileName: 'file3.zip',
+    url: 'https://example.com/file3.zip',
+    state: 'Queued',
+    progressPercent: 0,
+    speedBytesPerSec: 0,
+    downloadedBytes: 0,
+    totalBytes: 10000,
+    etaSeconds: null,
+    segmentsActive: 0,
+    segmentsTotal: 2,
+    moduleName: null,
+    accountName: null,
+    createdAt: Date.now(),
+  },
 ];
 
 function renderWithProviders() {
@@ -70,6 +86,7 @@ function renderWithProviders() {
     total: mockDownloads.length,
     Downloading: 1,
     Paused: 1,
+    Queued: 1,
   });
   return render(
     <QueryClientProvider client={queryClient}>
@@ -169,7 +186,7 @@ describe('DownloadsView', () => {
     });
 
     await waitFor(() => {
-      expect(useUiStore.getState().selectedDownloadIds).toEqual(['1', '2']);
+      expect(useUiStore.getState().selectedDownloadIds).toEqual(['1', '2', '3']);
     });
   });
 
@@ -440,5 +457,31 @@ describe('DownloadsView', () => {
       expect(useUiStore.getState().selectedDownloadIds).toEqual(['1', '2']);
       expect(useUiStore.getState().selectedDownloadId).toBe('2');
     });
+  });
+
+  it('should not invoke download_pause for Queued state downloads when toggling selected', async () => {
+    useUiStore.setState({
+      selectedDownloadId: null,
+      selectedDownloadIds: ['1', '2', '3'],
+      detailsPanelOpen: false,
+      filterBarExpanded: false,
+    });
+
+    renderWithProviders();
+    await screen.findByPlaceholderText('Search downloads...');
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent(SHORTCUT_ACTION_EVENT, {
+          detail: SHORTCUT_ACTIONS.downloadsToggleSelected,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockInvoke).toHaveBeenCalledWith('download_pause', { id: 1 });
+      expect(mockInvoke).toHaveBeenCalledWith('download_resume', { id: 2 });
+    });
+    expect(mockInvoke).not.toHaveBeenCalledWith('download_pause', { id: 3 });
   });
 });


### PR DESCRIPTION
## Summary
- Pause button in ActionCell now only renders for `Downloading` state (was `Downloading || Queued`), aligning UI with the domain state machine that only allows `Downloading → Paused`
- Bulk toggle handler (`handleToggleSelected`) similarly restricted to only pause `Downloading` downloads, preventing silent IPC errors for `Queued` selections
- Added 7 regression tests covering action button visibility per download state and bulk toggle behavior with `Queued` downloads

## Test plan
- [x] `npx vitest run` — 336/336 pass, 0 fail
- [x] `npm run lint` — 0 warnings, 0 errors
- [ ] Manual: start a download, verify Pause button appears while `Downloading`
- [ ] Manual: queue a download, verify NO Pause button appears while `Queued`
- [ ] Manual: trigger Retry state, verify NO Pause button appears
- [ ] Manual: select mixed-state downloads, press Space — only `Downloading` are paused, `Queued` are skipped

Closes #58

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts the Pause action to only Downloading items and updates the Space bulk toggle to ignore Queued, preventing invalid IPC calls. Adds i18n-backed aria-labels for action buttons and fixes #58.

- **Bug Fixes**
  - Show Pause button only when state is 'Downloading'.
  - Space toggle pauses only 'Downloading' and resumes 'Paused'; 'Queued' are ignored.
  - Add `pause`, `resume`, and `retry` labels to `en`/`fr` and set aria-labels on action buttons.

<sup>Written for commit b168ae5d04c38d48571acb27312c9708c0e4f61a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pause control now shows only for actively downloading items; queued downloads are excluded to prevent invalid pause attempts.
  * Bulk pause (Space) no longer tries to pause queued items.

* **Accessibility**
  * Action buttons gained descriptive aria-labels for better screen-reader support.

* **Tests**
  * Added tests verifying per-item action visibility and bulk-selection behavior.

* **Localization**
  * Added Pause/Resume/Retry labels for English and French.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->