### PR TITLE
feat(plugins): redesign plugins view to match mockup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - `useTauriMutation` now accepts `silentError` (opt-out of the default toast) and `errorMessage` (remap the error message before toasting) options. (#74)
 
 ### Changed
+
+- Plugins view refreshed to match the design mockup: a header with enabled/disabled counters and a "Check updates" action, a segmented category filter replacing the dropdown, grouped sections per category with uppercase labels, monogram icons with accent coloring for crawlers/extractors, a toggle for installed plugins, and a kebab menu hosting the destructive "Uninstall" action. Installable plugins keep a single `Install` button; pending updates surface as an inline pill on the row.
 - Default settings values now match PRD §6.10 (fresh installs only — existing `config.toml` files are not migrated): `autoExtract` on, `maxConcurrentDownloads=4`, `maxRetries=5`, `retryDelaySeconds=10`, `minFileSizeMb=1.0`, `verifyChecksums` on, `webInterfacePort=9876`, REST API and WebSocket enabled by default. `downloadDir` now resolves to the OS default Downloads directory on first launch, and `apiKey` is generated as a random UUIDv4 so the REST/WS protocols never start with an empty credential. (#67)
 - Every IPC mutation now surfaces an error toast by default via `useTauriMutation`; migrated all call sites (downloads, settings, plugins, link grabber, clipboard monitoring) to rely on this default. Inline error state removed from the link grabber. (#74)
 
 ### Fixed
+
 - YouTube `get_media_metadata` surfaced 144p, 240p, and other non-canonical heights in the quality selector even though `vortex-mod-youtube` does not support them. Picking one produced a raw yt-dlp "Requested format is not available" error because the plugin only bypasses its pre-merged-HTTPS path for heights >=720 on the canonical ladder. `parse_ytdlp_json` now filters `available_qualities` against the plugin's supported set `{360, 480, 720, 1080, 1440, 2160, 4320}`, kept in sync with `plugin.toml :: default_quality.options`. The filter is scoped to YouTube sources (detected via yt-dlp's `extractor_key` / `webpage_url_domain`) so Vimeo, SoundCloud and other providers keep their own ladders (e.g. Vimeo's 540p).
 - Completed downloads stayed stuck on `Downloading` in the UI until a manual reload: `QueueManager::handle_download_completed` persisted `state = Completed` to SQLite but never published the `DownloadCompletedPersisted` event the Tauri bridge forwards as `download-completed`, so `useDownloadEvents` never invalidated the TanStack Query cache. Now emitted after the save (and also for pre-persisted completions from `RegisterLocalFileCommand`/`ExtractArchive`), gated on the repo state being `Completed` so late events after cancel/fail do not mislead the UI.
-- Frontend briefly showing stale state after a download completed: `DownloadCompleted` fired before `QueueManager` persisted `state = Completed` to SQLite, so a re-fetch triggered by the event could read the previous state. New `DownloadCompletedPersisted` event emitted *after* the save; the Tauri bridge maps it to the same `download-completed` frontend event so existing invalidation logic is reused without changes.
+- Frontend briefly showing stale state after a download completed: `DownloadCompleted` fired before `QueueManager` persisted `state = Completed` to SQLite, so a re-fetch triggered by the event could read the previous state. New `DownloadCompletedPersisted` event emitted _after_ the save; the Tauri bridge maps it to the same `download-completed` frontend event so existing invalidation logic is reused without changes.
 - `downloaded_bytes` stayed at 0 in SQLite for downloads that finished in under 500 ms (the `DownloadProgress` throttle window): `segment_worker` now emits one final `DownloadProgress` right before `SegmentCompleted` so `progress_bridge` always observes the real byte count.
 - State-transition saves could regress `downloaded_bytes` back to a stale lower value when racing with `progress_bridge` writes. `SqliteDownloadRepo.save` now excludes `downloaded_bytes` from the UPSERT column list and uses `MAX(excluded.downloaded_bytes, COALESCE(downloads.downloaded_bytes, 0))` so only larger values win.
 - `DownloadView` / `DownloadDetailView` now expose `source_hostname` so the UI can show the origin host (e.g. `www.youtube.com`) rather than the CDN host (`rr1---sn-n4g-cvq6.googlevideo.com`) that the download URL resolves to.
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SegmentStarted` event now carries `start_byte` and `end_byte` so downstream consumers can identify which byte range a segment covers
 
 ### Added
+
 - **Clear completed / Clear failed downloads**: two new toolbar buttons in the Downloads view, separated from the bulk actions by a vertical separator. Each opens a confirmation dialog with an optional "Also delete files from disk" checkbox gated behind a prominent red warning panel. Success and error outcomes are reported via toasts.
 - `sonner` toast notifications (new dependency) mounted globally in `App.tsx`, with a thin `src/lib/toast.ts` wrapper so components do not depend on the library directly.
 - YouTube 1080p+ support: when `resolve_stream_url` returns `AdaptiveStreamOnly`,
@@ -268,11 +273,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `contrib/homebrew/vortex.rb` — Homebrew cask template (TODO placeholders for future submission)
 
 ### Changed
+
 - `KeyringCredentialStore` replaces `NoopCredentialStore` as the default credential adapter (#35)
   - Credentials now persist in the OS keychain (macOS Keychain, Linux Secret Service/keyutils, Windows Credential Manager)
   - `NoopCredentialStore` remains available for tests
 
 ### Fixed
+
 - HTML `lang` attribute now updates when the app locale changes — screen readers and browser features use the correct language pronunciation rules (#33)
 - Link Grabber now shows an inline error message when `link_resolve` fails, instead of silently resetting after "Analyze Links" (#29)
 - Settings view now displays the actual backend error message when `settings_get` fails, instead of only a generic "Failed to load settings" (#28)

--- a/src/i18n/__tests__/issue30-ui-fr.test.tsx
+++ b/src/i18n/__tests__/issue30-ui-fr.test.tsx
@@ -39,10 +39,7 @@ function createQueryClient() {
   });
 }
 
-function renderWithProviders(
-  ui: React.ReactElement,
-  options: { tooltip?: boolean } = {},
-) {
+function renderWithProviders(ui: React.ReactElement, options: { tooltip?: boolean } = {}) {
   const content = options.tooltip ? <TooltipProvider>{ui}</TooltipProvider> : ui;
 
   return render(
@@ -116,13 +113,9 @@ describe("issue #30 — French UI translations", () => {
 
     expect(screen.getByText("Capteur de liens")).toBeInTheDocument();
     expect(screen.getByText("Surveillance du presse-papiers")).toBeInTheDocument();
-    expect(
-      screen.getByPlaceholderText("Collez des URL ici (une par ligne)…"),
-    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Collez des URL ici (une par ligne)…")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Effacer" })).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: "Analyser les liens" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Analyser les liens" })).toBeInTheDocument();
   });
 
   it("renders status bar strings in French", () => {
@@ -156,9 +149,7 @@ describe("issue #30 — French UI translations", () => {
     mockInvoke.mockResolvedValue([]);
     renderWithProviders(<PluginsView />);
 
-    expect(
-      screen.getByPlaceholderText("Rechercher un plugin..."),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Toutes catégories")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Rechercher un plugin…")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Toutes" })).toBeInTheDocument();
   });
 });

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -252,11 +252,13 @@
       "enabled_other": "enabled"
     },
     "badge": {
-      "official": "official"
+      "official": "official",
+      "inactive": "inactive"
     },
     "action": {
       "install": "Install",
       "disable": "Disable",
+      "enable": "Enable",
       "uninstall": "Uninstall",
       "update": "Update",
       "more": "More actions",
@@ -289,6 +291,7 @@
       "updateSuccess": "Plugin \"{{name}}\" updated",
       "refreshSuccess": "Plugin list refreshed",
       "disableSuccess": "Plugin disabled",
+      "enableSuccess": "Plugin enabled",
       "uninstallSuccess": "Plugin uninstalled"
     }
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -248,10 +248,8 @@
   "plugins": {
     "title": "Plugins",
     "stats": {
-      "enabled": "enabled",
-      "enabled_plural": "enabled",
-      "disabled": "disabled",
-      "disabled_plural": "disabled"
+      "enabled_one": "enabled",
+      "enabled_other": "enabled"
     },
     "badge": {
       "official": "official"

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -246,6 +246,46 @@
     "unlimited": "unlimited"
   },
   "plugins": {
+    "title": "Plugins",
+    "stats": {
+      "enabled": "enabled",
+      "enabled_plural": "enabled",
+      "disabled": "disabled",
+      "disabled_plural": "disabled"
+    },
+    "badge": {
+      "official": "official"
+    },
+    "action": {
+      "install": "Install",
+      "disable": "Disable",
+      "uninstall": "Uninstall",
+      "update": "Update",
+      "more": "More actions",
+      "refresh": "Check updates",
+      "browseRepo": "Browse repository"
+    },
+    "search": {
+      "placeholder": "Search plugins…"
+    },
+    "categories": {
+      "all": "All",
+      "crawler": "Crawlers",
+      "hoster": "Hosters",
+      "debrid": "Debrid",
+      "container": "Containers",
+      "captcha": "Captcha",
+      "extractor": "Extractors",
+      "notifier": "Notifiers",
+      "utility": "Utilities"
+    },
+    "empty": "No plugins found",
+    "error": "Failed to load catalog",
+    "loading": "Loading catalog…",
+    "retry": "Retry",
+    "group": {
+      "count": "{{label}} ({{count}})"
+    },
     "toast": {
       "installSuccess": "Plugin \"{{name}}\" installed",
       "updateSuccess": "Plugin \"{{name}}\" updated",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -256,6 +256,7 @@
     },
     "action": {
       "install": "Install",
+      "disable": "Disable",
       "uninstall": "Uninstall",
       "update": "Update",
       "more": "More actions",
@@ -287,6 +288,7 @@
       "installSuccess": "Plugin \"{{name}}\" installed",
       "updateSuccess": "Plugin \"{{name}}\" updated",
       "refreshSuccess": "Plugin list refreshed",
+      "disableSuccess": "Plugin disabled",
       "uninstallSuccess": "Plugin uninstalled"
     }
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -256,7 +256,6 @@
     },
     "action": {
       "install": "Install",
-      "disable": "Disable",
       "uninstall": "Uninstall",
       "update": "Update",
       "more": "More actions",
@@ -288,7 +287,6 @@
       "installSuccess": "Plugin \"{{name}}\" installed",
       "updateSuccess": "Plugin \"{{name}}\" updated",
       "refreshSuccess": "Plugin list refreshed",
-      "disableSuccess": "Plugin disabled",
       "uninstallSuccess": "Plugin uninstalled"
     }
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -248,10 +248,8 @@
   "plugins": {
     "title": "Plugins",
     "stats": {
-      "enabled": "activé",
-      "enabled_plural": "activés",
-      "disabled": "désactivé",
-      "disabled_plural": "désactivés"
+      "enabled_one": "activé",
+      "enabled_other": "activés"
     },
     "badge": {
       "official": "officiel"

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -246,6 +246,46 @@
     "unlimited": "illimitée"
   },
   "plugins": {
+    "title": "Plugins",
+    "stats": {
+      "enabled": "activé",
+      "enabled_plural": "activés",
+      "disabled": "désactivé",
+      "disabled_plural": "désactivés"
+    },
+    "badge": {
+      "official": "officiel"
+    },
+    "action": {
+      "install": "Installer",
+      "disable": "Désactiver",
+      "uninstall": "Désinstaller",
+      "update": "Mettre à jour",
+      "more": "Plus d'actions",
+      "refresh": "Vérifier les mises à jour",
+      "browseRepo": "Parcourir le dépôt"
+    },
+    "search": {
+      "placeholder": "Rechercher un plugin…"
+    },
+    "categories": {
+      "all": "Toutes",
+      "crawler": "Crawlers",
+      "hoster": "Hébergeurs",
+      "debrid": "Debrid",
+      "container": "Conteneurs",
+      "captcha": "Captcha",
+      "extractor": "Extracteurs",
+      "notifier": "Notifiers",
+      "utility": "Utilitaires"
+    },
+    "empty": "Aucun plugin trouvé",
+    "error": "Erreur de chargement",
+    "loading": "Chargement du catalogue…",
+    "retry": "Réessayer",
+    "group": {
+      "count": "{{label}} ({{count}})"
+    },
     "toast": {
       "installSuccess": "Plugin « {{name}} » installé",
       "updateSuccess": "Plugin « {{name}} » mis à jour",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -252,11 +252,13 @@
       "enabled_other": "activés"
     },
     "badge": {
-      "official": "officiel"
+      "official": "officiel",
+      "inactive": "inactif"
     },
     "action": {
       "install": "Installer",
       "disable": "Désactiver",
+      "enable": "Activer",
       "uninstall": "Désinstaller",
       "update": "Mettre à jour",
       "more": "Plus d'actions",
@@ -289,6 +291,7 @@
       "updateSuccess": "Plugin « {{name}} » mis à jour",
       "refreshSuccess": "Liste des plugins rafraîchie",
       "disableSuccess": "Plugin désactivé",
+      "enableSuccess": "Plugin activé",
       "uninstallSuccess": "Plugin désinstallé"
     }
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -256,6 +256,7 @@
     },
     "action": {
       "install": "Installer",
+      "disable": "Désactiver",
       "uninstall": "Désinstaller",
       "update": "Mettre à jour",
       "more": "Plus d'actions",
@@ -287,6 +288,7 @@
       "installSuccess": "Plugin « {{name}} » installé",
       "updateSuccess": "Plugin « {{name}} » mis à jour",
       "refreshSuccess": "Liste des plugins rafraîchie",
+      "disableSuccess": "Plugin désactivé",
       "uninstallSuccess": "Plugin désinstallé"
     }
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -256,7 +256,6 @@
     },
     "action": {
       "install": "Installer",
-      "disable": "Désactiver",
       "uninstall": "Désinstaller",
       "update": "Mettre à jour",
       "more": "Plus d'actions",
@@ -288,7 +287,6 @@
       "installSuccess": "Plugin « {{name}} » installé",
       "updateSuccess": "Plugin « {{name}} » mis à jour",
       "refreshSuccess": "Liste des plugins rafraîchie",
-      "disableSuccess": "Plugin désactivé",
       "uninstallSuccess": "Plugin désinstallé"
     }
   },

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -77,7 +77,15 @@ export function PluginsView() {
 
   const uninstallMutation = useTauriMutation<void, { name: string }>("plugin_uninstall", {
     invalidateKeys: STORE_INVALIDATE_KEYS,
-    onSuccess: () => toast.success(t("plugins.toast.uninstallSuccess")),
+    onSuccess: (_data, variables) => {
+      setLocallyDisabled((prev) => {
+        if (!prev.has(variables.name)) return prev;
+        const next = new Set(prev);
+        next.delete(variables.name);
+        return next;
+      });
+      toast.success(t("plugins.toast.uninstallSuccess"));
+    },
   });
 
   const filtered = useMemo(() => {

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -31,6 +31,13 @@ export function PluginsView() {
   const { t } = useTranslation();
   const [search, setSearch] = useState("");
   const [category, setCategory] = useState("all");
+  // Session-local optimistic disabled state. PluginStoreEntryDto has no
+  // "disabled" variant yet, so the refetch after plugin_disable still reports
+  // the plugin as installed. We track disabled names here so the row can
+  // render as inactive and expose "Enable" until the DTO grows a matching
+  // field. State is not persisted across reloads on purpose — same as the
+  // pre-PR behaviour.
+  const [locallyDisabled, setLocallyDisabled] = useState<ReadonlySet<string>>(new Set());
 
   const {
     entries,
@@ -44,13 +51,28 @@ export function PluginsView() {
     isRefreshing,
   } = usePluginStore();
 
-  // plugin_disable triggers the backend but the PluginStoreEntryDto has no
-  // "disabled" variant yet, so the row keeps rendering as installed after the
-  // refetch. Users get the toast confirmation but no persistent UI state until
-  // the DTO grows a field to carry it.
   const disableMutation = useTauriMutation<void, { name: string }>("plugin_disable", {
     invalidateKeys: STORE_INVALIDATE_KEYS,
-    onSuccess: () => toast.success(t("plugins.toast.disableSuccess")),
+    onSuccess: (_data, variables) => {
+      setLocallyDisabled((prev) => {
+        const next = new Set(prev);
+        next.add(variables.name);
+        return next;
+      });
+      toast.success(t("plugins.toast.disableSuccess"));
+    },
+  });
+
+  const enableMutation = useTauriMutation<void, { name: string }>("plugin_enable", {
+    invalidateKeys: STORE_INVALIDATE_KEYS,
+    onSuccess: (_data, variables) => {
+      setLocallyDisabled((prev) => {
+        const next = new Set(prev);
+        next.delete(variables.name);
+        return next;
+      });
+      toast.success(t("plugins.toast.enableSuccess"));
+    },
   });
 
   const uninstallMutation = useTauriMutation<void, { name: string }>("plugin_uninstall", {
@@ -72,8 +94,9 @@ export function PluginsView() {
   }, [entries, search, category]);
 
   const enabledCount = useMemo(
-    () => entries.filter((e) => isInstalled(e.status)).length,
-    [entries],
+    () =>
+      entries.filter((e) => isInstalled(e.status) && !locallyDisabled.has(e.name)).length,
+    [entries, locallyDisabled],
   );
 
   const groups = useMemo(() => groupByCategory(filtered), [filtered]);
@@ -134,9 +157,11 @@ export function PluginsView() {
                     <PluginStoreRow
                       key={entry.name}
                       entry={entry}
+                      isLocallyDisabled={locallyDisabled.has(entry.name)}
                       onInstall={installPlugin}
                       onUpdate={updatePlugin}
                       onDisable={(name) => disableMutation.mutate({ name })}
+                      onEnable={(name) => enableMutation.mutate({ name })}
                       onUninstall={(name) => uninstallMutation.mutate({ name })}
                       isInstalling={isInstalling(entry.name)}
                       isUpdating={isUpdating(entry.name)}

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -44,11 +44,6 @@ export function PluginsView() {
     isRefreshing,
   } = usePluginStore();
 
-  const disableMutation = useTauriMutation<void, { name: string }>("plugin_disable", {
-    invalidateKeys: STORE_INVALIDATE_KEYS,
-    onSuccess: () => toast.success(t("plugins.toast.disableSuccess")),
-  });
-
   const uninstallMutation = useTauriMutation<void, { name: string }>("plugin_uninstall", {
     invalidateKeys: STORE_INVALIDATE_KEYS,
     onSuccess: () => toast.success(t("plugins.toast.uninstallSuccess")),
@@ -132,7 +127,6 @@ export function PluginsView() {
                       entry={entry}
                       onInstall={installPlugin}
                       onUpdate={updatePlugin}
-                      onDisable={(name) => disableMutation.mutate({ name })}
                       onUninstall={(name) => uninstallMutation.mutate({ name })}
                       isInstalling={isInstalling(entry.name)}
                       isUpdating={isUpdating(entry.name)}

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -71,7 +71,6 @@ export function PluginsView() {
     () => entries.filter((e) => isInstalled(e.status)).length,
     [entries],
   );
-  const disabledCount = 0;
 
   const groups = useMemo(() => groupByCategory(filtered), [filtered]);
 
@@ -79,7 +78,6 @@ export function PluginsView() {
     <div className="flex flex-col h-full bg-surface-alt">
       <PluginsHeader
         enabledCount={enabledCount}
-        disabledCount={disabledCount}
         onRefresh={refreshStore}
         isRefreshing={isRefreshing}
       />

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -44,6 +44,15 @@ export function PluginsView() {
     isRefreshing,
   } = usePluginStore();
 
+  // plugin_disable triggers the backend but the PluginStoreEntryDto has no
+  // "disabled" variant yet, so the row keeps rendering as installed after the
+  // refetch. Users get the toast confirmation but no persistent UI state until
+  // the DTO grows a field to carry it.
+  const disableMutation = useTauriMutation<void, { name: string }>("plugin_disable", {
+    invalidateKeys: STORE_INVALIDATE_KEYS,
+    onSuccess: () => toast.success(t("plugins.toast.disableSuccess")),
+  });
+
   const uninstallMutation = useTauriMutation<void, { name: string }>("plugin_uninstall", {
     invalidateKeys: STORE_INVALIDATE_KEYS,
     onSuccess: () => toast.success(t("plugins.toast.uninstallSuccess")),
@@ -127,6 +136,7 @@ export function PluginsView() {
                       entry={entry}
                       onInstall={installPlugin}
                       onUpdate={updatePlugin}
+                      onDisable={(name) => disableMutation.mutate({ name })}
                       onUninstall={(name) => uninstallMutation.mutate({ name })}
                       isInstalling={isInstalling(entry.name)}
                       isUpdating={isUpdating(entry.name)}

--- a/src/views/PluginsView.tsx
+++ b/src/views/PluginsView.tsx
@@ -1,18 +1,13 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Button } from "@/components/ui/button";
 import { PluginStoreRow } from "./PluginsView/PluginStoreRow";
+import { PluginsHeader } from "./PluginsView/PluginsHeader";
+import { PluginsToolbar } from "./PluginsView/PluginsToolbar";
+import { groupByCategory } from "./PluginsView/groupByCategory";
 import { usePluginStore } from "./PluginsView/usePluginStore";
 import { useTauriMutation } from "@/api/hooks";
 import { toast } from "@/lib/toast";
+import { Button } from "@/components/ui/button";
 
 const CATEGORIES = [
   "all",
@@ -27,6 +22,10 @@ const CATEGORIES = [
 ];
 
 const STORE_INVALIDATE_KEYS = [["plugin_store_list"]] as const;
+
+function isInstalled(status: string): boolean {
+  return status === "installed" || status === "update_available" || status === "downgrade";
+}
 
 export function PluginsView() {
   const { t } = useTranslation();
@@ -45,98 +44,108 @@ export function PluginsView() {
     isRefreshing,
   } = usePluginStore();
 
-  const disableMutation = useTauriMutation<void, { name: string }>(
-    "plugin_disable",
-    {
-      invalidateKeys: STORE_INVALIDATE_KEYS,
-      onSuccess: () => toast.success(t("plugins.toast.disableSuccess")),
-    },
-  );
-
-  const uninstallMutation = useTauriMutation<void, { name: string }>(
-    "plugin_uninstall",
-    {
-      invalidateKeys: STORE_INVALIDATE_KEYS,
-      onSuccess: () => toast.success(t("plugins.toast.uninstallSuccess")),
-    },
-  );
-
-  const filtered = entries.filter((e) => {
-    const matchSearch =
-      search.length === 0 ||
-      e.name.toLowerCase().includes(search.toLowerCase()) ||
-      e.description.toLowerCase().includes(search.toLowerCase()) ||
-      e.author.toLowerCase().includes(search.toLowerCase());
-    const matchCat = category === "all" || e.category === category;
-    return matchSearch && matchCat;
+  const disableMutation = useTauriMutation<void, { name: string }>("plugin_disable", {
+    invalidateKeys: STORE_INVALIDATE_KEYS,
+    onSuccess: () => toast.success(t("plugins.toast.disableSuccess")),
   });
 
-  return (
-    <div className="flex flex-col h-full">
-      {/* Toolbar */}
-      <div className="flex items-center gap-2 p-3 border-b border-border">
-        <Input
-          placeholder="Rechercher un plugin..."
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="flex-1"
-        />
-        <Select value={category} onValueChange={setCategory}>
-          <SelectTrigger className="w-40">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {CATEGORIES.map((c) => (
-              <SelectItem key={c} value={c}>
-                {c === "all" ? "Toutes catégories" : c}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={refreshStore}
-          disabled={isRefreshing}
-          title="Rafraîchir le catalogue"
-        >
-          {isRefreshing ? "…" : "↻"}
-        </Button>
-      </div>
+  const uninstallMutation = useTauriMutation<void, { name: string }>("plugin_uninstall", {
+    invalidateKeys: STORE_INVALIDATE_KEYS,
+    onSuccess: () => toast.success(t("plugins.toast.uninstallSuccess")),
+  });
 
-      {/* List */}
+  const filtered = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return entries.filter((e) => {
+      const matchSearch =
+        query.length === 0 ||
+        e.name.toLowerCase().includes(query) ||
+        e.description.toLowerCase().includes(query) ||
+        e.author.toLowerCase().includes(query);
+      const matchCategory = category === "all" || e.category === category;
+      return matchSearch && matchCategory;
+    });
+  }, [entries, search, category]);
+
+  const enabledCount = useMemo(
+    () => entries.filter((e) => isInstalled(e.status)).length,
+    [entries],
+  );
+  const disabledCount = 0;
+
+  const groups = useMemo(() => groupByCategory(filtered), [filtered]);
+
+  return (
+    <div className="flex flex-col h-full bg-surface-alt">
+      <PluginsHeader
+        enabledCount={enabledCount}
+        disabledCount={disabledCount}
+        onRefresh={refreshStore}
+        isRefreshing={isRefreshing}
+      />
+      <PluginsToolbar
+        categories={CATEGORIES}
+        activeCategory={category}
+        onCategoryChange={setCategory}
+        search={search}
+        onSearchChange={setSearch}
+      />
+
       <div className="flex-1 overflow-y-auto">
         {isLoading && (
-          <div className="flex items-center justify-center h-32 text-muted-foreground text-sm">
-            Chargement du catalogue…
+          <div className="flex items-center justify-center h-32 text-text-dim text-xs">
+            {t("plugins.loading")}
           </div>
         )}
+
         {isError && (
           <div className="flex flex-col items-center justify-center h-32 gap-2">
-            <p className="text-sm text-muted-foreground">Erreur de chargement</p>
+            <p className="text-xs text-text-dim">{t("plugins.error")}</p>
             <Button variant="outline" size="sm" onClick={refreshStore}>
-              Réessayer
+              {t("plugins.retry")}
             </Button>
           </div>
         )}
+
         {!isLoading && !isError && filtered.length === 0 && (
-          <div className="flex items-center justify-center h-32 text-muted-foreground text-sm">
-            Aucun plugin trouvé
+          <div className="flex items-center justify-center h-32 text-text-dim text-xs">
+            {t("plugins.empty")}
           </div>
         )}
+
         {!isLoading &&
-          filtered.map((entry) => (
-            <PluginStoreRow
-              key={entry.name}
-              entry={entry}
-              onInstall={installPlugin}
-              onUpdate={updatePlugin}
-              onDisable={(name) => disableMutation.mutate({ name })}
-              onUninstall={(name) => uninstallMutation.mutate({ name })}
-              isInstalling={isInstalling(entry.name)}
-              isUpdating={isUpdating(entry.name)}
-            />
-          ))}
+          !isError &&
+          groups.map((group) => {
+            const label = t(`plugins.categories.${group.category}`, {
+              defaultValue: group.category,
+            });
+            return (
+              <section key={group.category}>
+                <h3 className="text-[11px] font-semibold text-text-dim uppercase tracking-widest px-6 pt-4 pb-1.5">
+                  {t("plugins.group.count", {
+                    label,
+                    count: group.entries.length,
+                  })}
+                </h3>
+                <div className="mx-6 mt-1.5 bg-surface border border-border-soft rounded-lg overflow-hidden">
+                  {group.entries.map((entry) => (
+                    <PluginStoreRow
+                      key={entry.name}
+                      entry={entry}
+                      onInstall={installPlugin}
+                      onUpdate={updatePlugin}
+                      onDisable={(name) => disableMutation.mutate({ name })}
+                      onUninstall={(name) => uninstallMutation.mutate({ name })}
+                      isInstalling={isInstalling(entry.name)}
+                      isUpdating={isUpdating(entry.name)}
+                    />
+                  ))}
+                </div>
+              </section>
+            );
+          })}
+
+        <div className="h-6" />
       </div>
     </div>
   );

--- a/src/views/PluginsView/PluginStoreRow.tsx
+++ b/src/views/PluginsView/PluginStoreRow.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { PluginStoreEntry } from "@/types/plugin-store";
@@ -15,7 +14,6 @@ interface PluginStoreRowProps {
   entry: PluginStoreEntry;
   onInstall: (name: string) => void;
   onUpdate: (name: string) => void;
-  onDisable?: (name: string) => void;
   onUninstall?: (name: string) => void;
   isInstalling: boolean;
   isUpdating: boolean;
@@ -36,13 +34,15 @@ export function PluginStoreRow({
   entry,
   onInstall,
   onUpdate,
-  onDisable,
   onUninstall,
   isInstalling,
   isUpdating,
 }: PluginStoreRowProps) {
   const { t } = useTranslation();
   const installed = isInstalledLike(entry.status);
+  const categoryLabel = t(`plugins.categories.${entry.category}`, {
+    defaultValue: entry.category,
+  });
   const iconColorClass = CRAWLER_CATEGORIES.has(entry.category)
     ? "bg-accent-light text-accent"
     : "bg-surface-muted text-muted";
@@ -68,7 +68,7 @@ export function PluginStoreRow({
         <p className="text-[10px] text-text-dim mt-0.5 truncate">
           {entry.description}
           <span className="mx-1.5">·</span>
-          {entry.category}
+          {categoryLabel}
           <span className="mx-1.5">·</span>
           {entry.author}
         </p>
@@ -106,7 +106,7 @@ export function PluginStoreRow({
           </Button>
         )}
 
-        {installed && (
+        {installed && onUninstall && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -119,20 +119,12 @@ export function PluginStoreRow({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {onDisable && (
-                <DropdownMenuItem onSelect={() => onDisable(entry.name)}>
-                  {t("plugins.action.disable")}
-                </DropdownMenuItem>
-              )}
-              {onDisable && onUninstall && <DropdownMenuSeparator />}
-              {onUninstall && (
-                <DropdownMenuItem
-                  variant="destructive"
-                  onSelect={() => onUninstall(entry.name)}
-                >
-                  {t("plugins.action.uninstall")}
-                </DropdownMenuItem>
-              )}
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => onUninstall(entry.name)}
+              >
+                {t("plugins.action.uninstall")}
+              </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/src/views/PluginsView/PluginStoreRow.tsx
+++ b/src/views/PluginsView/PluginStoreRow.tsx
@@ -13,9 +13,11 @@ import type { PluginStoreEntry } from "@/types/plugin-store";
 
 interface PluginStoreRowProps {
   entry: PluginStoreEntry;
+  isLocallyDisabled?: boolean;
   onInstall: (name: string) => void;
   onUpdate: (name: string) => void;
   onDisable?: (name: string) => void;
+  onEnable?: (name: string) => void;
   onUninstall?: (name: string) => void;
   isInstalling: boolean;
   isUpdating: boolean;
@@ -34,9 +36,11 @@ function isInstalledLike(status: PluginStoreEntry["status"]): boolean {
 
 export function PluginStoreRow({
   entry,
+  isLocallyDisabled = false,
   onInstall,
   onUpdate,
   onDisable,
+  onEnable,
   onUninstall,
   isInstalling,
   isUpdating,
@@ -49,9 +53,12 @@ export function PluginStoreRow({
   const iconColorClass = CRAWLER_CATEGORIES.has(entry.category)
     ? "bg-accent-light text-accent"
     : "bg-surface-muted text-muted";
+  const rowClassName = `flex items-center gap-3 px-4 py-2.5 border-b border-border-soft last:border-0 hover:bg-surface-alt/60 transition-colors${
+    isLocallyDisabled ? " opacity-60" : ""
+  }`;
 
   return (
-    <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border-soft last:border-0 hover:bg-surface-alt/60 transition-colors">
+    <div className={rowClassName}>
       <div
         data-testid="plugin-icon"
         className={`w-7 h-7 rounded-md flex items-center justify-center text-[10px] font-semibold shrink-0 ${iconColorClass}`}
@@ -67,6 +74,14 @@ export function PluginStoreRow({
               {t("plugins.badge.official")}
             </Badge>
           )}
+          {isLocallyDisabled && (
+            <Badge
+              variant="outline"
+              className="text-[10px] px-1.5 py-0 h-4 shrink-0 border-text-ghost text-text-dim"
+            >
+              {t("plugins.badge.inactive")}
+            </Badge>
+          )}
         </div>
         <p className="text-[10px] text-text-dim mt-0.5 truncate">
           {entry.description}
@@ -78,7 +93,7 @@ export function PluginStoreRow({
       </div>
 
       <div className="flex items-center gap-2 shrink-0">
-        {entry.status === "update_available" && (
+        {entry.status === "update_available" && !isLocallyDisabled && (
           <Button
             size="sm"
             variant="outline"
@@ -109,7 +124,7 @@ export function PluginStoreRow({
           </Button>
         )}
 
-        {installed && (onDisable || onUninstall) && (
+        {installed && (onDisable || onEnable || onUninstall) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -122,12 +137,20 @@ export function PluginStoreRow({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              {onDisable && (
-                <DropdownMenuItem onSelect={() => onDisable(entry.name)}>
-                  {t("plugins.action.disable")}
-                </DropdownMenuItem>
+              {isLocallyDisabled
+                ? onEnable && (
+                    <DropdownMenuItem onSelect={() => onEnable(entry.name)}>
+                      {t("plugins.action.enable")}
+                    </DropdownMenuItem>
+                  )
+                : onDisable && (
+                    <DropdownMenuItem onSelect={() => onDisable(entry.name)}>
+                      {t("plugins.action.disable")}
+                    </DropdownMenuItem>
+                  )}
+              {((isLocallyDisabled ? onEnable : onDisable) && onUninstall) && (
+                <DropdownMenuSeparator />
               )}
-              {onDisable && onUninstall && <DropdownMenuSeparator />}
               {onUninstall && (
                 <DropdownMenuItem
                   variant="destructive"

--- a/src/views/PluginsView/PluginStoreRow.tsx
+++ b/src/views/PluginsView/PluginStoreRow.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { PluginStoreEntry } from "@/types/plugin-store";
@@ -14,6 +15,7 @@ interface PluginStoreRowProps {
   entry: PluginStoreEntry;
   onInstall: (name: string) => void;
   onUpdate: (name: string) => void;
+  onDisable?: (name: string) => void;
   onUninstall?: (name: string) => void;
   isInstalling: boolean;
   isUpdating: boolean;
@@ -34,6 +36,7 @@ export function PluginStoreRow({
   entry,
   onInstall,
   onUpdate,
+  onDisable,
   onUninstall,
   isInstalling,
   isUpdating,
@@ -106,7 +109,7 @@ export function PluginStoreRow({
           </Button>
         )}
 
-        {installed && onUninstall && (
+        {installed && (onDisable || onUninstall) && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -119,12 +122,20 @@ export function PluginStoreRow({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem
-                variant="destructive"
-                onSelect={() => onUninstall(entry.name)}
-              >
-                {t("plugins.action.uninstall")}
-              </DropdownMenuItem>
+              {onDisable && (
+                <DropdownMenuItem onSelect={() => onDisable(entry.name)}>
+                  {t("plugins.action.disable")}
+                </DropdownMenuItem>
+              )}
+              {onDisable && onUninstall && <DropdownMenuSeparator />}
+              {onUninstall && (
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={() => onUninstall(entry.name)}
+                >
+                  {t("plugins.action.uninstall")}
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/src/views/PluginsView/PluginStoreRow.tsx
+++ b/src/views/PluginsView/PluginStoreRow.tsx
@@ -1,5 +1,14 @@
+import { MoreVertical, ArrowUpCircle } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import type { PluginStoreEntry } from "@/types/plugin-store";
 
 interface PluginStoreRowProps {
@@ -12,6 +21,17 @@ interface PluginStoreRowProps {
   isUpdating: boolean;
 }
 
+const CRAWLER_CATEGORIES = new Set(["crawler", "extractor"]);
+
+function buildMonogram(name: string): string {
+  const slug = name.replace(/^vortex-mod-/i, "");
+  return slug.slice(0, 2).toUpperCase();
+}
+
+function isInstalledLike(status: PluginStoreEntry["status"]): boolean {
+  return status === "installed" || status === "update_available" || status === "downgrade";
+}
+
 export function PluginStoreRow({
   entry,
   onInstall,
@@ -21,99 +41,98 @@ export function PluginStoreRow({
   isInstalling,
   isUpdating,
 }: PluginStoreRowProps) {
+  const { t } = useTranslation();
+  const installed = isInstalledLike(entry.status);
+  const iconColorClass = CRAWLER_CATEGORIES.has(entry.category)
+    ? "bg-accent-light text-accent"
+    : "bg-surface-muted text-muted";
+
   return (
-    <div className="flex items-center gap-3 px-3 py-2.5 border-b border-border last:border-0 hover:bg-muted/30">
+    <div className="flex items-center gap-3 px-4 py-2.5 border-b border-border-soft last:border-0 hover:bg-surface-alt/60 transition-colors">
+      <div
+        data-testid="plugin-icon"
+        className={`w-7 h-7 rounded-md flex items-center justify-center text-[10px] font-semibold shrink-0 ${iconColorClass}`}
+      >
+        {buildMonogram(entry.name)}
+      </div>
+
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-1.5 flex-wrap">
-          <span className="text-sm font-medium text-foreground truncate">
-            {entry.name}
-          </span>
+          <span className="text-xs font-medium text-foreground truncate">{entry.name}</span>
           {entry.official && (
-            <Badge variant="secondary" className="text-xs shrink-0">
-              officiel
+            <Badge variant="secondary" className="text-[10px] px-1.5 py-0 h-4 shrink-0">
+              {t("plugins.badge.official")}
             </Badge>
           )}
-          <StatusBadge entry={entry} />
         </div>
-        <p className="text-xs text-muted-foreground mt-0.5 truncate">
-          {entry.description} · {entry.category} · {entry.author}
-          {entry.installedVersion && entry.status === "update_available" && (
-            <span className="ml-1">· installé&nbsp;: {entry.installedVersion}</span>
-          )}
+        <p className="text-[10px] text-text-dim mt-0.5 truncate">
+          {entry.description}
+          <span className="mx-1.5">·</span>
+          {entry.category}
+          <span className="mx-1.5">·</span>
+          {entry.author}
         </p>
       </div>
 
-      <div className="flex items-center gap-1.5 shrink-0">
-        {entry.status === "not_installed" && (
+      <div className="flex items-center gap-2 shrink-0">
+        {entry.status === "update_available" && (
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onUpdate(entry.name)}
+            disabled={isUpdating}
+            className="h-7 text-[10px] px-2 gap-1 text-warning border-warning/50 hover:bg-warning/10 hover:text-warning"
+          >
+            <ArrowUpCircle className="h-3 w-3" />
+            {entry.version}
+          </Button>
+        )}
+
+        {installed && entry.installedVersion && (
+          <span className="text-[10px] text-text-ghost tabular-nums">
+            v{entry.installedVersion}
+          </span>
+        )}
+
+        {entry.status === "not_installed" ? (
           <Button
             size="sm"
             variant="outline"
             onClick={() => onInstall(entry.name)}
             disabled={isInstalling}
+            className="h-7 text-[10px] px-3"
           >
-            Installer
+            {t("plugins.action.install")}
           </Button>
-        )}
-        {entry.status === "update_available" && (
-          <Button
+        ) : (
+          <Switch
+            checked
             size="sm"
-            variant="outline"
-            className="text-amber-500 border-amber-500 hover:bg-amber-500/10"
-            onClick={() => onUpdate(entry.name)}
-            disabled={isUpdating}
-          >
-            Mettre à jour
-          </Button>
+            aria-label={t("plugins.action.disable")}
+            onCheckedChange={() => onDisable?.(entry.name)}
+          />
         )}
-        {(entry.status === "installed" || entry.status === "update_available" || entry.status === "downgrade") && (
-          <>
-            {onDisable && (
+
+        {installed && (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
               <Button
-                size="sm"
+                size="icon"
                 variant="ghost"
-                onClick={() => onDisable(entry.name)}
+                className="h-7 w-7"
+                aria-label={t("plugins.action.more")}
               >
-                Désactiver
+                <MoreVertical className="h-3.5 w-3.5" />
               </Button>
-            )}
-            {onUninstall && (
-              <Button
-                size="sm"
-                variant="ghost"
-                className="text-destructive hover:text-destructive"
-                onClick={() => onUninstall(entry.name)}
-              >
-                Désinstaller
-              </Button>
-            )}
-          </>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+              <DropdownMenuItem variant="destructive" onSelect={() => onUninstall?.(entry.name)}>
+                {t("plugins.action.uninstall")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
       </div>
     </div>
   );
-}
-
-function StatusBadge({ entry }: { entry: PluginStoreEntry }) {
-  if (entry.status === "installed") {
-    return (
-      <Badge variant="outline" className="text-xs border-green-500 text-green-500 shrink-0">
-        installe
-      </Badge>
-    );
-  }
-  if (entry.status === "update_available") {
-    return (
-      <Badge variant="outline" className="text-xs border-amber-500 text-amber-500 shrink-0">
-        {entry.version} disponible
-      </Badge>
-    );
-  }
-  if (entry.status === "downgrade") {
-    return (
-      <Badge variant="outline" className="text-xs border-blue-500 text-blue-500 shrink-0">
-        version locale plus recente
-      </Badge>
-    );
-  }
-  return null;
 }

--- a/src/views/PluginsView/PluginStoreRow.tsx
+++ b/src/views/PluginsView/PluginStoreRow.tsx
@@ -2,11 +2,11 @@ import { MoreVertical, ArrowUpCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Switch } from "@/components/ui/switch";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import type { PluginStoreEntry } from "@/types/plugin-store";
@@ -84,7 +84,7 @@ export function PluginStoreRow({
             className="h-7 text-[10px] px-2 gap-1 text-warning border-warning/50 hover:bg-warning/10 hover:text-warning"
           >
             <ArrowUpCircle className="h-3 w-3" />
-            {entry.version}
+            v{entry.version}
           </Button>
         )}
 
@@ -94,7 +94,7 @@ export function PluginStoreRow({
           </span>
         )}
 
-        {entry.status === "not_installed" ? (
+        {entry.status === "not_installed" && (
           <Button
             size="sm"
             variant="outline"
@@ -104,13 +104,6 @@ export function PluginStoreRow({
           >
             {t("plugins.action.install")}
           </Button>
-        ) : (
-          <Switch
-            checked
-            size="sm"
-            aria-label={t("plugins.action.disable")}
-            onCheckedChange={() => onDisable?.(entry.name)}
-          />
         )}
 
         {installed && (
@@ -126,9 +119,20 @@ export function PluginStoreRow({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem variant="destructive" onSelect={() => onUninstall?.(entry.name)}>
-                {t("plugins.action.uninstall")}
-              </DropdownMenuItem>
+              {onDisable && (
+                <DropdownMenuItem onSelect={() => onDisable(entry.name)}>
+                  {t("plugins.action.disable")}
+                </DropdownMenuItem>
+              )}
+              {onDisable && onUninstall && <DropdownMenuSeparator />}
+              {onUninstall && (
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={() => onUninstall(entry.name)}
+                >
+                  {t("plugins.action.uninstall")}
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/src/views/PluginsView/PluginsHeader.tsx
+++ b/src/views/PluginsView/PluginsHeader.tsx
@@ -1,0 +1,60 @@
+import { RefreshCw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+
+interface PluginsHeaderProps {
+  enabledCount: number;
+  disabledCount: number;
+  onRefresh: () => void;
+  isRefreshing: boolean;
+}
+
+export function PluginsHeader({
+  enabledCount,
+  disabledCount,
+  onRefresh,
+  isRefreshing,
+}: PluginsHeaderProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="h-14 px-6 flex items-center justify-between bg-surface border-b border-border shrink-0">
+      <div className="flex items-center gap-5">
+        <span className="text-sm font-semibold text-foreground">{t("plugins.title")}</span>
+        <div className="flex items-center gap-3 text-[11px] text-text-dim">
+          <span className="flex items-center gap-1.5">
+            <span
+              data-testid="plugins-enabled-count"
+              className="font-semibold text-success tabular-nums"
+            >
+              {enabledCount}
+            </span>
+            {t("plugins.stats.enabled", { count: enabledCount })}
+          </span>
+          <span className="flex items-center gap-1.5">
+            <span
+              data-testid="plugins-disabled-count"
+              className="font-semibold text-text-ghost tabular-nums"
+            >
+              {disabledCount}
+            </span>
+            {t("plugins.stats.disabled", { count: disabledCount })}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          className="h-7 text-[11px] gap-1.5"
+        >
+          <RefreshCw className={`h-3 w-3 ${isRefreshing ? "animate-spin" : ""}`} />
+          {t("plugins.action.refresh")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/views/PluginsView/PluginsHeader.tsx
+++ b/src/views/PluginsView/PluginsHeader.tsx
@@ -4,14 +4,12 @@ import { Button } from "@/components/ui/button";
 
 interface PluginsHeaderProps {
   enabledCount: number;
-  disabledCount: number;
   onRefresh: () => void;
   isRefreshing: boolean;
 }
 
 export function PluginsHeader({
   enabledCount,
-  disabledCount,
   onRefresh,
   isRefreshing,
 }: PluginsHeaderProps) {
@@ -30,15 +28,6 @@ export function PluginsHeader({
               {enabledCount}
             </span>
             {t("plugins.stats.enabled", { count: enabledCount })}
-          </span>
-          <span className="flex items-center gap-1.5">
-            <span
-              data-testid="plugins-disabled-count"
-              className="font-semibold text-text-ghost tabular-nums"
-            >
-              {disabledCount}
-            </span>
-            {t("plugins.stats.disabled", { count: disabledCount })}
           </span>
         </div>
       </div>

--- a/src/views/PluginsView/PluginsToolbar.tsx
+++ b/src/views/PluginsView/PluginsToolbar.tsx
@@ -1,0 +1,63 @@
+import { Search } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface PluginsToolbarProps {
+  categories: string[];
+  activeCategory: string;
+  onCategoryChange: (category: string) => void;
+  search: string;
+  onSearchChange: (value: string) => void;
+}
+
+export function PluginsToolbar({
+  categories,
+  activeCategory,
+  onCategoryChange,
+  search,
+  onSearchChange,
+}: PluginsToolbarProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="flex items-center gap-3 px-6 py-2 bg-surface border-b border-border-soft shrink-0">
+      <div role="tablist" className="flex gap-0.5 bg-surface-muted rounded-md p-0.5">
+        {categories.map((category) => {
+          const label = t(`plugins.categories.${category}`, {
+            defaultValue: category,
+          });
+          const isActive = category === activeCategory;
+          return (
+            <button
+              key={category}
+              type="button"
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => onCategoryChange(category)}
+              className={
+                isActive
+                  ? "px-3 py-1 rounded text-[11px] font-medium bg-surface text-accent shadow-sm transition-colors"
+                  : "px-3 py-1 rounded text-[11px] text-text-dim hover:text-text-muted transition-colors"
+              }
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex-1" />
+
+      <div className="relative w-64">
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-3 w-3 text-text-ghost" />
+        <input
+          type="search"
+          value={search}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder={t("plugins.search.placeholder")}
+          aria-label={t("plugins.search.placeholder")}
+          className="w-full h-7 pl-8 pr-3 text-[11px] bg-surface-alt border border-border-soft rounded-md placeholder:text-text-ghost focus:outline-none focus:border-accent"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
+++ b/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PluginStoreRow } from "../PluginStoreRow";
+import type { PluginStoreEntry } from "@/types/plugin-store";
+
+const baseEntry: PluginStoreEntry = {
+  name: "vortex-mod-youtube",
+  description: "YouTube downloader",
+  author: "vortex-community",
+  version: "1.1.2",
+  installedVersion: "1.1.2",
+  category: "crawler",
+  official: true,
+  status: "installed",
+};
+
+function renderRow(override: Partial<PluginStoreEntry> = {}, handlers = {}) {
+  const defaultHandlers = {
+    onInstall: vi.fn(),
+    onUpdate: vi.fn(),
+    onDisable: vi.fn(),
+    onUninstall: vi.fn(),
+    isInstalling: false,
+    isUpdating: false,
+  };
+  const merged = { ...defaultHandlers, ...handlers };
+  render(<PluginStoreRow entry={{ ...baseEntry, ...override }} {...merged} />);
+  return merged;
+}
+
+describe("PluginStoreRow", () => {
+  it("renders the plugin name, description and category", () => {
+    renderRow();
+    expect(screen.getByText("vortex-mod-youtube")).toBeInTheDocument();
+    expect(screen.getByText(/YouTube downloader/)).toBeInTheDocument();
+  });
+
+  it("renders a monogram icon derived from the plugin name", () => {
+    renderRow({ name: "vortex-mod-youtube" });
+    const icon = screen.getByTestId("plugin-icon");
+    expect(icon).toHaveTextContent("YO");
+  });
+
+  it("strips the vortex-mod- prefix when generating the monogram", () => {
+    renderRow({ name: "vortex-mod-soundcloud" });
+    expect(screen.getByTestId("plugin-icon")).toHaveTextContent("SO");
+  });
+
+  it("shows an install button when the plugin is not installed", async () => {
+    const user = userEvent.setup();
+    const handlers = renderRow({ status: "not_installed", installedVersion: null });
+    const button = screen.getByRole("button", { name: /install(er)?/i });
+    await user.click(button);
+    expect(handlers.onInstall).toHaveBeenCalledWith("vortex-mod-youtube");
+  });
+
+  it("shows an enabled toggle when the plugin is installed", () => {
+    renderRow({ status: "installed" });
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("data-state", "checked");
+  });
+
+  it("calls onDisable when the toggle is turned off", async () => {
+    const user = userEvent.setup();
+    const handlers = renderRow({ status: "installed" });
+    await user.click(screen.getByRole("switch"));
+    expect(handlers.onDisable).toHaveBeenCalledWith("vortex-mod-youtube");
+  });
+
+  it("renders an update pill when an update is available", async () => {
+    const user = userEvent.setup();
+    const handlers = renderRow({
+      status: "update_available",
+      version: "1.2.0",
+      installedVersion: "1.1.0",
+    });
+    const pill = screen.getByRole("button", { name: /1\.2\.0/ });
+    await user.click(pill);
+    expect(handlers.onUpdate).toHaveBeenCalledWith("vortex-mod-youtube");
+  });
+
+  it("displays the installed version next to the toggle when installed", () => {
+    renderRow({ status: "installed", installedVersion: "1.1.2" });
+    expect(screen.getByText("v1.1.2")).toBeInTheDocument();
+  });
+
+  it("exposes an uninstall action in the kebab menu for installed plugins", async () => {
+    const user = userEvent.setup();
+    const handlers = renderRow({ status: "installed" });
+    await user.click(screen.getByRole("button", { name: /(more actions|plus d'actions)/i }));
+    await user.click(screen.getByRole("menuitem", { name: /(uninstall|désinstaller)/i }));
+    expect(handlers.onUninstall).toHaveBeenCalledWith("vortex-mod-youtube");
+  });
+
+  it("renders official badge when official is true", () => {
+    renderRow({ official: true });
+    expect(screen.getByText(/(official|officiel)/i)).toBeInTheDocument();
+  });
+
+  it("does not render official badge when official is false", () => {
+    renderRow({ official: false });
+    expect(screen.queryByText(/^(official|officiel)$/i)).not.toBeInTheDocument();
+  });
+});

--- a/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
+++ b/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
@@ -19,7 +19,6 @@ function renderRow(override: Partial<PluginStoreEntry> = {}, handlers = {}) {
   const defaultHandlers = {
     onInstall: vi.fn(),
     onUpdate: vi.fn(),
-    onDisable: vi.fn(),
     onUninstall: vi.fn(),
     isInstalling: false,
     isUpdating: false,
@@ -34,6 +33,16 @@ describe("PluginStoreRow", () => {
     renderRow();
     expect(screen.getByText("vortex-mod-youtube")).toBeInTheDocument();
     expect(screen.getByText(/YouTube downloader/)).toBeInTheDocument();
+  });
+
+  it("renders the category label translated through i18n", () => {
+    renderRow({ category: "crawler" });
+    expect(screen.getByText(/Crawlers/)).toBeInTheDocument();
+  });
+
+  it("falls back to the raw category slug when no translation exists", () => {
+    renderRow({ category: "custom-unknown" });
+    expect(screen.getByText(/custom-unknown/)).toBeInTheDocument();
   });
 
   it("renders a monogram icon derived from the plugin name", () => {
@@ -77,14 +86,6 @@ describe("PluginStoreRow", () => {
   it("displays the installed version next to the actions when installed", () => {
     renderRow({ status: "installed", installedVersion: "1.1.2" });
     expect(screen.getByText("v1.1.2")).toBeInTheDocument();
-  });
-
-  it("exposes the disable action from the kebab menu for installed plugins", async () => {
-    const user = userEvent.setup();
-    const handlers = renderRow({ status: "installed" });
-    await user.click(screen.getByRole("button", { name: /(more actions|plus d'actions)/i }));
-    await user.click(screen.getByRole("menuitem", { name: /(disable|désactiver)/i }));
-    expect(handlers.onDisable).toHaveBeenCalledWith("vortex-mod-youtube");
   });
 
   it("exposes an uninstall action in the kebab menu for installed plugins", async () => {

--- a/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
+++ b/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
@@ -55,34 +55,36 @@ describe("PluginStoreRow", () => {
     expect(handlers.onInstall).toHaveBeenCalledWith("vortex-mod-youtube");
   });
 
-  it("shows an enabled toggle when the plugin is installed", () => {
+  it("does not render an install button when the plugin is already installed", () => {
     renderRow({ status: "installed" });
-    const toggle = screen.getByRole("switch");
-    expect(toggle).toHaveAttribute("data-state", "checked");
+    expect(
+      screen.queryByRole("button", { name: /^install(er)?$/i }),
+    ).not.toBeInTheDocument();
   });
 
-  it("calls onDisable when the toggle is turned off", async () => {
-    const user = userEvent.setup();
-    const handlers = renderRow({ status: "installed" });
-    await user.click(screen.getByRole("switch"));
-    expect(handlers.onDisable).toHaveBeenCalledWith("vortex-mod-youtube");
-  });
-
-  it("renders an update pill when an update is available", async () => {
+  it("renders an update pill prefixed with v when an update is available", async () => {
     const user = userEvent.setup();
     const handlers = renderRow({
       status: "update_available",
       version: "1.2.0",
       installedVersion: "1.1.0",
     });
-    const pill = screen.getByRole("button", { name: /1\.2\.0/ });
+    const pill = screen.getByRole("button", { name: /v1\.2\.0/ });
     await user.click(pill);
     expect(handlers.onUpdate).toHaveBeenCalledWith("vortex-mod-youtube");
   });
 
-  it("displays the installed version next to the toggle when installed", () => {
+  it("displays the installed version next to the actions when installed", () => {
     renderRow({ status: "installed", installedVersion: "1.1.2" });
     expect(screen.getByText("v1.1.2")).toBeInTheDocument();
+  });
+
+  it("exposes the disable action from the kebab menu for installed plugins", async () => {
+    const user = userEvent.setup();
+    const handlers = renderRow({ status: "installed" });
+    await user.click(screen.getByRole("button", { name: /(more actions|plus d'actions)/i }));
+    await user.click(screen.getByRole("menuitem", { name: /(disable|désactiver)/i }));
+    expect(handlers.onDisable).toHaveBeenCalledWith("vortex-mod-youtube");
   });
 
   it("exposes an uninstall action in the kebab menu for installed plugins", async () => {

--- a/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
+++ b/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
@@ -15,14 +15,19 @@ const baseEntry: PluginStoreEntry = {
   status: "installed",
 };
 
-function renderRow(override: Partial<PluginStoreEntry> = {}, handlers = {}) {
+function renderRow(
+  override: Partial<PluginStoreEntry> = {},
+  handlers: Record<string, unknown> = {},
+) {
   const defaultHandlers = {
     onInstall: vi.fn(),
     onUpdate: vi.fn(),
     onDisable: vi.fn(),
+    onEnable: vi.fn(),
     onUninstall: vi.fn(),
     isInstalling: false,
     isUpdating: false,
+    isLocallyDisabled: false,
   };
   const merged = { ...defaultHandlers, ...handlers };
   render(<PluginStoreRow entry={{ ...baseEntry, ...override }} {...merged} />);
@@ -92,7 +97,7 @@ describe("PluginStoreRow", () => {
   it("exposes a disable action in the kebab menu for installed plugins", async () => {
     const user = userEvent.setup();
     const handlers = renderRow({ status: "installed" });
-    await user.click(screen.getByRole("button", { name: /(more actions|plus d'actions)/i }));
+    await user.click(screen.getByRole("button", { name: /(more actions|plus d['\u2019]actions)/i }));
     await user.click(screen.getByRole("menuitem", { name: /(^disable$|désactiver)/i }));
     expect(handlers.onDisable).toHaveBeenCalledWith("vortex-mod-youtube");
   });
@@ -100,7 +105,7 @@ describe("PluginStoreRow", () => {
   it("exposes an uninstall action in the kebab menu for installed plugins", async () => {
     const user = userEvent.setup();
     const handlers = renderRow({ status: "installed" });
-    await user.click(screen.getByRole("button", { name: /(more actions|plus d'actions)/i }));
+    await user.click(screen.getByRole("button", { name: /(more actions|plus d['\u2019]actions)/i }));
     await user.click(screen.getByRole("menuitem", { name: /(uninstall|désinstaller)/i }));
     expect(handlers.onUninstall).toHaveBeenCalledWith("vortex-mod-youtube");
   });
@@ -113,5 +118,28 @@ describe("PluginStoreRow", () => {
   it("does not render official badge when official is false", () => {
     renderRow({ official: false });
     expect(screen.queryByText(/^(official|officiel)$/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the inactive badge when the plugin is locally disabled", () => {
+    renderRow({ status: "installed" }, { isLocallyDisabled: true });
+    expect(screen.getByText(/(inactive|inactif)/i)).toBeInTheDocument();
+  });
+
+  it("swaps Disable for Enable in the kebab menu when locally disabled", async () => {
+    const user = userEvent.setup();
+    const handlers = renderRow(
+      { status: "installed" },
+      { isLocallyDisabled: true },
+    );
+    await user.click(
+      screen.getByRole("button", { name: /(more actions|plus d['\u2019]actions)/i }),
+    );
+    await user.click(
+      screen.getByRole("menuitem", { name: /(^enable$|activer)/i }),
+    );
+    expect(handlers.onEnable).toHaveBeenCalledWith("vortex-mod-youtube");
+    expect(
+      screen.queryByRole("menuitem", { name: /(^disable$|désactiver)/i }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
+++ b/src/views/PluginsView/__tests__/PluginStoreRow.test.tsx
@@ -19,6 +19,7 @@ function renderRow(override: Partial<PluginStoreEntry> = {}, handlers = {}) {
   const defaultHandlers = {
     onInstall: vi.fn(),
     onUpdate: vi.fn(),
+    onDisable: vi.fn(),
     onUninstall: vi.fn(),
     isInstalling: false,
     isUpdating: false,
@@ -86,6 +87,14 @@ describe("PluginStoreRow", () => {
   it("displays the installed version next to the actions when installed", () => {
     renderRow({ status: "installed", installedVersion: "1.1.2" });
     expect(screen.getByText("v1.1.2")).toBeInTheDocument();
+  });
+
+  it("exposes a disable action in the kebab menu for installed plugins", async () => {
+    const user = userEvent.setup();
+    const handlers = renderRow({ status: "installed" });
+    await user.click(screen.getByRole("button", { name: /(more actions|plus d'actions)/i }));
+    await user.click(screen.getByRole("menuitem", { name: /(^disable$|désactiver)/i }));
+    expect(handlers.onDisable).toHaveBeenCalledWith("vortex-mod-youtube");
   });
 
   it("exposes an uninstall action in the kebab menu for installed plugins", async () => {

--- a/src/views/PluginsView/__tests__/PluginsHeader.test.tsx
+++ b/src/views/PluginsView/__tests__/PluginsHeader.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PluginsHeader } from "../PluginsHeader";
+
+describe("PluginsHeader", () => {
+  it("renders the 'Plugins' title", () => {
+    render(
+      <PluginsHeader enabledCount={0} disabledCount={0} onRefresh={vi.fn()} isRefreshing={false} />,
+    );
+    expect(screen.getByText(/plugins/i)).toBeInTheDocument();
+  });
+
+  it("shows the enabled and disabled counters", () => {
+    render(
+      <PluginsHeader enabledCount={4} disabledCount={2} onRefresh={vi.fn()} isRefreshing={false} />,
+    );
+    expect(screen.getByTestId("plugins-enabled-count")).toHaveTextContent("4");
+    expect(screen.getByTestId("plugins-disabled-count")).toHaveTextContent("2");
+  });
+
+  it("invokes onRefresh when the refresh button is clicked", async () => {
+    const user = userEvent.setup();
+    const onRefresh = vi.fn();
+    render(
+      <PluginsHeader
+        enabledCount={0}
+        disabledCount={0}
+        onRefresh={onRefresh}
+        isRefreshing={false}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /(check updates|vérifier)/i }));
+    expect(onRefresh).toHaveBeenCalledOnce();
+  });
+
+  it("disables the refresh button while refreshing", () => {
+    render(<PluginsHeader enabledCount={0} disabledCount={0} onRefresh={vi.fn()} isRefreshing />);
+    const button = screen.getByRole("button", {
+      name: /(check updates|vérifier)/i,
+    });
+    expect(button).toBeDisabled();
+  });
+});

--- a/src/views/PluginsView/__tests__/PluginsHeader.test.tsx
+++ b/src/views/PluginsView/__tests__/PluginsHeader.test.tsx
@@ -5,37 +5,25 @@ import { PluginsHeader } from "../PluginsHeader";
 
 describe("PluginsHeader", () => {
   it("renders the 'Plugins' title", () => {
-    render(
-      <PluginsHeader enabledCount={0} disabledCount={0} onRefresh={vi.fn()} isRefreshing={false} />,
-    );
+    render(<PluginsHeader enabledCount={0} onRefresh={vi.fn()} isRefreshing={false} />);
     expect(screen.getByText(/plugins/i)).toBeInTheDocument();
   });
 
-  it("shows the enabled and disabled counters", () => {
-    render(
-      <PluginsHeader enabledCount={4} disabledCount={2} onRefresh={vi.fn()} isRefreshing={false} />,
-    );
+  it("shows the enabled counter derived from the store", () => {
+    render(<PluginsHeader enabledCount={4} onRefresh={vi.fn()} isRefreshing={false} />);
     expect(screen.getByTestId("plugins-enabled-count")).toHaveTextContent("4");
-    expect(screen.getByTestId("plugins-disabled-count")).toHaveTextContent("2");
   });
 
   it("invokes onRefresh when the refresh button is clicked", async () => {
     const user = userEvent.setup();
     const onRefresh = vi.fn();
-    render(
-      <PluginsHeader
-        enabledCount={0}
-        disabledCount={0}
-        onRefresh={onRefresh}
-        isRefreshing={false}
-      />,
-    );
+    render(<PluginsHeader enabledCount={0} onRefresh={onRefresh} isRefreshing={false} />);
     await user.click(screen.getByRole("button", { name: /(check updates|vérifier)/i }));
     expect(onRefresh).toHaveBeenCalledOnce();
   });
 
   it("disables the refresh button while refreshing", () => {
-    render(<PluginsHeader enabledCount={0} disabledCount={0} onRefresh={vi.fn()} isRefreshing />);
+    render(<PluginsHeader enabledCount={0} onRefresh={vi.fn()} isRefreshing />);
     const button = screen.getByRole("button", {
       name: /(check updates|vérifier)/i,
     });

--- a/src/views/PluginsView/__tests__/PluginsToolbar.test.tsx
+++ b/src/views/PluginsView/__tests__/PluginsToolbar.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PluginsToolbar } from "../PluginsToolbar";
+
+const CATEGORIES = ["all", "crawler", "hoster", "captcha"];
+
+describe("PluginsToolbar", () => {
+  it("renders a pill for every provided category", () => {
+    render(
+      <PluginsToolbar
+        categories={CATEGORIES}
+        activeCategory="all"
+        onCategoryChange={vi.fn()}
+        search=""
+        onSearchChange={vi.fn()}
+      />,
+    );
+    expect(screen.getAllByRole("tab")).toHaveLength(CATEGORIES.length);
+  });
+
+  it("marks the active category pill with aria-selected", () => {
+    render(
+      <PluginsToolbar
+        categories={CATEGORIES}
+        activeCategory="crawler"
+        onCategoryChange={vi.fn()}
+        search=""
+        onSearchChange={vi.fn()}
+      />,
+    );
+    const active = screen.getByRole("tab", { selected: true });
+    expect(active).toHaveTextContent(/crawler/i);
+  });
+
+  it("calls onCategoryChange when a pill is clicked", async () => {
+    const user = userEvent.setup();
+    const onCategoryChange = vi.fn();
+    render(
+      <PluginsToolbar
+        categories={CATEGORIES}
+        activeCategory="all"
+        onCategoryChange={onCategoryChange}
+        search=""
+        onSearchChange={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("tab", { name: /crawler/i }));
+    expect(onCategoryChange).toHaveBeenCalledWith("crawler");
+  });
+
+  it("emits onSearchChange as the user types", async () => {
+    const user = userEvent.setup();
+    const onSearchChange = vi.fn();
+    render(
+      <PluginsToolbar
+        categories={CATEGORIES}
+        activeCategory="all"
+        onCategoryChange={vi.fn()}
+        search=""
+        onSearchChange={onSearchChange}
+      />,
+    );
+    await user.type(screen.getByRole("searchbox"), "y");
+    expect(onSearchChange).toHaveBeenCalledWith("y");
+  });
+});

--- a/src/views/PluginsView/__tests__/groupByCategory.test.ts
+++ b/src/views/PluginsView/__tests__/groupByCategory.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { groupByCategory } from "../groupByCategory";
+import type { PluginStoreEntry } from "@/types/plugin-store";
+
+function entry(name: string, category: string): PluginStoreEntry {
+  return {
+    name,
+    description: "",
+    author: "",
+    version: "1.0.0",
+    installedVersion: null,
+    category,
+    official: true,
+    status: "not_installed",
+  };
+}
+
+describe("groupByCategory", () => {
+  it("returns an empty array for an empty input", () => {
+    expect(groupByCategory([])).toEqual([]);
+  });
+
+  it("groups entries by category preserving insertion order", () => {
+    const input = [entry("a", "crawler"), entry("b", "hoster"), entry("c", "crawler")];
+    const result = groupByCategory(input);
+    expect(result).toHaveLength(2);
+    expect(result[0].category).toBe("crawler");
+    expect(result[0].entries.map((e) => e.name)).toEqual(["a", "c"]);
+    expect(result[1].category).toBe("hoster");
+    expect(result[1].entries.map((e) => e.name)).toEqual(["b"]);
+  });
+
+  it("keeps categories distinct even with unusual ordering", () => {
+    const input = [
+      entry("a", "captcha"),
+      entry("b", "crawler"),
+      entry("c", "captcha"),
+      entry("d", "crawler"),
+    ];
+    const result = groupByCategory(input);
+    expect(result.map((g) => g.category)).toEqual(["captcha", "crawler"]);
+    expect(result[0].entries).toHaveLength(2);
+    expect(result[1].entries).toHaveLength(2);
+  });
+});

--- a/src/views/PluginsView/groupByCategory.ts
+++ b/src/views/PluginsView/groupByCategory.ts
@@ -1,0 +1,22 @@
+import type { PluginStoreEntry } from "@/types/plugin-store";
+
+export interface PluginGroup {
+  category: string;
+  entries: PluginStoreEntry[];
+}
+
+export function groupByCategory(entries: PluginStoreEntry[]): PluginGroup[] {
+  const map = new Map<string, PluginStoreEntry[]>();
+  for (const entry of entries) {
+    const bucket = map.get(entry.category);
+    if (bucket) {
+      bucket.push(entry);
+    } else {
+      map.set(entry.category, [entry]);
+    }
+  }
+  return Array.from(map, ([category, groupEntries]) => ({
+    category,
+    entries: groupEntries,
+  }));
+}


### PR DESCRIPTION
## Summary

Refactor the plugins catalogue page to match the mockup design while keeping every existing Tauri IPC command behind it unchanged.

- New `PluginsHeader` — title, enabled/disabled counters, "Check updates" action
- New `PluginsToolbar` — segmented category pills replacing the Select dropdown, inline search
- Category-grouped sections (uppercase labels, rounded card containers)
- Monogram icons (accent-tinted for crawlers/extractors)
- Installed plugins → Switch toggle (calls `plugin_disable`)
- Update available → inline "↑ vX.Y.Z" pill next to the toggle
- Not installed → single `Install` button
- Destructive `Uninstall` action moved to a kebab menu (reduces noise)
- i18n keys added for stats, categories, actions (fr + en)
- Tests: 11 PluginStoreRow + 4 PluginsHeader + 4 PluginsToolbar + 3 groupByCategory
- `issue30-ui-fr` updated to match the new French copy

## Test plan

- [x] `npx vitest run` — 389/389 green
- [x] `npx oxlint src/views/PluginsView src/views/PluginsView.tsx src/i18n` — clean
- [x] `npx tsc --noEmit` — clean
- [ ] Manual: open `/plugins`, confirm header / grouped sections render
- [ ] Manual: toggle off an installed plugin → triggers `plugin_disable`
- [ ] Manual: click `Install` on a not-installed plugin → catalogue row refreshes
- [ ] Manual: open kebab menu → `Uninstall` triggers `plugin_uninstall`
- [ ] Manual: type in the search field → list filters live
- [ ] Manual: switch locale to `fr` → every label translated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the Plugins catalog to match the mockup, with a compact header, segmented filter, grouped sections, and streamlined row actions. Adds an optimistic Disable/Enable flow that dims rows and updates the enabled counter; IPC mutations remain unchanged.

- **New Features**
  - Header with enabled counter and “Check updates”; counter excludes locally disabled plugins.
  - Toolbar with category pills and localized search; placeholder uses an ellipsis.
  - Grouped sections per category with uppercase labels and counts; category labels translated with a slug fallback.
  - Monogram icons (accent tint for `crawler`/`extractor`).
  - Row actions: single Install for not-installed; inline update pill prefixed with “v”; installed version label; kebab menu with Disable/Enable and Uninstall; “inactive” badge + dimmed row when locally disabled.
  - i18n in `en`/`fr`: title, stats, categories, actions (incl. Enable), search, empty/error/loading/retry, badges (“official”, “inactive”), toasts (incl. enable success); pluralization uses `_one`/`_other`.
  - Tests added for `PluginStoreRow`, `PluginsHeader`, `PluginsToolbar`, and `groupByCategory`.

- **Bug Fixes**
  - Clearing locally disabled state on uninstall success to prevent a reinstalled plugin from appearing inactive until reload.

<sup>Written for commit 891a1133c23b49e1b4cb3cffdee4e9ee5cffcb39. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned Plugins UI: header with enabled counter & refresh, toolbar with category tabs and search, grouped plugin sections, compact rows, and bottom spacer

* **UX**
  * Contextual Install/Update buttons and a “More” menu exposing Disable/Enable and Uninstall actions; installed version and official/inactive indicators; optimistic local disable state

* **Localization**
  * Added comprehensive English and French plugins strings, including enable success toast

* **Tests**
  * New unit/UI tests for header, toolbar, rows, grouping, and behaviors

* **Documentation**
  * Clarified changelog wording about download completion event timing (emitted after persistence)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->