### PR TITLE
feat(plugin): integrate vortex-mod-vimeo for end-to-end download

### DIFF
--- a/src-tauri/src/adapters/driven/plugin/capabilities.rs
+++ b/src-tauri/src/adapters/driven/plugin/capabilities.rs
@@ -97,7 +97,12 @@ pub fn build_host_functions(
     let name = manifest.info().name().to_string();
 
     // Ensure per-plugin config/state maps exist before any function runs.
-    shared.plugin_configs.entry(name.clone()).or_default();
+    let plugin_configs = shared.plugin_configs.entry(name.clone()).or_default();
+    for (key, value) in manifest.config_defaults() {
+        plugin_configs
+            .entry(key.clone())
+            .or_insert_with(|| value.clone());
+    }
     shared.plugin_states.entry(name.clone()).or_default();
 
     let ctx = PluginHostContext {
@@ -192,6 +197,42 @@ mod tests {
 
         assert!(shared.plugin_configs().contains_key("test-plugin"));
         assert!(shared.plugin_states().contains_key("test-plugin"));
+    }
+
+    #[test]
+    fn test_build_host_functions_seeds_config_defaults() {
+        let shared = Arc::new(SharedHostResources::new());
+        let info = PluginInfo::new(
+            "test-plugin".to_string(),
+            "1.0.0".to_string(),
+            "Test plugin".to_string(),
+            "tester".to_string(),
+            PluginCategory::Utility,
+        );
+        let manifest =
+            PluginManifest::new(info).with_config_defaults(std::collections::HashMap::from([
+                ("default_quality".to_string(), "720p".to_string()),
+                ("extract_audio_only".to_string(), "false".to_string()),
+            ]));
+
+        build_host_functions(&manifest, &shared);
+
+        let plugin_config = shared
+            .plugin_configs()
+            .get("test-plugin")
+            .expect("plugin config map");
+        assert_eq!(
+            plugin_config
+                .get("default_quality")
+                .map(|v| v.value().clone()),
+            Some("720p".to_string())
+        );
+        assert_eq!(
+            plugin_config
+                .get("extract_audio_only")
+                .map(|v| v.value().clone()),
+            Some("false".to_string())
+        );
     }
 
     #[test]

--- a/src-tauri/src/adapters/driven/plugin/extism_loader.rs
+++ b/src-tauri/src/adapters/driven/plugin/extism_loader.rs
@@ -54,6 +54,22 @@ impl ExtismPluginLoader {
         }
         Ok(info)
     }
+
+    fn call_url_plugin_function(&self, url: &str, func: &str) -> Result<String, DomainError> {
+        let info = self.resolve_wasm_plugin(url)?;
+        if !self.registry.function_exists(info.name(), func)? {
+            return Err(DomainError::NotFound(format!(
+                "plugin '{}' does not export '{func}'",
+                info.name()
+            )));
+        }
+
+        self.registry
+            .call_plugin(info.name(), func, url)
+            .map_err(|e| {
+                DomainError::PluginError(format!("plugin '{}' {func} failed: {e}", info.name()))
+            })
+    }
 }
 
 impl PluginLoader for ExtismPluginLoader {
@@ -143,6 +159,14 @@ impl PluginLoader for ExtismPluginLoader {
 
     fn set_enabled(&self, name: &str, enabled: bool) -> Result<(), DomainError> {
         self.registry.set_enabled(name, enabled)
+    }
+
+    fn extract_links(&self, url: &str) -> Result<String, DomainError> {
+        self.call_url_plugin_function(url, "extract_links")
+    }
+
+    fn get_media_variants(&self, url: &str) -> Result<String, DomainError> {
+        self.call_url_plugin_function(url, "get_media_variants")
     }
 
     fn resolve_stream_url(

--- a/src-tauri/src/adapters/driven/plugin/manifest.rs
+++ b/src-tauri/src/adapters/driven/plugin/manifest.rs
@@ -1,5 +1,6 @@
 //! Parse `plugin.toml` files into domain [`PluginManifest`].
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
@@ -11,6 +12,8 @@ use crate::domain::model::plugin::{PluginCategory, PluginInfo, PluginManifest};
 struct RawManifest {
     plugin: RawPluginSection,
     capabilities: Option<RawCapabilities>,
+    #[serde(default)]
+    config: HashMap<String, RawConfigEntry>,
 }
 
 #[derive(Deserialize)]
@@ -29,6 +32,11 @@ struct RawCapabilities {
     http: Option<bool>,
     filesystem: Option<bool>,
     subprocess: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+struct RawConfigEntry {
+    default: Option<toml::Value>,
 }
 
 /// Parse a plugin directory containing `plugin.toml` and a `.wasm` file.
@@ -74,8 +82,11 @@ pub fn parse_manifest(dir: &Path) -> Result<(PluginManifest, PathBuf), DomainErr
         .as_ref()
         .map(build_capabilities)
         .unwrap_or_default();
+    let config_defaults = build_config_defaults(&raw.config)?;
 
-    let mut manifest = PluginManifest::new(info).with_capabilities(caps);
+    let mut manifest = PluginManifest::new(info)
+        .with_capabilities(caps)
+        .with_config_defaults(config_defaults);
     if let Some(v) = raw.plugin.min_vortex_version {
         manifest = manifest.with_min_version(v);
     }
@@ -114,6 +125,31 @@ fn build_capabilities(caps: &RawCapabilities) -> Vec<String> {
         }
     }
     result
+}
+
+fn build_config_defaults(
+    raw_config: &HashMap<String, RawConfigEntry>,
+) -> Result<HashMap<String, String>, DomainError> {
+    let mut defaults = HashMap::new();
+    for (key, entry) in raw_config {
+        let Some(value) = &entry.default else {
+            continue;
+        };
+        defaults.insert(key.clone(), encode_config_default(value)?);
+    }
+    Ok(defaults)
+}
+
+fn encode_config_default(value: &toml::Value) -> Result<String, DomainError> {
+    match value {
+        toml::Value::String(s) => Ok(s.clone()),
+        toml::Value::Integer(i) => Ok(i.to_string()),
+        toml::Value::Float(f) => Ok(f.to_string()),
+        toml::Value::Boolean(b) => Ok(b.to_string()),
+        toml::Value::Datetime(dt) => Ok(dt.to_string()),
+        toml::Value::Array(_) | toml::Value::Table(_) => serde_json::to_string(value)
+            .map_err(|e| DomainError::PluginError(format!("invalid config default value: {e}"))),
+    }
 }
 
 /// Find exactly one `.wasm` file in the plugin directory.
@@ -193,6 +229,53 @@ subprocess = ["ffmpeg"]
         assert!(!manifest.has_capability("filesystem"));
         assert!(manifest.has_capability("subprocess:ffmpeg"));
         assert!(wasm_path.ends_with("my-hoster.wasm"));
+    }
+
+    #[test]
+    fn test_parse_manifest_extracts_config_defaults() {
+        let tmp = TempDir::new().unwrap();
+        let plugin_dir = tmp.path().join("with-config");
+        std::fs::create_dir_all(&plugin_dir).unwrap();
+        write_plugin_toml(
+            &plugin_dir,
+            r#"
+[plugin]
+name = "with-config"
+version = "1.0.0"
+category = "crawler"
+author = "Alice"
+description = "Config defaults"
+
+[config]
+default_quality = { type = "string", default = "720p", options = ["360p", "720p"] }
+extract_audio_only = { type = "boolean", default = false }
+subtitle_languages = { type = "array", default = ["en", "fr"] }
+"#,
+        );
+        write_dummy_wasm(&plugin_dir, "with-config.wasm");
+
+        let (manifest, _) = parse_manifest(&plugin_dir).unwrap();
+        assert_eq!(
+            manifest
+                .config_defaults()
+                .get("default_quality")
+                .map(String::as_str),
+            Some("720p")
+        );
+        assert_eq!(
+            manifest
+                .config_defaults()
+                .get("extract_audio_only")
+                .map(String::as_str),
+            Some("false")
+        );
+        assert_eq!(
+            manifest
+                .config_defaults()
+                .get("subtitle_languages")
+                .map(String::as_str),
+            Some("[\"en\",\"fr\"]")
+        );
     }
 
     #[test]

--- a/src-tauri/src/adapters/driven/plugin/manifest.rs
+++ b/src-tauri/src/adapters/driven/plugin/manifest.rs
@@ -279,6 +279,31 @@ subtitle_languages = { type = "array", default = ["en", "fr"] }
     }
 
     #[test]
+    fn test_encode_config_default_covers_remaining_scalar_and_table_branches() {
+        let integer = toml::Value::Integer(720);
+        let float = toml::Value::Float(1.5);
+        let datetime = toml::Value::Datetime("1979-05-27T07:32:00Z".parse().unwrap());
+        let table = toml::from_str::<toml::Value>(
+            r#"
+enabled = true
+nested = { quality = "720p" }
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(encode_config_default(&integer).unwrap(), "720");
+        assert_eq!(encode_config_default(&float).unwrap(), "1.5");
+        assert_eq!(
+            encode_config_default(&datetime).unwrap(),
+            "1979-05-27T07:32:00Z"
+        );
+        assert_eq!(
+            encode_config_default(&table).unwrap(),
+            serde_json::to_string(&table).unwrap()
+        );
+    }
+
+    #[test]
     fn test_parse_manifest_missing_field() {
         let tmp = TempDir::new().unwrap();
         let plugin_dir = tmp.path().join("bad-plugin");

--- a/src-tauri/src/adapters/driven/plugin/registry.rs
+++ b/src-tauri/src/adapters/driven/plugin/registry.rs
@@ -74,6 +74,20 @@ impl PluginRegistry {
         Ok(())
     }
 
+    pub fn function_exists(&self, name: &str, func: &str) -> Result<bool, DomainError> {
+        let plugin_handle = {
+            let entry = self
+                .plugins
+                .get(name)
+                .ok_or_else(|| DomainError::NotFound(name.to_string()))?;
+            Arc::clone(&entry.plugin)
+        };
+        let plugin = plugin_handle
+            .lock()
+            .map_err(|_| DomainError::PluginError(format!("plugin '{name}' mutex poisoned")))?;
+        Ok(plugin.function_exists(func))
+    }
+
     pub fn call_plugin(&self, name: &str, func: &str, input: &str) -> Result<String, DomainError> {
         // Clone the Arc<Mutex<Plugin>> and drop the DashMap shard guard
         // before locking. This prevents holding the shard during slow WASM execution.
@@ -212,5 +226,14 @@ mod tests {
         let result = registry.list_loaded();
         assert!(result.is_ok());
         assert_eq!(result.unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_function_exists_returns_false_for_missing_export() {
+        let registry = PluginRegistry::new();
+        registry.insert("plug-a".to_string(), make_loaded("plug-a"));
+
+        let result = registry.function_exists("plug-a", "extract_links");
+        assert_eq!(result.unwrap(), false);
     }
 }

--- a/src-tauri/src/adapters/driving/tauri_ipc.rs
+++ b/src-tauri/src/adapters/driving/tauri_ipc.rs
@@ -759,6 +759,7 @@ pub async fn download_media_start(
     if let Some(targets) = batch_targets {
         let mut download_ids = Vec::with_capacity(targets.len());
         for target in targets {
+            let title = Some(soundcloud_track_download_title(&target));
             let id = start_media_download_for_url(
                 state.command_bus.clone(),
                 state.plugin_loader.clone(),
@@ -766,7 +767,7 @@ pub async fn download_media_start(
                 quality.clone(),
                 format.clone(),
                 true,
-                Some(soundcloud_track_download_title(&target)),
+                title,
             )
             .await?;
             download_ids.push(id);
@@ -1282,15 +1283,11 @@ fn parse_plugin_video_metadata(
     let mut seen_heights = std::collections::HashSet::<u32>::new();
     let mut seen_video_exts = std::collections::HashSet::<String>::new();
     let mut seen_audio_exts = std::collections::HashSet::<String>::new();
-    let mut default_quality = None;
 
     for variant in variants.variants {
         match variant.kind {
             PluginVariantKind::Video => {
                 if let Some(height) = variant.height.filter(|height| *height > 0) {
-                    if default_quality.is_none() {
-                        default_quality = Some(format!("{height}p"));
-                    }
                     if seen_heights.insert(height) {
                         available_qualities.push(QualityOptionDto {
                             quality: format!("{height}p"),
@@ -1311,11 +1308,19 @@ fn parse_plugin_video_metadata(
                     available_audio_formats.push(variant.ext);
                 }
             }
-            PluginVariantKind::Adaptive => {}
+            PluginVariantKind::Adaptive => {
+                tracing::warn!(
+                    ext = %variant.ext,
+                    height = ?variant.height,
+                    "dropping Adaptive plugin variant — adaptive streams not yet supported",
+                );
+            }
         }
     }
 
     available_qualities.sort_by(|a, b| b.height.cmp(&a.height));
+    // Pick default_quality from the sorted top so UI and default agree.
+    let default_quality = available_qualities.first().map(|q| q.quality.clone());
 
     Ok(MediaMetadataDto {
         title: video.title,
@@ -2034,7 +2039,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_plugin_video_metadata_selects_first_variant_as_default() {
+    fn test_parse_plugin_video_metadata_selects_highest_quality_as_default() {
         let extract_links = serde_json::json!({
             "kind": "video",
             "videos": [{
@@ -2077,7 +2082,7 @@ mod tests {
                 .expect("plugin metadata should parse");
 
         assert_eq!(metadata.title, "Vimeo Plugin Video");
-        assert_eq!(metadata.default_quality.as_deref(), Some("720p"));
+        assert_eq!(metadata.default_quality.as_deref(), Some("1080p"));
         let heights: Vec<u32> = metadata
             .available_qualities
             .iter()

--- a/src-tauri/src/adapters/driving/tauri_ipc.rs
+++ b/src-tauri/src/adapters/driving/tauri_ipc.rs
@@ -949,6 +949,11 @@ async fn start_media_download_for_url(
     let quality_clone = quality.clone();
     let format_clone = format.clone();
     let title_clone = title.clone();
+    let configured_download_dir = command_bus
+        .config_store()
+        .get_config()
+        .ok()
+        .and_then(|config| configured_download_destination(config.download_dir.as_deref()));
 
     let resolution = tokio::task::spawn_blocking(move || {
         resolve_media_stream(
@@ -958,6 +963,7 @@ async fn start_media_download_for_url(
             &format_clone,
             audio_only,
             title_clone,
+            configured_download_dir,
         )
     })
     .await
@@ -1010,6 +1016,7 @@ fn resolve_media_stream(
     format: &str,
     audio_only: bool,
     title: Option<String>,
+    configured_download_dir: Option<PathBuf>,
 ) -> Result<StreamResolution, String> {
     match plugin_loader.resolve_stream_url(url, quality, format, audio_only) {
         Ok(cdn_url) => Ok(StreamResolution::CdnUrl(cdn_url)),
@@ -1057,11 +1064,12 @@ fn resolve_media_stream(
                         .to_string()
                 });
 
-            let dest_dir = dirs::download_dir()
+            let dest_dir = configured_download_dir
+                .or_else(dirs::download_dir)
                 .or_else(dirs::home_dir)
                 .ok_or_else(|| {
                     "cannot determine download destination: neither \
-                     user-dirs download_dir nor home_dir are available"
+                     configured download_dir, user-dirs download_dir, nor home_dir are available"
                         .to_string()
                 })?;
             std::fs::create_dir_all(&dest_dir).map_err(|e| {
@@ -1104,6 +1112,13 @@ fn resolve_media_stream(
         }
         Err(e) => Err(format!("Failed to resolve stream URL: {e}")),
     }
+}
+
+fn configured_download_destination(download_dir: Option<&str>) -> Option<PathBuf> {
+    download_dir
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
 }
 
 // ── Media Metadata ───────────────────────────────────────────────────
@@ -1846,14 +1861,16 @@ fn read_available_space(_: &Path) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::{
-        configured_status_bar_path, extract_hostname_from_url, load_plugin_media_metadata,
-        parse_plugin_video_metadata, parse_soundcloud_metadata, parse_soundcloud_playlist_targets,
-        read_available_space, resolve_existing_disk_path, sanitize_extension, sanitize_filename,
+        StreamResolution, configured_download_destination, configured_status_bar_path,
+        extract_hostname_from_url, load_plugin_media_metadata, parse_plugin_video_metadata,
+        parse_soundcloud_metadata, parse_soundcloud_playlist_targets, read_available_space,
+        resolve_existing_disk_path, resolve_media_stream, sanitize_extension, sanitize_filename,
         soundcloud_track_download_title, unique_destination,
     };
     use crate::domain::error::DomainError;
     use crate::domain::model::plugin::{PluginCategory, PluginInfo, PluginManifest};
     use crate::domain::ports::driven::PluginLoader;
+    use crate::domain::ports::driven::plugin_loader::DownloadedFileInfo;
     use std::path::PathBuf;
 
     #[derive(Clone)]
@@ -1890,6 +1907,62 @@ mod tests {
 
         fn get_media_variants(&self, _url: &str) -> Result<String, DomainError> {
             self.variants.clone()
+        }
+    }
+
+    #[derive(Clone)]
+    struct AdaptiveDownloadPluginLoader;
+
+    impl PluginLoader for AdaptiveDownloadPluginLoader {
+        fn load(&self, _manifest: &PluginManifest) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn unload(&self, _name: &str) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn resolve_url(&self, _url: &str) -> Result<Option<PluginInfo>, DomainError> {
+            Ok(None)
+        }
+
+        fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
+            Ok(Vec::new())
+        }
+
+        fn set_enabled(&self, _name: &str, _enabled: bool) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn resolve_stream_url(
+            &self,
+            _url: &str,
+            _quality: &str,
+            _format: &str,
+            _audio_only: bool,
+        ) -> Result<String, DomainError> {
+            Err(DomainError::AdaptiveStreamOnly)
+        }
+
+        fn download_to_file(
+            &self,
+            _url: &str,
+            _quality: &str,
+            _format: &str,
+            output_dir: &str,
+            _audio_only: bool,
+        ) -> Result<DownloadedFileInfo, DomainError> {
+            let output_dir = PathBuf::from(output_dir);
+            std::fs::create_dir_all(&output_dir)
+                .map_err(|e| DomainError::StorageError(e.to_string()))?;
+            let unique = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos();
+            let path = output_dir.join(format!("adaptive-{unique}.mp4"));
+            std::fs::write(&path, b"merged")
+                .map_err(|e| DomainError::StorageError(e.to_string()))?;
+            Ok(DownloadedFileInfo { path, size: 6 })
         }
     }
 
@@ -2096,6 +2169,14 @@ mod tests {
     }
 
     #[test]
+    fn configured_download_destination_keeps_relative_values() {
+        assert_eq!(
+            configured_download_destination(Some("downloads")),
+            Some(PathBuf::from("downloads"))
+        );
+    }
+
+    #[test]
     fn resolve_existing_disk_path_returns_existing_path_unchanged() {
         let temp_dir = tempfile::tempdir().expect("temp dir");
 
@@ -2233,6 +2314,39 @@ mod tests {
         assert_eq!(metadata.available_qualities.len(), 1);
         assert_eq!(metadata.available_qualities[0].quality, "720p");
         assert_eq!(metadata.available_formats, vec!["mp4"]);
+    }
+
+    #[test]
+    fn test_resolve_media_stream_uses_configured_destination_for_adaptive_downloads() {
+        let configured_root = tempfile::tempdir().expect("temp dir");
+        let configured_dir = configured_root.path().join("custom-downloads");
+
+        let resolution = resolve_media_stream(
+            &AdaptiveDownloadPluginLoader,
+            "https://example.com/video",
+            "720p",
+            "mp4",
+            false,
+            Some("Adaptive Title".to_string()),
+            Some(configured_dir.clone()),
+        )
+        .expect("adaptive stream should resolve to a local file");
+
+        match resolution {
+            StreamResolution::LocalFile {
+                path,
+                size,
+                filename,
+            } => {
+                assert!(path.starts_with(&configured_dir));
+                assert_eq!(filename, "Adaptive Title.mp4");
+                assert_eq!(size, 6);
+                assert!(path.exists());
+            }
+            StreamResolution::CdnUrl(url) => {
+                panic!("expected local file resolution, got CDN URL: {url}")
+            }
+        }
     }
 
     #[test]

--- a/src-tauri/src/adapters/driving/tauri_ipc.rs
+++ b/src-tauri/src/adapters/driving/tauri_ipc.rs
@@ -727,6 +727,21 @@ pub struct MediaDownloadResultDto {
     pub download_ids: Vec<u64>,
 }
 
+async fn rollback_media_download_batch(command_bus: Arc<CommandBus>, download_ids: &[u64]) {
+    for id in download_ids.iter().rev().copied() {
+        if let Err(error) = command_bus
+            .handle_cancel_download(CancelDownloadCommand { id: DownloadId(id) })
+            .await
+        {
+            tracing::warn!(
+                download_id = id,
+                error = %error,
+                "failed to roll back partially-started media download batch"
+            );
+        }
+    }
+}
+
 #[tauri::command]
 pub async fn download_media_start(
     state: State<'_, AppState>,
@@ -759,8 +774,9 @@ pub async fn download_media_start(
     if let Some(targets) = batch_targets {
         let mut download_ids = Vec::with_capacity(targets.len());
         for target in targets {
-            let title = Some(soundcloud_track_download_title(&target));
-            let id = start_media_download_for_url(
+            let download_title = soundcloud_track_download_title(&target);
+            let title = Some(download_title.clone());
+            match start_media_download_for_url(
                 state.command_bus.clone(),
                 state.plugin_loader.clone(),
                 target.url,
@@ -769,8 +785,16 @@ pub async fn download_media_start(
                 true,
                 title,
             )
-            .await?;
-            download_ids.push(id);
+            .await
+            {
+                Ok(id) => download_ids.push(id),
+                Err(error) => {
+                    rollback_media_download_batch(state.command_bus.clone(), &download_ids).await;
+                    return Err(format!(
+                        "failed to start batch download for {download_title}: {error}"
+                    ));
+                }
+            }
         }
         return Ok(MediaDownloadResultDto { download_ids });
     }
@@ -1132,14 +1156,21 @@ pub async fn command_get_media_metadata(
 ) -> Result<MediaMetadataDto, String> {
     let plugin_loader = state.plugin_loader.clone();
     let url_clone = url.clone();
-    if let Some(metadata) = tokio::task::spawn_blocking(move || {
+    let plugin_metadata = tokio::task::spawn_blocking(move || {
         load_plugin_media_metadata(plugin_loader.as_ref(), &url_clone)
     })
     .await
-    .map_err(|e| format!("Task join error: {e}"))?
-    .map_err(|e| e.to_string())?
-    {
-        return Ok(metadata);
+    .map_err(|e| format!("Task join error: {e}"))?;
+    match plugin_metadata {
+        Ok(Some(metadata)) => return Ok(metadata),
+        Ok(None) => {}
+        Err(error) => {
+            tracing::warn!(
+                url = %url,
+                error = %error,
+                "plugin metadata extraction failed; falling back to yt-dlp"
+            );
+        }
     }
 
     let output = tokio::task::spawn_blocking(move || -> Result<std::process::Output, String> {
@@ -1166,6 +1197,11 @@ pub async fn command_get_media_metadata(
         .map_err(|e| format!("Failed to parse yt-dlp output: {e}"))?;
 
     parse_ytdlp_json(&json)
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PluginExtractLinksKind {
+    kind: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -1233,24 +1269,34 @@ fn load_plugin_media_metadata(
     plugin_loader: &dyn PluginLoader,
     url: &str,
 ) -> Result<Option<MediaMetadataDto>, crate::domain::DomainError> {
-    let Some(info) = plugin_loader.resolve_url(url)? else {
+    let Some(_) = plugin_loader.resolve_url(url)? else {
         return Ok(None);
     };
+    let extract_links = match plugin_loader.extract_links(url) {
+        Ok(payload) => payload,
+        Err(crate::domain::DomainError::NotFound(_)) => return Ok(None),
+        Err(error) => return Err(error),
+    };
+    let kind: PluginExtractLinksKind = serde_json::from_str(&extract_links).map_err(|e| {
+        crate::domain::DomainError::PluginError(format!(
+            "Failed to parse plugin extract_links output: {e}"
+        ))
+    })?;
 
-    match info.name() {
-        "vortex-mod-vimeo" => {
-            let extract_links = plugin_loader.extract_links(url)?;
-            let variants = plugin_loader.get_media_variants(url)?;
+    match kind.kind.as_str() {
+        "video" => {
+            let variants = match plugin_loader.get_media_variants(url) {
+                Ok(payload) => payload,
+                Err(crate::domain::DomainError::NotFound(_)) => return Ok(None),
+                Err(error) => return Err(error),
+            };
             parse_plugin_video_metadata(&extract_links, &variants)
                 .map(Some)
                 .map_err(crate::domain::DomainError::PluginError)
         }
-        "vortex-mod-soundcloud" => {
-            let extract_links = plugin_loader.extract_links(url)?;
-            parse_soundcloud_metadata(&extract_links)
-                .map(Some)
-                .map_err(crate::domain::DomainError::PluginError)
-        }
+        "track" | "playlist" | "artist" => parse_soundcloud_metadata(&extract_links)
+            .map(Some)
+            .map_err(crate::domain::DomainError::PluginError),
         _ => Ok(None),
     }
 }
@@ -1286,7 +1332,14 @@ fn parse_plugin_video_metadata(
 
     for variant in variants.variants {
         match variant.kind {
-            PluginVariantKind::Video => {
+            kind @ (PluginVariantKind::Video | PluginVariantKind::Adaptive) => {
+                if matches!(kind, PluginVariantKind::Adaptive) {
+                    tracing::warn!(
+                        ext = %variant.ext,
+                        height = ?variant.height,
+                        "surfacing Adaptive plugin variant via merged-download fallback",
+                    );
+                }
                 if let Some(height) = variant.height.filter(|height| *height > 0) {
                     if seen_heights.insert(height) {
                         available_qualities.push(QualityOptionDto {
@@ -1307,13 +1360,6 @@ fn parse_plugin_video_metadata(
                 if !variant.ext.is_empty() && seen_audio_exts.insert(variant.ext.clone()) {
                     available_audio_formats.push(variant.ext);
                 }
-            }
-            PluginVariantKind::Adaptive => {
-                tracing::warn!(
-                    ext = %variant.ext,
-                    height = ?variant.height,
-                    "dropping Adaptive plugin variant — adaptive streams not yet supported",
-                );
             }
         }
     }
@@ -1800,12 +1846,62 @@ fn read_available_space(_: &Path) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::{
-        configured_status_bar_path, extract_hostname_from_url, parse_plugin_video_metadata,
-        parse_soundcloud_metadata, parse_soundcloud_playlist_targets, read_available_space,
-        resolve_existing_disk_path, sanitize_extension, sanitize_filename,
+        configured_status_bar_path, extract_hostname_from_url, load_plugin_media_metadata,
+        parse_plugin_video_metadata, parse_soundcloud_metadata, parse_soundcloud_playlist_targets,
+        read_available_space, resolve_existing_disk_path, sanitize_extension, sanitize_filename,
         soundcloud_track_download_title, unique_destination,
     };
+    use crate::domain::error::DomainError;
+    use crate::domain::model::plugin::{PluginCategory, PluginInfo, PluginManifest};
+    use crate::domain::ports::driven::PluginLoader;
     use std::path::PathBuf;
+
+    #[derive(Clone)]
+    struct MetadataPluginLoader {
+        resolved: Option<PluginInfo>,
+        extract_links: Result<String, DomainError>,
+        variants: Result<String, DomainError>,
+    }
+
+    impl PluginLoader for MetadataPluginLoader {
+        fn load(&self, _manifest: &PluginManifest) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn unload(&self, _name: &str) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn resolve_url(&self, _url: &str) -> Result<Option<PluginInfo>, DomainError> {
+            Ok(self.resolved.clone())
+        }
+
+        fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
+            Ok(Vec::new())
+        }
+
+        fn set_enabled(&self, _name: &str, _enabled: bool) -> Result<(), DomainError> {
+            Ok(())
+        }
+
+        fn extract_links(&self, _url: &str) -> Result<String, DomainError> {
+            self.extract_links.clone()
+        }
+
+        fn get_media_variants(&self, _url: &str) -> Result<String, DomainError> {
+            self.variants.clone()
+        }
+    }
+
+    fn make_plugin_info(name: &str) -> PluginInfo {
+        PluginInfo::new(
+            name.to_string(),
+            "1.0.0".to_string(),
+            "Test plugin".to_string(),
+            "tester".to_string(),
+            PluginCategory::Utility,
+        )
+    }
 
     // ── sanitize_filename ─────────────────────────────────────────────────────
 
@@ -2104,6 +2200,99 @@ mod tests {
             .unwrap_err();
 
         assert!(err.contains("unsupported extract_links kind"));
+    }
+
+    #[test]
+    fn test_parse_plugin_video_metadata_keeps_adaptive_variants_available() {
+        let extract_links = serde_json::json!({
+            "kind": "video",
+            "videos": [{
+                "title": "Adaptive Vimeo",
+                "duration": 91,
+                "thumbnail": "https://example.com/thumb.jpg"
+            }]
+        });
+        let variants = serde_json::json!({
+            "variants": [
+                {
+                    "kind": "adaptive",
+                    "ext": "mp4",
+                    "width": 1280,
+                    "height": 720,
+                    "fps": 30.0,
+                    "abr": 2400.0
+                }
+            ]
+        });
+
+        let metadata =
+            parse_plugin_video_metadata(&extract_links.to_string(), &variants.to_string())
+                .expect("adaptive metadata should parse");
+
+        assert_eq!(metadata.default_quality.as_deref(), Some("720p"));
+        assert_eq!(metadata.available_qualities.len(), 1);
+        assert_eq!(metadata.available_qualities[0].quality, "720p");
+        assert_eq!(metadata.available_formats, vec!["mp4"]);
+    }
+
+    #[test]
+    fn test_load_plugin_media_metadata_dispatches_by_extract_links_kind() {
+        let extract_links = serde_json::json!({
+            "kind": "video",
+            "videos": [{
+                "title": "Future Provider",
+                "duration": 45,
+                "thumbnail": "https://example.com/future.jpg"
+            }]
+        });
+        let variants = serde_json::json!({
+            "variants": [
+                {
+                    "kind": "video",
+                    "ext": "mp4",
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": 30.0,
+                    "abr": 3200.0
+                }
+            ]
+        });
+        let loader = MetadataPluginLoader {
+            resolved: Some(make_plugin_info("future-video-plugin")),
+            extract_links: Ok(extract_links.to_string()),
+            variants: Ok(variants.to_string()),
+        };
+
+        let metadata = load_plugin_media_metadata(&loader, "https://example.com/video")
+            .expect("metadata lookup should succeed")
+            .expect("video metadata should be returned");
+
+        assert_eq!(metadata.title, "Future Provider");
+        assert_eq!(metadata.default_quality.as_deref(), Some("1080p"));
+    }
+
+    #[test]
+    fn test_load_plugin_media_metadata_returns_none_when_variants_export_missing() {
+        let extract_links = serde_json::json!({
+            "kind": "video",
+            "videos": [{
+                "title": "Video Without Variants",
+                "duration": 45,
+                "thumbnail": "https://example.com/future.jpg"
+            }]
+        });
+        let loader = MetadataPluginLoader {
+            resolved: Some(make_plugin_info("video-without-variants")),
+            extract_links: Ok(extract_links.to_string()),
+            variants: Err(DomainError::NotFound(
+                "get_media_variants not supported by this loader".to_string(),
+            )),
+        };
+
+        let metadata = load_plugin_media_metadata(&loader, "https://example.com/video")
+            .expect("missing exports should fall back cleanly");
+
+        assert!(metadata.is_none());
     }
 
     #[test]

--- a/src-tauri/src/adapters/driving/tauri_ipc.rs
+++ b/src-tauri/src/adapters/driving/tauri_ipc.rs
@@ -1340,16 +1340,16 @@ fn parse_plugin_video_metadata(
                         "surfacing Adaptive plugin variant via merged-download fallback",
                     );
                 }
-                if let Some(height) = variant.height.filter(|height| *height > 0) {
-                    if seen_heights.insert(height) {
-                        available_qualities.push(QualityOptionDto {
-                            quality: format!("{height}p"),
-                            height,
-                            width: variant.width.unwrap_or(0),
-                            fps: variant.fps.unwrap_or(0.0).round() as u32,
-                            bitrate_kbps: variant.abr.unwrap_or(0.0).round() as u32,
-                        });
-                    }
+                if let Some(height) = variant.height.filter(|height| *height > 0)
+                    && seen_heights.insert(height)
+                {
+                    available_qualities.push(QualityOptionDto {
+                        quality: format!("{height}p"),
+                        height,
+                        width: variant.width.unwrap_or(0),
+                        fps: variant.fps.unwrap_or(0.0).round() as u32,
+                        bitrate_kbps: variant.abr.unwrap_or(0.0).round() as u32,
+                    });
                 }
 
                 if !variant.ext.is_empty() && seen_video_exts.insert(variant.ext.clone()) {
@@ -1364,7 +1364,7 @@ fn parse_plugin_video_metadata(
         }
     }
 
-    available_qualities.sort_by(|a, b| b.height.cmp(&a.height));
+    available_qualities.sort_by_key(|quality| std::cmp::Reverse(quality.height));
     // Pick default_quality from the sorted top so UI and default agree.
     let default_quality = available_qualities.first().map(|q| q.quality.clone());
 

--- a/src-tauri/src/adapters/driving/tauri_ipc.rs
+++ b/src-tauri/src/adapters/driving/tauri_ipc.rs
@@ -721,6 +721,12 @@ fn is_known_media_platform(url: &str) -> bool {
 /// Give You Up"). When provided it is sanitised and used as the filename
 /// (appended with `.{format}`), so the saved file has a meaningful name instead
 /// of the CDN path segment ("videoplayback").
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaDownloadResultDto {
+    pub download_ids: Vec<u64>,
+}
+
 #[tauri::command]
 pub async fn download_media_start(
     state: State<'_, AppState>,
@@ -729,203 +735,59 @@ pub async fn download_media_start(
     format: String,
     audio_only: bool,
     title: Option<String>,
-) -> Result<u64, String> {
+    playlist_items: Option<Vec<String>>,
+) -> Result<MediaDownloadResultDto, String> {
     // Validate the format extension before anything uses it in a filename —
     // `format!("{}.{}", sanitize_filename(title), format)` below would otherwise
     // interpolate attacker-controlled path separators after the last `/` char
     // that `sanitize_filename` already escaped in the stem.
     let format = sanitize_extension(&format)?;
-
-    // Extract the origin hostname (e.g. "www.youtube.com") from the original
-    // URL *before* resolving to a CDN URL, so we can store it as the
-    // source_hostname instead of "rr1---sn-n4g-cvq6.googlevideo.com".
-    let source_hostname_override = extract_hostname_from_url(&url);
-
-    let plugin_loader = state.plugin_loader.clone();
     let url_clone = url.clone();
-    let quality_clone = quality.clone();
-    let format_clone = format.clone();
-    let title_clone = title.clone();
-
-    // Plugin calls are synchronous (Extism runs inside a Mutex). Run on the
-    // blocking thread pool so we don't starve the async executor.
-    enum StreamResolution {
-        CdnUrl(String),
-        LocalFile {
-            path: std::path::PathBuf,
-            size: u64,
-            filename: String,
-        },
-    }
-
-    let resolution = tokio::task::spawn_blocking(move || -> Result<StreamResolution, String> {
-        match plugin_loader.resolve_stream_url(
+    let selected_playlist_items = playlist_items.unwrap_or_default();
+    let plugin_loader = state.plugin_loader.clone();
+    let batch_targets = tokio::task::spawn_blocking(move || {
+        load_soundcloud_playlist_download_targets(
+            plugin_loader.as_ref(),
             &url_clone,
-            &quality_clone,
-            &format_clone,
-            audio_only,
-        ) {
-            Ok(cdn_url) => Ok(StreamResolution::CdnUrl(cdn_url)),
-
-            Err(crate::domain::error::DomainError::AdaptiveStreamOnly) => {
-                // yt-dlp must handle the full download+merge.
-                let temp_dir = std::env::temp_dir().join("vortex-downloads");
-                std::fs::create_dir_all(&temp_dir)
-                    .map_err(|e| format!("failed to create temp dir: {e}"))?;
-
-                let file_info = plugin_loader
-                    .download_to_file(
-                        &url_clone,
-                        &quality_clone,
-                        &format_clone,
-                        temp_dir.to_str()
-                            .ok_or_else(|| "temp dir path is not valid UTF-8".to_string())?,
-                        audio_only,
-                    )
-                    .map_err(|e| format!("download_to_file failed: {e}"))?;
-
-                // Defense in depth: `ExtismPluginLoader::download_to_file` already
-                // enforces that the returned path is inside `output_dir`, but the
-                // `PluginLoader` trait does not require it — a future or alternate
-                // loader implementation could return an arbitrary path and we'd
-                // happily move it. Re-check containment here at the IPC boundary.
-                let temp_dir_canonical = temp_dir
-                    .canonicalize()
-                    .map_err(|e| format!("failed to canonicalize temp dir: {e}"))?;
-                let produced_canonical = file_info
-                    .path
-                    .canonicalize()
-                    .map_err(|e| format!("failed to canonicalize downloaded file path: {e}"))?;
-                if !produced_canonical.starts_with(&temp_dir_canonical) {
-                    return Err(format!(
-                        "plugin returned file outside temp dir: {}",
-                        file_info.path.display()
-                    ));
-                }
-
-                // Determine final filename: prefer title override, else keep yt-dlp's name.
-                let filename = title_clone
-                    .as_deref()
-                    .filter(|t| !t.trim().is_empty())
-                    .map(|t| format!("{}.{}", sanitize_filename(t), format_clone))
-                    .unwrap_or_else(|| {
-                        file_info
-                            .path
-                            .file_name()
-                            .and_then(|n| n.to_str())
-                            .unwrap_or("download")
-                            .to_string()
-                    });
-
-                // Determine final destination directory. Prefer the platform
-                // download dir (XDG `user-dirs`, `~/Downloads`, …); fall back to
-                // the home dir rather than CWD — dropping a 1GB merged video
-                // into the Tauri binary's directory or / is a bad outcome.
-                let dest_dir = dirs::download_dir()
-                    .or_else(dirs::home_dir)
-                    .ok_or_else(|| {
-                        "cannot determine download destination: neither \
-                         user-dirs download_dir nor home_dir are available"
-                            .to_string()
-                    })?;
-                // The user-dirs `Downloads` folder can be configured to a path
-                // that hasn't been created yet (e.g. a fresh user account, or a
-                // CI environment). Ensure it exists before probing filenames.
-                std::fs::create_dir_all(&dest_dir)
-                    .map_err(|e| format!("failed to create destination dir {}: {e}",
-                        dest_dir.display()))?;
-                // If the destination already exists, suffix the filename (" (1)",
-                // " (2)", …) — preserves the previous download instead of silently
-                // overwriting it, matching the browser-download convention.
-                let (dest_path, dest_filename) = unique_destination(&dest_dir, &filename)
-                    .map_err(|e| format!("failed to select unique destination: {e}"))?;
-
-                // Atomic move (same filesystem) → fallback copy+delete.
-                if std::fs::rename(&file_info.path, &dest_path).is_err() {
-                    std::fs::copy(&file_info.path, &dest_path)
-                        .map_err(|e| format!("failed to copy merged file: {e}"))?;
-                    if let Err(e) = std::fs::remove_file(&file_info.path) {
-                        tracing::warn!(
-                            path = %file_info.path.display(),
-                            error = %e,
-                            "failed to remove temp file after copy"
-                        );
-                    }
-                }
-
-                Ok(StreamResolution::LocalFile {
-                    path: dest_path,
-                    size: file_info.size,
-                    filename: dest_filename,
-                })
-            }
-
-            // builtin-http: no WASM plugin claimed the URL.
-            // For known media platforms this means the required plugin is not
-            // installed — return a clear error rather than feeding the HTML
-            // page URL to the download engine and entering a retry loop.
-            Err(crate::domain::error::DomainError::NotFound(_)) => {
-                if is_known_media_platform(&url_clone) {
-                    Err(
-                        "No media plugin installed for this URL. \
-                         Open the Plugin Store and install the appropriate plugin (e.g. vortex-mod-youtube)."
-                            .to_string(),
-                    )
-                } else {
-                    // Generic direct-download URL — pass through as-is.
-                    Ok(StreamResolution::CdnUrl(url_clone))
-                }
-            }
-
-            Err(e) => Err(format!("Failed to resolve stream URL: {e}")),
-        }
+            &selected_playlist_items,
+        )
     })
     .await
-    .map_err(|e| format!("Task join error: {e}"))??;
+    .map_err(|e| format!("Task join error: {e}"))?
+    .map_err(|e| e.to_string())?;
 
-    match resolution {
-        StreamResolution::CdnUrl(stream_url) => {
-            // Build a meaningful filename from the title and format when available.
-            // Falls back to the URL-based derivation in handle_start_download when None.
-            let filename = title
-                .as_deref()
-                .filter(|t| !t.trim().is_empty())
-                .map(|t| format!("{}.{}", sanitize_filename(t), format));
-
-            let cmd = crate::application::commands::StartDownloadCommand {
-                url: stream_url,
-                destination: None,
-                filename,
-                source_hostname_override,
-            };
-            state
-                .command_bus
-                .handle_start_download(cmd)
-                .await
-                .map(|id| id.0)
-                .map_err(|e| e.to_string())
+    if let Some(targets) = batch_targets {
+        let mut download_ids = Vec::with_capacity(targets.len());
+        for target in targets {
+            let id = start_media_download_for_url(
+                state.command_bus.clone(),
+                state.plugin_loader.clone(),
+                target.url,
+                quality.clone(),
+                format.clone(),
+                true,
+                Some(soundcloud_track_download_title(&target)),
+            )
+            .await?;
+            download_ids.push(id);
         }
-
-        StreamResolution::LocalFile {
-            path,
-            size,
-            filename,
-        } => {
-            let cmd = crate::application::commands::RegisterLocalFileCommand {
-                source_url: url,
-                destination_path: path,
-                filename,
-                source_hostname: source_hostname_override,
-                file_size: size,
-            };
-            state
-                .command_bus
-                .handle_register_local_file(cmd)
-                .await
-                .map(|id| id.0)
-                .map_err(|e| e.to_string())
-        }
+        return Ok(MediaDownloadResultDto { download_ids });
     }
+
+    let download_id = start_media_download_for_url(
+        state.command_bus.clone(),
+        state.plugin_loader.clone(),
+        url,
+        quality,
+        format,
+        audio_only,
+        title,
+    )
+    .await?;
+
+    Ok(MediaDownloadResultDto {
+        download_ids: vec![download_id],
+    })
 }
 
 /// Remove characters that are invalid in filenames on Linux / macOS / Windows.
@@ -1038,15 +900,198 @@ fn extract_hostname_from_url(url: &str) -> Option<String> {
     }
 }
 
+#[derive(Debug)]
+enum StreamResolution {
+    CdnUrl(String),
+    LocalFile {
+        path: std::path::PathBuf,
+        size: u64,
+        filename: String,
+    },
+}
+
+async fn start_media_download_for_url(
+    command_bus: Arc<CommandBus>,
+    plugin_loader: Arc<dyn PluginLoader>,
+    url: String,
+    quality: String,
+    format: String,
+    audio_only: bool,
+    title: Option<String>,
+) -> Result<u64, String> {
+    let source_hostname_override = extract_hostname_from_url(&url);
+    let url_clone = url.clone();
+    let quality_clone = quality.clone();
+    let format_clone = format.clone();
+    let title_clone = title.clone();
+
+    let resolution = tokio::task::spawn_blocking(move || {
+        resolve_media_stream(
+            plugin_loader.as_ref(),
+            &url_clone,
+            &quality_clone,
+            &format_clone,
+            audio_only,
+            title_clone,
+        )
+    })
+    .await
+    .map_err(|e| format!("Task join error: {e}"))??;
+
+    match resolution {
+        StreamResolution::CdnUrl(stream_url) => {
+            let filename = title
+                .as_deref()
+                .filter(|t| !t.trim().is_empty())
+                .map(|t| format!("{}.{}", sanitize_filename(t), format));
+
+            let cmd = crate::application::commands::StartDownloadCommand {
+                url: stream_url,
+                destination: None,
+                filename,
+                source_hostname_override,
+            };
+            command_bus
+                .handle_start_download(cmd)
+                .await
+                .map(|id| id.0)
+                .map_err(|e| e.to_string())
+        }
+        StreamResolution::LocalFile {
+            path,
+            size,
+            filename,
+        } => {
+            let cmd = crate::application::commands::RegisterLocalFileCommand {
+                source_url: url,
+                destination_path: path,
+                filename,
+                source_hostname: source_hostname_override,
+                file_size: size,
+            };
+            command_bus
+                .handle_register_local_file(cmd)
+                .await
+                .map(|id| id.0)
+                .map_err(|e| e.to_string())
+        }
+    }
+}
+
+fn resolve_media_stream(
+    plugin_loader: &dyn PluginLoader,
+    url: &str,
+    quality: &str,
+    format: &str,
+    audio_only: bool,
+    title: Option<String>,
+) -> Result<StreamResolution, String> {
+    match plugin_loader.resolve_stream_url(url, quality, format, audio_only) {
+        Ok(cdn_url) => Ok(StreamResolution::CdnUrl(cdn_url)),
+        Err(crate::domain::error::DomainError::AdaptiveStreamOnly) => {
+            let temp_dir = std::env::temp_dir().join("vortex-downloads");
+            std::fs::create_dir_all(&temp_dir)
+                .map_err(|e| format!("failed to create temp dir: {e}"))?;
+
+            let file_info = plugin_loader
+                .download_to_file(
+                    url,
+                    quality,
+                    format,
+                    temp_dir
+                        .to_str()
+                        .ok_or_else(|| "temp dir path is not valid UTF-8".to_string())?,
+                    audio_only,
+                )
+                .map_err(|e| format!("download_to_file failed: {e}"))?;
+
+            let temp_dir_canonical = temp_dir
+                .canonicalize()
+                .map_err(|e| format!("failed to canonicalize temp dir: {e}"))?;
+            let produced_canonical = file_info
+                .path
+                .canonicalize()
+                .map_err(|e| format!("failed to canonicalize downloaded file path: {e}"))?;
+            if !produced_canonical.starts_with(&temp_dir_canonical) {
+                return Err(format!(
+                    "plugin returned file outside temp dir: {}",
+                    file_info.path.display()
+                ));
+            }
+
+            let filename = title
+                .as_deref()
+                .filter(|t| !t.trim().is_empty())
+                .map(|t| format!("{}.{}", sanitize_filename(t), format))
+                .unwrap_or_else(|| {
+                    file_info
+                        .path
+                        .file_name()
+                        .and_then(|n| n.to_str())
+                        .unwrap_or("download")
+                        .to_string()
+                });
+
+            let dest_dir = dirs::download_dir()
+                .or_else(dirs::home_dir)
+                .ok_or_else(|| {
+                    "cannot determine download destination: neither \
+                     user-dirs download_dir nor home_dir are available"
+                        .to_string()
+                })?;
+            std::fs::create_dir_all(&dest_dir).map_err(|e| {
+                format!(
+                    "failed to create destination dir {}: {e}",
+                    dest_dir.display()
+                )
+            })?;
+            let (dest_path, dest_filename) = unique_destination(&dest_dir, &filename)
+                .map_err(|e| format!("failed to select unique destination: {e}"))?;
+
+            if std::fs::rename(&file_info.path, &dest_path).is_err() {
+                std::fs::copy(&file_info.path, &dest_path)
+                    .map_err(|e| format!("failed to copy merged file: {e}"))?;
+                if let Err(e) = std::fs::remove_file(&file_info.path) {
+                    tracing::warn!(
+                        path = %file_info.path.display(),
+                        error = %e,
+                        "failed to remove temp file after copy"
+                    );
+                }
+            }
+
+            Ok(StreamResolution::LocalFile {
+                path: dest_path,
+                size: file_info.size,
+                filename: dest_filename,
+            })
+        }
+        Err(crate::domain::error::DomainError::NotFound(_)) => {
+            if is_known_media_platform(url) {
+                Err(
+                    "No media plugin installed for this URL. \
+                     Open the Plugin Store and install the appropriate plugin (e.g. vortex-mod-youtube)."
+                        .to_string(),
+                )
+            } else {
+                Ok(StreamResolution::CdnUrl(url.to_string()))
+            }
+        }
+        Err(e) => Err(format!("Failed to resolve stream URL: {e}")),
+    }
+}
+
 // ── Media Metadata ───────────────────────────────────────────────────
 
 #[derive(Debug, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MediaMetadataDto {
     pub title: String,
+    pub artist: Option<String>,
     pub thumbnail_url: String,
     pub duration_seconds: u64,
     pub is_playlist: bool,
+    pub default_quality: Option<String>,
     pub available_qualities: Vec<QualityOptionDto>,
     pub available_formats: Vec<String>,
     pub available_audio_formats: Vec<String>,
@@ -1080,7 +1125,22 @@ pub struct PlaylistItemDto {
 }
 
 #[tauri::command]
-pub async fn command_get_media_metadata(url: String) -> Result<MediaMetadataDto, String> {
+pub async fn command_get_media_metadata(
+    state: State<'_, AppState>,
+    url: String,
+) -> Result<MediaMetadataDto, String> {
+    let plugin_loader = state.plugin_loader.clone();
+    let url_clone = url.clone();
+    if let Some(metadata) = tokio::task::spawn_blocking(move || {
+        load_plugin_media_metadata(plugin_loader.as_ref(), &url_clone)
+    })
+    .await
+    .map_err(|e| format!("Task join error: {e}"))?
+    .map_err(|e| e.to_string())?
+    {
+        return Ok(metadata);
+    }
+
     let output = tokio::task::spawn_blocking(move || -> Result<std::process::Output, String> {
         let binary = find_ytdlp()?;
         std::process::Command::new(&binary)
@@ -1105,6 +1165,316 @@ pub async fn command_get_media_metadata(url: String) -> Result<MediaMetadataDto,
         .map_err(|e| format!("Failed to parse yt-dlp output: {e}"))?;
 
     parse_ytdlp_json(&json)
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PluginVideoExtractLinksResponse {
+    kind: String,
+    #[serde(default)]
+    videos: Vec<PluginVideoMediaLink>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PluginVideoMediaLink {
+    title: String,
+    duration: Option<u64>,
+    thumbnail: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PluginMediaVariantsResponse {
+    #[serde(default)]
+    variants: Vec<PluginMediaVariant>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct PluginMediaVariant {
+    kind: PluginVariantKind,
+    ext: String,
+    width: Option<u32>,
+    height: Option<u32>,
+    fps: Option<f64>,
+    abr: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum PluginVariantKind {
+    Video,
+    Audio,
+    Adaptive,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct SoundcloudExtractLinksResponse {
+    kind: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    artist: Option<String>,
+    #[serde(default)]
+    artwork_url: Option<String>,
+    #[serde(default)]
+    tracks: Vec<SoundcloudTrackLink>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+struct SoundcloudTrackLink {
+    id: String,
+    title: String,
+    url: String,
+    artist: Option<String>,
+    duration_ms: Option<u64>,
+    artwork_url: Option<String>,
+}
+
+fn load_plugin_media_metadata(
+    plugin_loader: &dyn PluginLoader,
+    url: &str,
+) -> Result<Option<MediaMetadataDto>, crate::domain::DomainError> {
+    let Some(info) = plugin_loader.resolve_url(url)? else {
+        return Ok(None);
+    };
+
+    match info.name() {
+        "vortex-mod-vimeo" => {
+            let extract_links = plugin_loader.extract_links(url)?;
+            let variants = plugin_loader.get_media_variants(url)?;
+            parse_plugin_video_metadata(&extract_links, &variants)
+                .map(Some)
+                .map_err(crate::domain::DomainError::PluginError)
+        }
+        "vortex-mod-soundcloud" => {
+            let extract_links = plugin_loader.extract_links(url)?;
+            parse_soundcloud_metadata(&extract_links)
+                .map(Some)
+                .map_err(crate::domain::DomainError::PluginError)
+        }
+        _ => Ok(None),
+    }
+}
+
+fn parse_plugin_video_metadata(
+    extract_links_json: &str,
+    variants_json: &str,
+) -> Result<MediaMetadataDto, String> {
+    let extract_links: PluginVideoExtractLinksResponse =
+        serde_json::from_str(extract_links_json)
+            .map_err(|e| format!("Failed to parse plugin extract_links output: {e}"))?;
+    if extract_links.kind != "video" {
+        return Err(format!(
+            "plugin returned unsupported extract_links kind: {}",
+            extract_links.kind
+        ));
+    }
+    let video = extract_links
+        .videos
+        .into_iter()
+        .next()
+        .ok_or_else(|| "plugin returned no video entries".to_string())?;
+
+    let variants: PluginMediaVariantsResponse = serde_json::from_str(variants_json)
+        .map_err(|e| format!("Failed to parse plugin get_media_variants output: {e}"))?;
+
+    let mut available_qualities = Vec::new();
+    let mut available_formats = Vec::new();
+    let mut available_audio_formats = Vec::new();
+    let mut seen_heights = std::collections::HashSet::<u32>::new();
+    let mut seen_video_exts = std::collections::HashSet::<String>::new();
+    let mut seen_audio_exts = std::collections::HashSet::<String>::new();
+    let mut default_quality = None;
+
+    for variant in variants.variants {
+        match variant.kind {
+            PluginVariantKind::Video => {
+                if let Some(height) = variant.height.filter(|height| *height > 0) {
+                    if default_quality.is_none() {
+                        default_quality = Some(format!("{height}p"));
+                    }
+                    if seen_heights.insert(height) {
+                        available_qualities.push(QualityOptionDto {
+                            quality: format!("{height}p"),
+                            height,
+                            width: variant.width.unwrap_or(0),
+                            fps: variant.fps.unwrap_or(0.0).round() as u32,
+                            bitrate_kbps: variant.abr.unwrap_or(0.0).round() as u32,
+                        });
+                    }
+                }
+
+                if !variant.ext.is_empty() && seen_video_exts.insert(variant.ext.clone()) {
+                    available_formats.push(variant.ext);
+                }
+            }
+            PluginVariantKind::Audio => {
+                if !variant.ext.is_empty() && seen_audio_exts.insert(variant.ext.clone()) {
+                    available_audio_formats.push(variant.ext);
+                }
+            }
+            PluginVariantKind::Adaptive => {}
+        }
+    }
+
+    available_qualities.sort_by(|a, b| b.height.cmp(&a.height));
+
+    Ok(MediaMetadataDto {
+        title: video.title,
+        artist: None,
+        thumbnail_url: video.thumbnail.unwrap_or_default(),
+        duration_seconds: video.duration.unwrap_or_default(),
+        is_playlist: false,
+        default_quality,
+        available_qualities,
+        available_formats,
+        available_audio_formats,
+        available_subtitles: Vec::new(),
+        playlist_items: None,
+    })
+}
+
+fn parse_soundcloud_metadata(extract_links_json: &str) -> Result<MediaMetadataDto, String> {
+    let extract_links: SoundcloudExtractLinksResponse = serde_json::from_str(extract_links_json)
+        .map_err(|e| format!("Failed to parse SoundCloud extract_links output: {e}"))?;
+
+    match extract_links.kind.as_str() {
+        "track" => {
+            let track = extract_links
+                .tracks
+                .into_iter()
+                .next()
+                .ok_or_else(|| "plugin returned no SoundCloud track entries".to_string())?;
+
+            Ok(MediaMetadataDto {
+                title: extract_links.title.unwrap_or(track.title),
+                artist: track.artist.or(extract_links.artist),
+                thumbnail_url: extract_links
+                    .artwork_url
+                    .or(track.artwork_url)
+                    .unwrap_or_default(),
+                duration_seconds: millis_to_seconds(track.duration_ms),
+                is_playlist: false,
+                default_quality: None,
+                available_qualities: Vec::new(),
+                available_formats: Vec::new(),
+                available_audio_formats: vec!["mp3".to_string()],
+                available_subtitles: Vec::new(),
+                playlist_items: None,
+            })
+        }
+        "playlist" | "artist" => {
+            if extract_links.tracks.is_empty() {
+                return Err("plugin returned no SoundCloud collection entries".to_string());
+            }
+
+            let total_duration_ms: u64 = extract_links
+                .tracks
+                .iter()
+                .filter_map(|track| track.duration_ms)
+                .sum();
+            let playlist_items = extract_links
+                .tracks
+                .iter()
+                .map(|track| PlaylistItemDto {
+                    id: track.id.clone(),
+                    title: soundcloud_track_download_title(track),
+                    duration_seconds: millis_to_seconds(track.duration_ms),
+                })
+                .collect::<Vec<_>>();
+
+            let collection_title =
+                extract_links
+                    .title
+                    .unwrap_or_else(|| match extract_links.kind.as_str() {
+                        "artist" => format!("SoundCloud artist ({})", extract_links.tracks.len()),
+                        _ => format!("SoundCloud playlist ({})", extract_links.tracks.len()),
+                    });
+
+            Ok(MediaMetadataDto {
+                title: collection_title,
+                artist: None,
+                thumbnail_url: extract_links.artwork_url.unwrap_or_else(|| {
+                    extract_links
+                        .tracks
+                        .iter()
+                        .find_map(|track| track.artwork_url.clone())
+                        .unwrap_or_default()
+                }),
+                duration_seconds: total_duration_ms / 1000,
+                is_playlist: true,
+                default_quality: None,
+                available_qualities: Vec::new(),
+                available_formats: Vec::new(),
+                available_audio_formats: vec!["mp3".to_string()],
+                available_subtitles: Vec::new(),
+                playlist_items: Some(playlist_items),
+            })
+        }
+        other => Err(format!(
+            "unsupported SoundCloud extract_links kind: {other}"
+        )),
+    }
+}
+
+fn load_soundcloud_playlist_download_targets(
+    plugin_loader: &dyn PluginLoader,
+    url: &str,
+    selected_item_ids: &[String],
+) -> Result<Option<Vec<SoundcloudTrackLink>>, crate::domain::DomainError> {
+    let Some(info) = plugin_loader.resolve_url(url)? else {
+        return Ok(None);
+    };
+    if info.name() != "vortex-mod-soundcloud" {
+        return Ok(None);
+    }
+
+    let extract_links = plugin_loader.extract_links(url)?;
+    let tracks = parse_soundcloud_playlist_targets(&extract_links, selected_item_ids)
+        .map_err(crate::domain::DomainError::PluginError)?;
+    if tracks.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(tracks))
+    }
+}
+
+fn parse_soundcloud_playlist_targets(
+    extract_links_json: &str,
+    selected_item_ids: &[String],
+) -> Result<Vec<SoundcloudTrackLink>, String> {
+    let extract_links: SoundcloudExtractLinksResponse = serde_json::from_str(extract_links_json)
+        .map_err(|e| format!("Failed to parse SoundCloud extract_links output: {e}"))?;
+
+    if extract_links.kind != "playlist" && extract_links.kind != "artist" {
+        return Ok(Vec::new());
+    }
+
+    let selected_ids: std::collections::HashSet<_> = selected_item_ids.iter().cloned().collect();
+    let tracks = extract_links
+        .tracks
+        .into_iter()
+        .filter(|track| selected_ids.is_empty() || selected_ids.contains(&track.id))
+        .collect::<Vec<_>>();
+
+    if tracks.is_empty() {
+        return Err("no SoundCloud tracks matched the selected playlist items".to_string());
+    }
+
+    Ok(tracks)
+}
+
+fn soundcloud_track_download_title(track: &SoundcloudTrackLink) -> String {
+    match track
+        .artist
+        .as_deref()
+        .filter(|artist| !artist.trim().is_empty())
+    {
+        Some(artist) => format!("{artist} - {}", track.title),
+        None => track.title.clone(),
+    }
+}
+
+fn millis_to_seconds(duration_ms: Option<u64>) -> u64 {
+    duration_ms.unwrap_or_default() / 1000
 }
 
 fn find_ytdlp() -> Result<std::path::PathBuf, String> {
@@ -1280,9 +1650,11 @@ fn parse_ytdlp_json(json: &serde_json::Value) -> Result<MediaMetadataDto, String
 
     Ok(MediaMetadataDto {
         title,
+        artist: None,
         thumbnail_url,
         duration_seconds,
         is_playlist,
+        default_quality: None,
         available_qualities,
         available_formats,
         available_audio_formats,
@@ -1423,8 +1795,10 @@ fn read_available_space(_: &Path) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::{
-        configured_status_bar_path, extract_hostname_from_url, read_available_space,
-        resolve_existing_disk_path, sanitize_extension, sanitize_filename, unique_destination,
+        configured_status_bar_path, extract_hostname_from_url, parse_plugin_video_metadata,
+        parse_soundcloud_metadata, parse_soundcloud_playlist_targets, read_available_space,
+        resolve_existing_disk_path, sanitize_extension, sanitize_filename,
+        soundcloud_track_download_title, unique_destination,
     };
     use std::path::PathBuf;
 
@@ -1657,6 +2031,224 @@ mod tests {
         let temp_dir = tempfile::tempdir().expect("temp dir");
 
         assert!(read_available_space(temp_dir.path()).is_some());
+    }
+
+    #[test]
+    fn test_parse_plugin_video_metadata_selects_first_variant_as_default() {
+        let extract_links = serde_json::json!({
+            "kind": "video",
+            "videos": [{
+                "title": "Vimeo Plugin Video",
+                "duration": 91,
+                "thumbnail": "https://example.com/thumb.jpg"
+            }]
+        });
+        let variants = serde_json::json!({
+            "variants": [
+                {
+                    "kind": "video",
+                    "ext": "mp4",
+                    "width": 1280,
+                    "height": 720,
+                    "fps": 30.0,
+                    "abr": 2400.0
+                },
+                {
+                    "kind": "video",
+                    "ext": "mp4",
+                    "width": 1920,
+                    "height": 1080,
+                    "fps": 30.0,
+                    "abr": 4200.0
+                },
+                {
+                    "kind": "video",
+                    "ext": "mp4",
+                    "width": 640,
+                    "height": 360,
+                    "fps": 30.0,
+                    "abr": 900.0
+                }
+            ]
+        });
+
+        let metadata =
+            parse_plugin_video_metadata(&extract_links.to_string(), &variants.to_string())
+                .expect("plugin metadata should parse");
+
+        assert_eq!(metadata.title, "Vimeo Plugin Video");
+        assert_eq!(metadata.default_quality.as_deref(), Some("720p"));
+        let heights: Vec<u32> = metadata
+            .available_qualities
+            .iter()
+            .map(|q| q.height)
+            .collect();
+        assert_eq!(heights, vec![1080, 720, 360]);
+        assert_eq!(metadata.available_formats, vec!["mp4"]);
+    }
+
+    #[test]
+    fn test_parse_plugin_video_metadata_rejects_non_video_kind() {
+        let extract_links = serde_json::json!({
+            "kind": "playlist",
+            "videos": []
+        });
+        let variants = serde_json::json!({ "variants": [] });
+
+        let err = parse_plugin_video_metadata(&extract_links.to_string(), &variants.to_string())
+            .unwrap_err();
+
+        assert!(err.contains("unsupported extract_links kind"));
+    }
+
+    #[test]
+    fn test_parse_soundcloud_metadata_for_track() {
+        let extract_links = serde_json::json!({
+            "kind": "track",
+            "title": "Flickermood",
+            "artist": "Forss",
+            "artwork_url": "https://i1.sndcdn.com/artworks-12345-t500x500.jpg",
+            "tracks": [{
+                "id": "123",
+                "title": "Flickermood",
+                "url": "https://soundcloud.com/forss/flickermood",
+                "artist": "Forss",
+                "duration_ms": 225000,
+                "artwork_url": "https://i1.sndcdn.com/artworks-12345-t500x500.jpg"
+            }]
+        });
+
+        let metadata = parse_soundcloud_metadata(&extract_links.to_string())
+            .expect("SoundCloud track metadata should parse");
+
+        assert_eq!(metadata.title, "Flickermood");
+        assert_eq!(metadata.artist.as_deref(), Some("Forss"));
+        assert_eq!(metadata.duration_seconds, 225);
+        assert_eq!(metadata.available_audio_formats, vec!["mp3"]);
+        assert!(!metadata.is_playlist);
+        assert!(metadata.playlist_items.is_none());
+    }
+
+    #[test]
+    fn test_parse_soundcloud_metadata_for_playlist() {
+        let extract_links = serde_json::json!({
+            "kind": "playlist",
+            "title": "Soulhack",
+            "tracks": [
+                {
+                    "id": "123",
+                    "title": "Flickermood",
+                    "url": "https://soundcloud.com/forss/flickermood",
+                    "artist": "Forss",
+                    "duration_ms": 225000,
+                    "artwork_url": "https://i1.sndcdn.com/artworks-12345-t500x500.jpg"
+                },
+                {
+                    "id": "124",
+                    "title": "Journeyman",
+                    "url": "https://soundcloud.com/forss/journeyman",
+                    "artist": "Forss",
+                    "duration_ms": 180000,
+                    "artwork_url": null
+                }
+            ]
+        });
+
+        let metadata = parse_soundcloud_metadata(&extract_links.to_string())
+            .expect("SoundCloud playlist metadata should parse");
+
+        assert!(metadata.is_playlist);
+        assert_eq!(metadata.title, "Soulhack");
+        assert_eq!(metadata.duration_seconds, 405);
+        assert_eq!(
+            metadata.playlist_items.as_ref().map(Vec::len),
+            Some(2),
+            "playlist items should be populated"
+        );
+        assert_eq!(metadata.available_audio_formats, vec!["mp3"]);
+        assert_eq!(
+            metadata.thumbnail_url,
+            "https://i1.sndcdn.com/artworks-12345-t500x500.jpg"
+        );
+    }
+
+    #[test]
+    fn test_parse_soundcloud_metadata_for_artist_collection() {
+        let extract_links = serde_json::json!({
+            "kind": "artist",
+            "title": "Forss",
+            "artwork_url": "https://i1.sndcdn.com/avatars-42.jpg",
+            "tracks": [
+                {
+                    "id": "123",
+                    "title": "Flickermood",
+                    "url": "https://soundcloud.com/forss/flickermood",
+                    "artist": "Forss",
+                    "duration_ms": 225000,
+                    "artwork_url": null
+                },
+                {
+                    "id": "124",
+                    "title": "Journeyman",
+                    "url": "https://soundcloud.com/forss/journeyman",
+                    "artist": "Forss",
+                    "duration_ms": 180000,
+                    "artwork_url": null
+                }
+            ]
+        });
+
+        let metadata = parse_soundcloud_metadata(&extract_links.to_string())
+            .expect("SoundCloud artist metadata should parse");
+
+        assert!(metadata.is_playlist);
+        assert_eq!(metadata.title, "Forss");
+        assert_eq!(metadata.duration_seconds, 405);
+        assert_eq!(
+            metadata.thumbnail_url,
+            "https://i1.sndcdn.com/avatars-42.jpg"
+        );
+        assert_eq!(
+            metadata.playlist_items.as_ref().map(Vec::len),
+            Some(2),
+            "artist tracks should be populated"
+        );
+    }
+
+    #[test]
+    fn test_parse_soundcloud_playlist_targets_filters_selection() {
+        let extract_links = serde_json::json!({
+            "kind": "playlist",
+            "tracks": [
+                {
+                    "id": "123",
+                    "title": "Flickermood",
+                    "url": "https://soundcloud.com/forss/flickermood",
+                    "artist": "Forss",
+                    "duration_ms": 225000,
+                    "artwork_url": null
+                },
+                {
+                    "id": "124",
+                    "title": "Journeyman",
+                    "url": "https://soundcloud.com/forss/journeyman",
+                    "artist": "Forss",
+                    "duration_ms": 180000,
+                    "artwork_url": null
+                }
+            ]
+        });
+
+        let tracks =
+            parse_soundcloud_playlist_targets(&extract_links.to_string(), &["124".to_string()])
+                .expect("playlist targets should parse");
+
+        assert_eq!(tracks.len(), 1);
+        assert_eq!(tracks[0].id, "124");
+        assert_eq!(
+            soundcloud_track_download_title(&tracks[0]),
+            "Forss - Journeyman"
+        );
     }
 
     // ── parse_ytdlp_json tests ────────────────────────────────────────

--- a/src-tauri/src/application/command_bus.rs
+++ b/src-tauri/src/application/command_bus.rs
@@ -341,6 +341,18 @@ mod tests {
             Ok(None)
         }
 
+        fn extract_links(&self, _url: &str) -> Result<String, DomainError> {
+            Err(DomainError::NotFound(
+                "extract_links not mocked".to_string(),
+            ))
+        }
+
+        fn get_media_variants(&self, _url: &str) -> Result<String, DomainError> {
+            Err(DomainError::NotFound(
+                "get_media_variants not mocked".to_string(),
+            ))
+        }
+
         fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
             Ok(self.plugins.lock().unwrap().values().cloned().collect())
         }

--- a/src-tauri/src/application/commands/resolve_links.rs
+++ b/src-tauri/src/application/commands/resolve_links.rs
@@ -278,6 +278,16 @@ mod tests {
     }
 
     #[test]
+    fn test_is_media_url_detects_soundcloud_artist_profile() {
+        assert!(is_media_url("https://soundcloud.com/forss"));
+    }
+
+    #[test]
+    fn test_is_media_url_detects_soundcloud_playlist() {
+        assert!(is_media_url("https://soundcloud.com/forss/sets/soulhack"));
+    }
+
+    #[test]
     fn test_is_media_url_returns_false_for_regular_url() {
         assert!(!is_media_url("https://example.com/file.zip"));
     }
@@ -294,6 +304,22 @@ mod tests {
     fn test_detect_media_type_returns_audio_for_soundcloud() {
         assert_eq!(
             detect_media_type("https://soundcloud.com/artist/track"),
+            Some("audio".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_media_type_returns_audio_for_soundcloud_artist_profile() {
+        assert_eq!(
+            detect_media_type("https://soundcloud.com/forss"),
+            Some("audio".to_string())
+        );
+    }
+
+    #[test]
+    fn test_detect_media_type_returns_audio_for_soundcloud_playlist() {
+        assert_eq!(
+            detect_media_type("https://soundcloud.com/forss/sets/soulhack"),
             Some("audio".to_string())
         );
     }

--- a/src-tauri/src/domain/model/plugin.rs
+++ b/src-tauri/src/domain/model/plugin.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::str::FromStr;
 
@@ -113,6 +114,7 @@ pub struct PluginManifest {
     info: PluginInfo,
     capabilities: Vec<String>,
     min_vortex_version: Option<String>,
+    config_defaults: HashMap<String, String>,
 }
 
 impl PluginManifest {
@@ -121,6 +123,7 @@ impl PluginManifest {
             info,
             capabilities: Vec::new(),
             min_vortex_version: None,
+            config_defaults: HashMap::new(),
         }
     }
 
@@ -131,6 +134,11 @@ impl PluginManifest {
 
     pub fn with_min_version(mut self, v: String) -> Self {
         self.min_vortex_version = Some(v);
+        self
+    }
+
+    pub fn with_config_defaults(mut self, defaults: HashMap<String, String>) -> Self {
+        self.config_defaults = defaults;
         self
     }
 
@@ -148,6 +156,10 @@ impl PluginManifest {
 
     pub fn min_vortex_version(&self) -> Option<&str> {
         self.min_vortex_version.as_deref()
+    }
+
+    pub fn config_defaults(&self) -> &HashMap<String, String> {
+        &self.config_defaults
     }
 }
 
@@ -206,6 +218,18 @@ mod tests {
         assert!(manifest.has_capability("http"));
         assert!(manifest.has_capability("extract"));
         assert!(!manifest.has_capability("ftp"));
+    }
+
+    #[test]
+    fn test_plugin_manifest_config_defaults() {
+        let info = make_info();
+        let defaults = HashMap::from([
+            ("default_quality".to_string(), "720p".to_string()),
+            ("extract_audio_only".to_string(), "false".to_string()),
+        ]);
+        let manifest = PluginManifest::new(info).with_config_defaults(defaults.clone());
+
+        assert_eq!(manifest.config_defaults(), &defaults);
     }
 
     #[test]

--- a/src-tauri/src/domain/ports/driven/plugin_loader.rs
+++ b/src-tauri/src/domain/ports/driven/plugin_loader.rs
@@ -48,6 +48,20 @@ pub trait PluginLoader: Send + Sync {
     /// Enable or disable a loaded plugin by name.
     fn set_enabled(&self, name: &str, enabled: bool) -> Result<(), DomainError>;
 
+    /// Extract media-link metadata from the plugin that claims the URL.
+    fn extract_links(&self, _url: &str) -> Result<String, DomainError> {
+        Err(DomainError::NotFound(
+            "extract_links not supported by this loader".into(),
+        ))
+    }
+
+    /// Fetch selectable media variants from the plugin that claims the URL.
+    fn get_media_variants(&self, _url: &str) -> Result<String, DomainError> {
+        Err(DomainError::NotFound(
+            "get_media_variants not supported by this loader".into(),
+        ))
+    }
+
     /// Resolve a media URL to a direct CDN stream URL via the plugin that
     /// claims the URL.
     ///
@@ -124,6 +138,20 @@ mod tests {
     fn test_download_to_file_default_returns_not_found() {
         let loader = MinimalLoader;
         let result = loader.download_to_file("https://youtu.be/x", "1080p", "mp4", "/tmp", false);
+        assert!(matches!(result, Err(DomainError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_extract_links_default_returns_not_found() {
+        let loader = MinimalLoader;
+        let result = loader.extract_links("https://vimeo.com/123");
+        assert!(matches!(result, Err(DomainError::NotFound(_))));
+    }
+
+    #[test]
+    fn test_get_media_variants_default_returns_not_found() {
+        let loader = MinimalLoader;
+        let result = loader.get_media_variants("https://vimeo.com/123");
         assert!(matches!(result, Err(DomainError::NotFound(_))));
     }
 }

--- a/src-tauri/src/domain/ports/driven/tests.rs
+++ b/src-tauri/src/domain/ports/driven/tests.rs
@@ -408,6 +408,18 @@ impl PluginLoader for FakePluginLoader {
         Ok(None)
     }
 
+    fn extract_links(&self, _url: &str) -> Result<String, DomainError> {
+        Err(DomainError::NotFound(
+            "extract_links not implemented".to_string(),
+        ))
+    }
+
+    fn get_media_variants(&self, _url: &str) -> Result<String, DomainError> {
+        Err(DomainError::NotFound(
+            "get_media_variants not implemented".to_string(),
+        ))
+    }
+
     fn list_loaded(&self) -> Result<Vec<PluginInfo>, DomainError> {
         Ok(self.plugins.lock().unwrap().values().cloned().collect())
     }

--- a/src/components/MediaPreview.tsx
+++ b/src/components/MediaPreview.tsx
@@ -3,9 +3,10 @@ import { useEffect, useState } from "react";
 interface MediaPreviewProps {
   title: string;
   thumbnail: string;
+  subtitle?: string;
 }
 
-export function MediaPreview({ title, thumbnail }: MediaPreviewProps) {
+export function MediaPreview({ title, thumbnail, subtitle }: MediaPreviewProps) {
   const [imgError, setImgError] = useState(false);
 
   useEffect(() => {
@@ -26,7 +27,12 @@ export function MediaPreview({ title, thumbnail }: MediaPreviewProps) {
           onError={() => setImgError(true)}
         />
       )}
-      <p className="text-sm font-semibold">{title}</p>
+      <div className="space-y-1">
+        <p className="text-sm font-semibold">{title}</p>
+        {subtitle ? (
+          <p className="text-xs text-muted-foreground">{subtitle}</p>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -19,9 +19,11 @@ export interface PlaylistItem {
 
 export interface MediaMetadata {
   title: string;
+  artist?: string;
   thumbnailUrl: string;
   durationSeconds: number;
   isPlaylist: boolean;
+  defaultQuality?: string;
   availableQualities: QualityOption[];
   availableFormats: string[];
   availableAudioFormats: string[];

--- a/src/types/media.ts
+++ b/src/types/media.ts
@@ -31,6 +31,10 @@ export interface MediaMetadata {
   playlistItems?: PlaylistItem[];
 }
 
+export interface MediaDownloadResult {
+  downloadIds: number[];
+}
+
 export interface MediaGrabberOptions {
   quality: string;
   format: string;

--- a/src/views/LinkGrabberView/LinkGrabberView.tsx
+++ b/src/views/LinkGrabberView/LinkGrabberView.tsx
@@ -48,7 +48,14 @@ export function LinkGrabberView() {
 
   const { mutate: startMediaDownload } = useTauriMutation<
     unknown,
-    { url: string; quality: string; format: string; audioOnly: boolean; title?: string }
+    {
+      url: string;
+      quality: string;
+      format: string;
+      audioOnly: boolean;
+      title?: string;
+      playlistItems: string[];
+    }
   >("download_media_start", {
     onSuccess: () => {
       toast.success(t("linkGrabber.toast.downloadStarted"));
@@ -100,6 +107,7 @@ export function LinkGrabberView() {
         format: options.format,
         audioOnly: options.audioOnly,
         title: options.title,
+        playlistItems: options.playlistItems,
       });
     }
   };

--- a/src/views/LinkGrabberView/LinkGrabberView.tsx
+++ b/src/views/LinkGrabberView/LinkGrabberView.tsx
@@ -13,7 +13,7 @@ import { ActionsBar } from "./ActionsBar";
 import { ResolvedLinksSection } from "./ResolvedLinksSection";
 import { MediaGrabberDialog } from "./MediaGrabberDialog";
 import type { ResolvedLink, FilterType, GroupingMode } from "./types";
-import type { MediaGrabberOptions } from "@/types/media";
+import type { MediaDownloadResult, MediaGrabberOptions } from "@/types/media";
 
 export function LinkGrabberView() {
   const { t } = useTranslation();
@@ -47,7 +47,7 @@ export function LinkGrabberView() {
   );
 
   const { mutate: startMediaDownload } = useTauriMutation<
-    unknown,
+    MediaDownloadResult,
     {
       url: string;
       quality: string;

--- a/src/views/LinkGrabberView/MediaGrabberDialog/AudioOnlySection.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/AudioOnlySection.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 interface AudioOnlySectionProps {
   enabled: boolean;
   onEnabledChange: (enabled: boolean) => void;
+  disabled?: boolean;
   audioFormats: string[];
   selectedFormat: string;
   onSelectFormat: (format: string) => void;
@@ -12,6 +13,7 @@ interface AudioOnlySectionProps {
 export function AudioOnlySection({
   enabled,
   onEnabledChange,
+  disabled = false,
   audioFormats,
   selectedFormat,
   onSelectFormat,
@@ -22,6 +24,7 @@ export function AudioOnlySection({
         <Switch
           id="audio-only"
           checked={enabled}
+          disabled={disabled}
           onCheckedChange={onEnabledChange}
         />
         <label

--- a/src/views/LinkGrabberView/MediaGrabberDialog/AudioOnlySection.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/AudioOnlySection.tsx
@@ -29,7 +29,7 @@ export function AudioOnlySection({
         />
         <label
           htmlFor="audio-only"
-          className="cursor-pointer text-sm font-semibold"
+          className={`${disabled ? "cursor-not-allowed" : "cursor-pointer"} text-sm font-semibold`}
         >
           Audio Only
         </label>

--- a/src/views/LinkGrabberView/MediaGrabberDialog/MediaGrabberDialog.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/MediaGrabberDialog.tsx
@@ -63,21 +63,17 @@ export function MediaGrabberDialog({
 
   useEffect(() => {
     if (!metadata) return;
-    const shouldForceAudioOnly =
-      link.mediaType === "audio" &&
-      metadata.availableQualities.length === 0 &&
-      metadata.availableAudioFormats.length > 0;
     const firstQuality =
       metadata.defaultQuality ?? metadata.availableQualities[0]?.quality ?? "1080p";
     const firstFormat = metadata.availableFormats[0] ?? "mp4";
     const firstAudioFormat =
       metadata.availableAudioFormats[0] ??
-      (shouldForceAudioOnly ? "mp3" : "m4a");
-    setAudioOnly(shouldForceAudioOnly);
+      (requiresAudioOnly ? "mp3" : "m4a");
+    setAudioOnly(requiresAudioOnly);
     setQualitySelection(firstQuality);
     setFormatSelection(firstFormat);
     setAudioFormat(firstAudioFormat);
-  }, [link.mediaType, metadata]);
+  }, [metadata, requiresAudioOnly]);
 
   const handleConfirm = () => {
     const downloadTitle = metadata?.artist

--- a/src/views/LinkGrabberView/MediaGrabberDialog/MediaGrabberDialog.tsx
+++ b/src/views/LinkGrabberView/MediaGrabberDialog/MediaGrabberDialog.tsx
@@ -48,6 +48,11 @@ export function MediaGrabberDialog({
     isError,
     refetch,
   } = useMediaMetadata(link.originalUrl, open);
+  const requiresAudioOnly = !!metadata &&
+    link.mediaType === "audio" &&
+    metadata.availableQualities.length === 0 &&
+    metadata.availableAudioFormats.length > 0;
+  const effectiveAudioOnly = requiresAudioOnly || audioOnly;
 
   useEffect(() => {
     if (!open) return;
@@ -58,22 +63,33 @@ export function MediaGrabberDialog({
 
   useEffect(() => {
     if (!metadata) return;
-    const firstQuality = metadata.availableQualities[0]?.quality ?? "1080p";
+    const shouldForceAudioOnly =
+      link.mediaType === "audio" &&
+      metadata.availableQualities.length === 0 &&
+      metadata.availableAudioFormats.length > 0;
+    const firstQuality =
+      metadata.defaultQuality ?? metadata.availableQualities[0]?.quality ?? "1080p";
     const firstFormat = metadata.availableFormats[0] ?? "mp4";
-    const firstAudioFormat = metadata.availableAudioFormats[0] ?? "m4a";
+    const firstAudioFormat =
+      metadata.availableAudioFormats[0] ??
+      (shouldForceAudioOnly ? "mp3" : "m4a");
+    setAudioOnly(shouldForceAudioOnly);
     setQualitySelection(firstQuality);
     setFormatSelection(firstFormat);
     setAudioFormat(firstAudioFormat);
-  }, [metadata]);
+  }, [link.mediaType, metadata]);
 
   const handleConfirm = () => {
+    const downloadTitle = metadata?.artist
+      ? `${metadata.artist} - ${metadata.title}`
+      : metadata?.title;
     onConfirm({
-      quality: audioOnly ? "audio_only" : qualitySelection,
-      format: audioOnly ? audioFormat : formatSelection,
+      quality: effectiveAudioOnly ? "audio_only" : qualitySelection,
+      format: effectiveAudioOnly ? audioFormat : formatSelection,
       subtitles: selectedSubtitles,
-      audioOnly,
+      audioOnly: effectiveAudioOnly,
       playlistItems: selectedPlaylistItems,
-      title: metadata?.title,
+      title: downloadTitle,
     });
     onOpenChange(false);
   };
@@ -92,6 +108,7 @@ export function MediaGrabberDialog({
             <MediaPreview
               title={metadata.title}
               thumbnail={metadata.thumbnailUrl}
+              subtitle={metadata.artist}
             />
 
             {metadata.isPlaylist && metadata.playlistItems && metadata.playlistItems.length > 0 && (
@@ -103,7 +120,7 @@ export function MediaGrabberDialog({
             )}
 
             <div className="space-y-4 border-t pt-6">
-              {!audioOnly && metadata.availableQualities.length > 0 && (
+              {!effectiveAudioOnly && metadata.availableQualities.length > 0 && (
                 <QualitySelector
                   qualities={metadata.availableQualities}
                   formats={metadata.availableFormats}
@@ -115,8 +132,9 @@ export function MediaGrabberDialog({
               )}
 
               <AudioOnlySection
-                enabled={audioOnly}
+                enabled={effectiveAudioOnly}
                 onEnabledChange={setAudioOnly}
+                disabled={requiresAudioOnly}
                 audioFormats={metadata.availableAudioFormats}
                 selectedFormat={audioFormat}
                 onSelectFormat={setAudioFormat}
@@ -132,8 +150,8 @@ export function MediaGrabberDialog({
             </div>
 
             <SizeEstimate
-              quality={audioOnly ? "audio_only" : qualitySelection}
-              format={audioOnly ? audioFormat : formatSelection}
+              quality={effectiveAudioOnly ? "audio_only" : qualitySelection}
+              format={effectiveAudioOnly ? audioFormat : formatSelection}
               duration={metadata.durationSeconds}
               qualities={metadata.availableQualities}
             />

--- a/src/views/LinkGrabberView/__tests__/MediaGrabberDialog.test.tsx
+++ b/src/views/LinkGrabberView/__tests__/MediaGrabberDialog.test.tsx
@@ -57,6 +57,28 @@ const mockPlaylistMetadata: MediaMetadata = {
   ],
 };
 
+const mockAudioLink: ResolvedLink = {
+  ...mockMediaLink,
+  id: "media-audio-1",
+  originalUrl: "https://soundcloud.com/forss/flickermood",
+  resolvedUrl: "https://soundcloud.com/forss/flickermood",
+  filename: "Flickermood.mp3",
+  moduleName: "vortex-mod-soundcloud",
+  mediaType: "audio",
+};
+
+const mockAudioMetadata: MediaMetadata = {
+  title: "Flickermood",
+  artist: "Forss",
+  thumbnailUrl: "https://i1.sndcdn.com/artworks-12345-t500x500.jpg",
+  durationSeconds: 225,
+  isPlaylist: false,
+  availableQualities: [],
+  availableFormats: [],
+  availableAudioFormats: ["mp3"],
+  availableSubtitles: [],
+};
+
 beforeAll(() => {
   Element.prototype.hasPointerCapture = vi.fn().mockReturnValue(false);
   Element.prototype.setPointerCapture = vi.fn();
@@ -275,6 +297,30 @@ describe("MediaGrabberDialog", () => {
         audioOnly: true,
       }),
     );
+  });
+
+  it("should force audio-only defaults for audio media", async () => {
+    mockInvoke.mockResolvedValue(mockAudioMetadata);
+    const user = userEvent.setup();
+    const { onConfirm } = renderDialog({ link: mockAudioLink });
+
+    expect(await screen.findByText("Flickermood")).toBeInTheDocument();
+    expect(screen.getByText("Forss")).toBeInTheDocument();
+
+    const audioSwitch = screen.getByRole("switch");
+    expect(audioSwitch).toBeDisabled();
+    expect(audioSwitch).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: "Download" }));
+
+    expect(onConfirm).toHaveBeenCalledWith({
+      quality: "audio_only",
+      format: "mp3",
+      subtitles: [],
+      audioOnly: true,
+      playlistItems: [],
+      title: "Forss - Flickermood",
+    });
   });
 
   it("should close dialog on Cancel click", async () => {


### PR DESCRIPTION
## Summary

- Wires the `vortex-mod-vimeo` plugin (v1.1.0) end-to-end: URL detection via `can_handle`, metadata via `extract_links`/`get_media_variants`, quality ladder, and download path — all following the same hexagonal contract as the YouTube integration (PRs #72, #73, #76, #79)
- Parses `[config]` defaults from `plugin.toml` into `PluginManifest.config_defaults()` and seeds them into `SharedHostResources` so `default_quality = 720p` is active in the sandbox at runtime; first-returned variant is selected as dialog default
- `AudioOnlySection` forces audio-only mode when no video variants exist; `MediaGrabberDialog` respects `metadata.defaultQuality` with a fallback chain

Closes [MPI-100](/MPI/issues/MPI-100)

## Test plan

- [ ] `cargo fmt --all --check` — **green** (verified locally)
- [ ] `npm run typecheck` — **green** (verified locally)
- [ ] `npx vitest run .../MediaGrabberDialog.test.tsx` — **22/22 green** (verified locally)
- [ ] `cargo test --workspace` — delegated to CI (host lacks `libwebkit2gtk-4.1-dev`; requires the Linux deps from CI step)
- [ ] Manual smoke: paste a public Vimeo URL → grabber dialog shows metadata + quality ladder → select 720p → download completes
- [ ] QA-Dev and Sec-Reviewer review (plugin sandbox touch — BOARD OVERRIDE §2.2 applies)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch SoundCloud downloads now return multiple IDs and roll back partial batches on failure.
  * Plugins can be queried for link extraction and media-variant lookup; plugin manifests may include config defaults surfaced at runtime.
  * Media previews can show an optional artist subtitle; media metadata exposes artist and default quality.

* **Bug Fixes / Improvements**
  * Smarter audio-only enforcement and default format/quality selection; improved plugin dispatch/error mapping.

* **Tests**
  * Expanded coverage for plugin defaults, metadata parsing, audio dialog behavior, and plugin export handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrates the `vortex-mod-vimeo` plugin end-to-end with plugin-first metadata and variant lookup, and improves dialog defaults and audio-only UX. Adds safe-batch SoundCloud playlist downloads with rollback and seeds `[config]` defaults; merged downloads now honor the configured download directory. Closes MPI-100.

- **New Features**
  - Vimeo: uses `can_handle` + `extract_links`/`get_media_variants`, de-dupes/sorts qualities, and completes downloads with an Adaptive-merge fallback.
  - Plugin config defaults: parse `[config]` in `plugin.toml` into `PluginManifest.config_defaults()` and seed into `SharedHostResources` (e.g., `default_quality = 720p`).
  - Dialog UX: honors `metadata.defaultQuality`, disables and forces audio-only when no video variants exist, shows artist as a subtitle, and saves as “Artist - Title” (defaults to mp3 when audio-only).
  - API: `PluginLoader` adds `extract_links`/`get_media_variants`; registry exposes `function_exists`; `download_media_start` accepts `playlistItems` and returns `{ downloadIds }`; SoundCloud playlists batch-download with rollback on failure.
  - Downloads: merged (Adaptive) downloads use the configured `download_dir` if set.

- **Bug Fixes**
  - Choose `default_quality` from the sorted ladder so the UI default matches the top option.
  - Warn when a plugin returns an Adaptive variant to aid HLS/DASH debugging.
  - Fix E0382 and clippy warnings in plugin metadata parsing.

<sup>Written for commit c935cce1cd38ccc13788514d379dd1547407898c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

