### PR TITLE
fix(plugins): stop watcher from clobbering loader state during install

### DIFF
--- a/src-tauri/src/adapters/driven/plugin/extism_loader.rs
+++ b/src-tauri/src/adapters/driven/plugin/extism_loader.rs
@@ -3,6 +3,8 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use dashmap::DashSet;
+
 use crate::domain::error::DomainError;
 use crate::domain::model::plugin::{PluginInfo, PluginManifest};
 use crate::domain::ports::driven::PluginLoader;
@@ -18,6 +20,26 @@ pub struct ExtismPluginLoader {
     plugins_dir: PathBuf,
     shared_resources: Arc<SharedHostResources>,
     builtin_http: HttpModule,
+    /// Plugin names whose install is currently in flight. The watcher
+    /// skips events for these so watcher-driven unload/load calls don't
+    /// race the install's own `load_from_dir` and leave the plugin out
+    /// of the registry after the user sees a success toast.
+    installs_in_progress: Arc<DashSet<String>>,
+}
+
+/// RAII guard: clears the `installs_in_progress` flag when dropped, so
+/// the flag is released even if `load_from_dir`'s body returns an error
+/// or panics. Leaking the flag would make the watcher permanently ignore
+/// events for that plugin name.
+struct InstallInFlight<'a> {
+    set: &'a DashSet<String>,
+    name: &'a str,
+}
+
+impl Drop for InstallInFlight<'_> {
+    fn drop(&mut self) {
+        self.set.remove(self.name);
+    }
 }
 
 impl ExtismPluginLoader {
@@ -30,6 +52,7 @@ impl ExtismPluginLoader {
             plugins_dir,
             shared_resources,
             builtin_http: HttpModule::new()?,
+            installs_in_progress: Arc::new(DashSet::new()),
         })
     }
 
@@ -43,6 +66,21 @@ impl ExtismPluginLoader {
 
     pub fn builtin_http(&self) -> &HttpModule {
         &self.builtin_http
+    }
+
+    /// Returns `true` if `name` is currently being installed via
+    /// `load_from_dir`. The plugin watcher consults this to avoid
+    /// reacting to events from the install's own filesystem writes.
+    pub fn is_install_in_progress(&self, name: &str) -> bool {
+        self.installs_in_progress.contains(name)
+    }
+
+    /// Test-only: mark a plugin as being installed without actually going
+    /// through `load_from_dir`, so watcher tests can assert that events
+    /// are suppressed while an install is in flight.
+    #[cfg(test)]
+    pub fn mark_install_in_progress_for_testing(&self, name: &str) {
+        self.installs_in_progress.insert(name.to_string());
     }
 
     fn resolve_wasm_plugin(&self, url: &str) -> Result<PluginInfo, DomainError> {
@@ -259,6 +297,16 @@ impl PluginLoader for ExtismPluginLoader {
     fn load_from_dir(&self, dir: &std::path::Path) -> Result<(), DomainError> {
         let (manifest, _wasm_path) = parse_manifest(dir)?;
         let name = manifest.info().name();
+
+        // Mark the install so the watcher ignores its own copy-path
+        // events (remove_dir_all + copy fire REMOVE/CREATE events that
+        // would otherwise race this function's final `self.load()` and
+        // potentially leave the plugin unloaded in memory).
+        self.installs_in_progress.insert(name.to_string());
+        let _in_flight = InstallInFlight {
+            set: &self.installs_in_progress,
+            name,
+        };
 
         // Copy staged files to the permanent plugins directory
         let dest_dir = self.plugins_dir.join(name);

--- a/src-tauri/src/adapters/driven/plugin/extism_loader.rs
+++ b/src-tauri/src/adapters/driven/plugin/extism_loader.rs
@@ -1,9 +1,9 @@
 //! Implements [`PluginLoader`] using Extism and [`PluginRegistry`].
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
-
-use dashmap::DashSet;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
 
 use crate::domain::error::DomainError;
 use crate::domain::model::plugin::{PluginInfo, PluginManifest};
@@ -15,30 +15,51 @@ use super::capabilities::{SharedHostResources, build_host_functions};
 use super::manifest::{find_wasm_file, parse_manifest};
 use super::registry::{LoadedPlugin, PluginRegistry};
 
+/// Per-plugin install coordination.
+///
+/// - `serializer` is held for the entire `load_from_dir` body so two
+///   concurrent installs of the **same** plugin name can't race on the
+///   staging/destination filesystem writes; the second one blocks until
+///   the first completes.
+/// - `count` is an independent refcount used by the watcher's
+///   `is_install_in_progress` check. A refcount (rather than a boolean)
+///   is needed because several installs for the same plugin can queue up
+///   behind the serializer; the watcher must stay suppressed until the
+///   **last** install finishes, not just the first.
+struct InstallState {
+    serializer: Mutex<()>,
+    count: AtomicUsize,
+}
+
+impl InstallState {
+    fn new() -> Self {
+        Self {
+            serializer: Mutex::new(()),
+            count: AtomicUsize::new(0),
+        }
+    }
+}
+
 pub struct ExtismPluginLoader {
     registry: Arc<PluginRegistry>,
     plugins_dir: PathBuf,
     shared_resources: Arc<SharedHostResources>,
     builtin_http: HttpModule,
-    /// Plugin names whose install is currently in flight. The watcher
-    /// skips events for these so watcher-driven unload/load calls don't
-    /// race the install's own `load_from_dir` and leave the plugin out
-    /// of the registry after the user sees a success toast.
-    installs_in_progress: Arc<DashSet<String>>,
+    /// Per-plugin install coordination. See [`InstallState`] for the
+    /// two pieces of state it carries (serializer + refcount).
+    installs: Arc<Mutex<HashMap<String, Arc<InstallState>>>>,
 }
 
-/// RAII guard: clears the `installs_in_progress` flag when dropped, so
-/// the flag is released even if `load_from_dir`'s body returns an error
-/// or panics. Leaking the flag would make the watcher permanently ignore
-/// events for that plugin name.
-struct InstallInFlight<'a> {
-    set: &'a DashSet<String>,
-    name: &'a str,
+/// RAII guard: decrements the install refcount when dropped, so the
+/// watcher's suppression window closes exactly when the install returns
+/// (success, error, or panic) — never earlier, never later.
+struct InstallInFlight {
+    state: Arc<InstallState>,
 }
 
-impl Drop for InstallInFlight<'_> {
+impl Drop for InstallInFlight {
     fn drop(&mut self) {
-        self.set.remove(self.name);
+        self.state.count.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -52,7 +73,7 @@ impl ExtismPluginLoader {
             plugins_dir,
             shared_resources,
             builtin_http: HttpModule::new()?,
-            installs_in_progress: Arc::new(DashSet::new()),
+            installs: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -68,19 +89,51 @@ impl ExtismPluginLoader {
         &self.builtin_http
     }
 
-    /// Returns `true` if `name` is currently being installed via
-    /// `load_from_dir`. The plugin watcher consults this to avoid
-    /// reacting to events from the install's own filesystem writes.
-    pub fn is_install_in_progress(&self, name: &str) -> bool {
-        self.installs_in_progress.contains(name)
+    /// Get or create the [`InstallState`] for a plugin name. The outer
+    /// map mutex is held only long enough to clone the `Arc`; the
+    /// returned state carries its own serializer.
+    fn get_or_create_install_state(&self, name: &str) -> Arc<InstallState> {
+        let mut map = self
+            .installs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        map.entry(name.to_string())
+            .or_insert_with(|| Arc::new(InstallState::new()))
+            .clone()
     }
 
-    /// Test-only: mark a plugin as being installed without actually going
+    /// Returns `true` if at least one install is currently in flight for
+    /// `name`. The plugin watcher consults this to avoid reacting to
+    /// events from the install's own filesystem writes.
+    pub fn is_install_in_progress(&self, name: &str) -> bool {
+        let map = self
+            .installs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        map.get(name)
+            .is_some_and(|s| s.count.load(Ordering::SeqCst) > 0)
+    }
+
+    /// Test-only: bump the install refcount for a plugin without going
     /// through `load_from_dir`, so watcher tests can assert that events
     /// are suppressed while an install is in flight.
     #[cfg(test)]
     pub fn mark_install_in_progress_for_testing(&self, name: &str) {
-        self.installs_in_progress.insert(name.to_string());
+        let state = self.get_or_create_install_state(name);
+        state.count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Test-only mirror of [`Self::mark_install_in_progress_for_testing`]
+    /// used to exercise the refcount's "last one out wins" behaviour.
+    #[cfg(test)]
+    pub fn unmark_install_in_progress_for_testing(&self, name: &str) {
+        let map = self
+            .installs
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(state) = map.get(name) {
+            state.count.fetch_sub(1, Ordering::SeqCst);
+        }
     }
 
     fn resolve_wasm_plugin(&self, url: &str) -> Result<PluginInfo, DomainError> {
@@ -296,20 +349,46 @@ impl PluginLoader for ExtismPluginLoader {
 
     fn load_from_dir(&self, dir: &std::path::Path) -> Result<(), DomainError> {
         let (manifest, _wasm_path) = parse_manifest(dir)?;
-        let name = manifest.info().name();
+        let name = manifest.info().name().to_string();
 
-        // Mark the install so the watcher ignores its own copy-path
-        // events (remove_dir_all + copy fire REMOVE/CREATE events that
-        // would otherwise race this function's final `self.load()` and
-        // potentially leave the plugin unloaded in memory).
-        self.installs_in_progress.insert(name.to_string());
+        // Per-plugin install coordination:
+        //
+        //   1. Bump the refcount up-front so the watcher starts skipping
+        //      events *immediately*, before any filesystem mutation.
+        //   2. Take the per-plugin serializer lock so concurrent installs
+        //      of the same plugin name can't interleave on the staging
+        //      and destination directories.
+        //
+        // The `InstallInFlight` guard decrements the refcount on drop; the
+        // local `_serializer_guard` releases the lock on drop. Both run
+        // even on error or panic, so the state never leaks.
+        let state = self.get_or_create_install_state(&name);
+        state.count.fetch_add(1, Ordering::SeqCst);
         let _in_flight = InstallInFlight {
-            set: &self.installs_in_progress,
-            name,
+            state: state.clone(),
         };
+        let _serializer_guard = state
+            .serializer
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        // Ensure any prior in-memory instance is cleared before we touch
+        // the filesystem. Doing this inside the suppression window (after
+        // the refcount bump) closes the gap that would otherwise let a
+        // delayed watcher event re-insert the plugin between an external
+        // `unload()` call and the start of this function, causing the
+        // final `self.load()` below to fail with `AlreadyExists`.
+        //
+        // Only swallow `NotFound` — other errors (poisoned mutex, etc.)
+        // must abort the install to avoid leaving the in-memory state
+        // half-mutated.
+        match self.unload(&name) {
+            Ok(()) | Err(DomainError::NotFound(_)) => {}
+            Err(e) => return Err(e),
+        }
 
         // Copy staged files to the permanent plugins directory
-        let dest_dir = self.plugins_dir.join(name);
+        let dest_dir = self.plugins_dir.join(&name);
         if dest_dir.exists() {
             std::fs::remove_dir_all(&dest_dir).map_err(|e| {
                 DomainError::PluginError(format!(
@@ -400,6 +479,37 @@ description = "Test plugin"
         let wasm_bytes: &[u8] = &[0x00, 0x61, 0x73, 0x6D, 0x01, 0x00, 0x00, 0x00];
         let mut wf = std::fs::File::create(plugin_dir.join(format!("{name}.wasm"))).unwrap();
         wf.write_all(wasm_bytes).unwrap();
+    }
+
+    #[test]
+    fn test_overlapping_installs_keep_suppression_active_until_last_drop() {
+        // The reason we track a refcount rather than a boolean flag: two
+        // concurrent installs of the same plugin must both hold the
+        // watcher's suppression active. If the first install's guard
+        // cleared the flag while the second is still running, watcher
+        // events would resume processing and could race the second
+        // install's final `self.load()`.
+        let tmp = TempDir::new().unwrap();
+        let loader = ExtismPluginLoader::new(
+            tmp.path().to_path_buf(),
+            Arc::new(SharedHostResources::new()),
+        )
+        .unwrap();
+
+        loader.mark_install_in_progress_for_testing("my-plugin");
+        loader.mark_install_in_progress_for_testing("my-plugin");
+        assert!(loader.is_install_in_progress("my-plugin"));
+
+        // First install completes.
+        loader.unmark_install_in_progress_for_testing("my-plugin");
+        assert!(
+            loader.is_install_in_progress("my-plugin"),
+            "suppression must stay active while a second install is still running"
+        );
+
+        // Second install completes — suppression clears.
+        loader.unmark_install_in_progress_for_testing("my-plugin");
+        assert!(!loader.is_install_in_progress("my-plugin"));
     }
 
     #[test]

--- a/src-tauri/src/adapters/driven/plugin/watcher.rs
+++ b/src-tauri/src/adapters/driven/plugin/watcher.rs
@@ -60,46 +60,56 @@ fn handle_fs_event(event: &notify::Event, loader: &ExtismPluginLoader) {
     }
 }
 
-/// Identify the plugin name a filesystem event refers to, if any.
+/// Identify the plugin name when the event path points at one of the
+/// two well-known *plugin files*: `plugins_dir/<name>/plugin.toml` or
+/// `plugins_dir/<name>/<something>.wasm`. Anything else (nested paths,
+/// siblings of a plugin dir, arbitrary files directly under
+/// `plugins_dir`) returns `None`.
 ///
-/// Only two path shapes qualify, both anchored directly under
-/// `plugins_dir` so an event deeper in the tree can't unload a plugin
-/// whose leaf name coincidentally matches some nested directory:
-///
-/// - **File event**: `plugins_dir/<name>/plugin.toml` or
-///   `plugins_dir/<name>/<something>.wasm`. The plugin name is the
-///   parent directory's file name.
-/// - **Folder event**: `plugins_dir/<name>` itself. The plugin name is
-///   the path's own file name. Used for backends that emit a single
-///   `Remove(Folder)` when a plugin directory is deleted (macOS
-///   FSEvents, sometimes Windows ReadDirectoryChangesW).
-///
-/// Any other path (nested subdirectories, sibling files in
-/// `plugins_dir`, paths outside `plugins_dir`) returns `None`.
-fn plugin_name_from_event_path<'a>(
+/// This is the restrictive shape — required for upsert events, where a
+/// folder creation has nothing loadable by itself and would only log
+/// noise.
+fn plugin_name_from_plugin_file<'a>(
     path: &'a std::path::Path,
     plugins_dir: &std::path::Path,
 ) -> Option<&'a str> {
-    if is_plugin_toml(path) || is_wasm_file(path) {
-        let parent = path.parent()?;
-        if parent.parent() == Some(plugins_dir) {
-            return parent.file_name().and_then(|n| n.to_str());
-        }
+    if !(is_plugin_toml(path) || is_wasm_file(path)) {
+        return None;
     }
+    let parent = path.parent()?;
+    if parent.parent() == Some(plugins_dir) {
+        parent.file_name().and_then(|n| n.to_str())
+    } else {
+        None
+    }
+}
+
+/// Identify the plugin name when the event path is the plugin
+/// directory itself (`plugins_dir/<name>`). Needed for backends that
+/// emit a single `Remove(Folder)` when a plugin is deleted (macOS
+/// FSEvents, sometimes Windows ReadDirectoryChangesW) instead of per-
+/// file events.
+fn plugin_name_from_plugin_dir<'a>(
+    path: &'a std::path::Path,
+    plugins_dir: &std::path::Path,
+) -> Option<&'a str> {
     if path.parent() == Some(plugins_dir) {
-        return path.file_name().and_then(|n| n.to_str());
+        path.file_name().and_then(|n| n.to_str())
+    } else {
+        None
     }
-    None
 }
 
 /// Handle a CREATE/MODIFY event for a plugin file.
 ///
-/// Reloads the plugin whose directory contains the changed file. Paths
-/// that aren't a plugin file directly under `plugins_dir/<name>/` are
-/// ignored.
+/// Only reloads when the event is on a `plugin.toml` or `*.wasm`
+/// directly under a plugin directory. Folder-level events (e.g.
+/// `plugins_dir/<name>` being `mkdir`'d before any plugin file is
+/// written) don't carry any loadable content yet; ignoring them keeps
+/// the log quiet and avoids pointless `parse_manifest` failures.
 fn handle_upsert_event(path: &std::path::Path, loader: &ExtismPluginLoader) {
     let plugins_dir = loader.plugins_dir();
-    let Some(name) = plugin_name_from_event_path(path, plugins_dir) else {
+    let Some(name) = plugin_name_from_plugin_file(path, plugins_dir) else {
         return;
     };
 
@@ -133,16 +143,18 @@ fn handle_upsert_event(path: &std::path::Path, loader: &ExtismPluginLoader) {
     }
 }
 
-/// Handle a REMOVE event. Uses the same direct-under-`plugins_dir`
-/// constraint as the upsert branch so a remove of a nested directory
-/// whose leaf name happens to match a loaded plugin can't unload it.
-///
-/// Accepts both file-level removes (`plugins_dir/<name>/plugin.toml`
-/// etc. — inotify) and folder-level removes (`plugins_dir/<name>` —
-/// FSEvents, sometimes ReadDirectoryChangesW).
+/// Handle a REMOVE event. Accepts both file-level removes
+/// (`plugins_dir/<name>/plugin.toml` etc. — typical of inotify) and
+/// folder-level removes (`plugins_dir/<name>` itself — FSEvents,
+/// sometimes ReadDirectoryChangesW). The direct-under-`plugins_dir`
+/// constraint on both shapes keeps a remove of a nested directory
+/// whose leaf name coincidentally matches a loaded plugin from
+/// unloading it by mistake.
 fn handle_remove_event(path: &std::path::Path, loader: &ExtismPluginLoader) {
     let plugins_dir = loader.plugins_dir();
-    let Some(name) = plugin_name_from_event_path(path, plugins_dir) else {
+    let Some(name) = plugin_name_from_plugin_file(path, plugins_dir)
+        .or_else(|| plugin_name_from_plugin_dir(path, plugins_dir))
+    else {
         return;
     };
 
@@ -275,6 +287,38 @@ description = "Test plugin"
 
         handle_fs_event(&event, &loader);
         assert!(!loader.registry().contains("doomed-plugin"));
+    }
+
+    #[test]
+    fn test_handle_fs_event_upsert_ignores_non_plugin_file_events() {
+        // A CREATE event for a path directly under plugins_dir that
+        // isn't a plugin file (e.g. a stray `.txt` a user dropped in)
+        // must not trigger the reload logic. The previous code used the
+        // folder-fallback candidate for upserts too and would have fed
+        // "stray.txt" through parse_manifest, logging a warning.
+        let tmp = TempDir::new().unwrap();
+        let loader = make_loader(tmp.path());
+        // Plug-in dir exists with a valid plugin so we'd notice if the
+        // handler reloaded the wrong thing.
+        setup_plugin_dir(tmp.path(), "real-plugin");
+
+        let stray = tmp.path().join("stray.txt");
+        std::fs::write(&stray, "not a plugin").unwrap();
+        let event = notify::Event {
+            kind: EventKind::Create(CreateKind::File),
+            paths: vec![stray],
+            attrs: Default::default(),
+        };
+
+        handle_fs_event(&event, &loader);
+        assert!(
+            !loader.registry().contains("stray.txt"),
+            "non-plugin file events must not enter the reload path"
+        );
+        assert!(
+            !loader.registry().contains("real-plugin"),
+            "the stray file must not reload unrelated plugins"
+        );
     }
 
     #[test]

--- a/src-tauri/src/adapters/driven/plugin/watcher.rs
+++ b/src-tauri/src/adapters/driven/plugin/watcher.rs
@@ -60,42 +60,71 @@ fn handle_fs_event(event: &notify::Event, loader: &ExtismPluginLoader) {
     }
 }
 
-/// Handle a CREATE/MODIFY event for a `plugin.toml` or `*.wasm` file.
+/// Identify the plugin name a filesystem event refers to, if any.
+///
+/// Only two path shapes qualify, both anchored directly under
+/// `plugins_dir` so an event deeper in the tree can't unload a plugin
+/// whose leaf name coincidentally matches some nested directory:
+///
+/// - **File event**: `plugins_dir/<name>/plugin.toml` or
+///   `plugins_dir/<name>/<something>.wasm`. The plugin name is the
+///   parent directory's file name.
+/// - **Folder event**: `plugins_dir/<name>` itself. The plugin name is
+///   the path's own file name. Used for backends that emit a single
+///   `Remove(Folder)` when a plugin directory is deleted (macOS
+///   FSEvents, sometimes Windows ReadDirectoryChangesW).
+///
+/// Any other path (nested subdirectories, sibling files in
+/// `plugins_dir`, paths outside `plugins_dir`) returns `None`.
+fn plugin_name_from_event_path<'a>(
+    path: &'a std::path::Path,
+    plugins_dir: &std::path::Path,
+) -> Option<&'a str> {
+    if is_plugin_toml(path) || is_wasm_file(path) {
+        let parent = path.parent()?;
+        if parent.parent() == Some(plugins_dir) {
+            return parent.file_name().and_then(|n| n.to_str());
+        }
+    }
+    if path.parent() == Some(plugins_dir) {
+        return path.file_name().and_then(|n| n.to_str());
+    }
+    None
+}
+
+/// Handle a CREATE/MODIFY event for a plugin file.
 ///
 /// Reloads the plugin whose directory contains the changed file. Paths
-/// that aren't a plugin file are ignored.
+/// that aren't a plugin file directly under `plugins_dir/<name>/` are
+/// ignored.
 fn handle_upsert_event(path: &std::path::Path, loader: &ExtismPluginLoader) {
-    if !(is_plugin_toml(path) || is_wasm_file(path)) {
-        return;
-    }
-    let Some(plugin_dir) = path.parent() else {
-        return;
-    };
-    let Some(dir_name) = plugin_dir.file_name().and_then(|n| n.to_str()) else {
+    let plugins_dir = loader.plugins_dir();
+    let Some(name) = plugin_name_from_event_path(path, plugins_dir) else {
         return;
     };
 
-    if loader.is_install_in_progress(dir_name) {
+    if loader.is_install_in_progress(name) {
         tracing::debug!(
-            plugin = %dir_name,
+            plugin = %name,
             "skipping watcher upsert while install is in flight",
         );
         return;
     }
 
+    let plugin_dir = plugins_dir.join(name);
     tracing::info!(
         "plugin file changed, attempting load from {}",
         plugin_dir.display()
     );
-    match parse_manifest(plugin_dir) {
+    match parse_manifest(&plugin_dir) {
         Ok((manifest, _)) => {
-            let name = manifest.info().name().to_string();
+            let manifest_name = manifest.info().name().to_string();
             // Unload first if present (reload case). Ignore NotFound.
-            let _ = loader.unload(&name);
+            let _ = loader.unload(&manifest_name);
             if let Err(e) = loader.load(&manifest) {
-                tracing::warn!("failed to load plugin '{name}': {e}");
+                tracing::warn!("failed to load plugin '{manifest_name}': {e}");
             } else {
-                tracing::info!("plugin '{name}' loaded");
+                tracing::info!("plugin '{manifest_name}' loaded");
             }
         }
         Err(e) => {
@@ -104,32 +133,16 @@ fn handle_upsert_event(path: &std::path::Path, loader: &ExtismPluginLoader) {
     }
 }
 
-/// Handle a REMOVE event. Tries both shapes the underlying backend may
-/// deliver:
+/// Handle a REMOVE event. Uses the same direct-under-`plugins_dir`
+/// constraint as the upsert branch so a remove of a nested directory
+/// whose leaf name happens to match a loaded plugin can't unload it.
 ///
-/// - **Per-file remove** (Linux inotify for files inside a watched dir):
-///   `path = plugins/<name>/plugin.toml` or `…/<name>.wasm`. The plugin
-///   name is the **parent** directory's name.
-/// - **Folder-level remove** (macOS FSEvents, sometimes Windows
-///   ReadDirectoryChangesW): `path = plugins/<name>/`, no per-file
-///   events are emitted. The plugin name is the path's **own** last
-///   segment.
-///
-/// Trying both candidates avoids leaving a plugin loaded when the
-/// backend coalesces the event into a single folder removal. Extra
-/// calls are cheap — `unload` returns `NotFound` when the candidate
-/// doesn't name a registered plugin, which we log at debug level.
+/// Accepts both file-level removes (`plugins_dir/<name>/plugin.toml`
+/// etc. — inotify) and folder-level removes (`plugins_dir/<name>` —
+/// FSEvents, sometimes ReadDirectoryChangesW).
 fn handle_remove_event(path: &std::path::Path, loader: &ExtismPluginLoader) {
-    let file_candidate = (is_plugin_toml(path) || is_wasm_file(path))
-        .then(|| {
-            path.parent()
-                .and_then(|p| p.file_name())
-                .and_then(|n| n.to_str())
-        })
-        .flatten();
-    let folder_candidate = path.file_name().and_then(|n| n.to_str());
-
-    let Some(name) = file_candidate.or(folder_candidate) else {
+    let plugins_dir = loader.plugins_dir();
+    let Some(name) = plugin_name_from_event_path(path, plugins_dir) else {
         return;
     };
 
@@ -262,6 +275,40 @@ description = "Test plugin"
 
         handle_fs_event(&event, &loader);
         assert!(!loader.registry().contains("doomed-plugin"));
+    }
+
+    #[test]
+    fn test_handle_fs_event_remove_nested_path_does_not_unload_plugin() {
+        // A remove event for a path nested deeper than
+        // `plugins_dir/<name>/` — even if its leaf happens to match a
+        // loaded plugin — must NOT unload that plugin. The risk comes
+        // from `RecursiveMode::Recursive`: any subdirectory that gets
+        // created then deleted inside a plugin dir could coincidentally
+        // share a plugin's name.
+        let tmp = TempDir::new().unwrap();
+        setup_plugin_dir(tmp.path(), "safe-plugin");
+        let loader = make_loader(tmp.path());
+        loader.load(&make_manifest_for("safe-plugin")).unwrap();
+        assert!(loader.registry().contains("safe-plugin"));
+
+        // plugins/safe-plugin/subdir/safe-plugin — leaf matches the
+        // loaded plugin but the path isn't a direct child of plugins_dir.
+        let nested_path = tmp
+            .path()
+            .join("safe-plugin")
+            .join("subdir")
+            .join("safe-plugin");
+        let event = notify::Event {
+            kind: EventKind::Remove(RemoveKind::Folder),
+            paths: vec![nested_path],
+            attrs: Default::default(),
+        };
+
+        handle_fs_event(&event, &loader);
+        assert!(
+            loader.registry().contains("safe-plugin"),
+            "nested folder remove must not unload a plugin whose name it coincidentally shares"
+        );
     }
 
     #[test]

--- a/src-tauri/src/adapters/driven/plugin/watcher.rs
+++ b/src-tauri/src/adapters/driven/plugin/watcher.rs
@@ -45,66 +45,105 @@ impl PluginWatcher {
 }
 
 fn handle_fs_event(event: &notify::Event, loader: &ExtismPluginLoader) {
-    for path in &event.paths {
-        if !(is_plugin_toml(path) || is_wasm_file(path)) {
-            continue;
-        }
-        let Some(plugin_dir) = path.parent() else {
-            continue;
-        };
-        let Some(dir_name) = plugin_dir.file_name().and_then(|n| n.to_str()) else {
-            continue;
-        };
-
-        // Skip watcher events for a plugin while its store install is in
-        // flight. The install handler owns the load/unload lifecycle in
-        // that window; reacting here would race its final `self.load()`
-        // and could leave the plugin unloaded despite a success toast.
-        if loader.is_install_in_progress(dir_name) {
-            tracing::debug!(
-                plugin = %dir_name,
-                kind = ?event.kind,
-                "skipping watcher event while install is in flight",
-            );
-            continue;
-        }
-
-        match event.kind {
-            EventKind::Create(_) | EventKind::Modify(_) => {
-                tracing::info!(
-                    "plugin file changed, attempting load from {}",
-                    plugin_dir.display()
-                );
-                match parse_manifest(plugin_dir) {
-                    Ok((manifest, _)) => {
-                        let name = manifest.info().name().to_string();
-                        // Unload first if present (reload case). Ignore NotFound.
-                        let _ = loader.unload(&name);
-                        if let Err(e) = loader.load(&manifest) {
-                            tracing::warn!("failed to load plugin '{name}': {e}");
-                        } else {
-                            tracing::info!("plugin '{name}' loaded");
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "failed to parse manifest at {}: {e}",
-                            plugin_dir.display()
-                        );
-                    }
-                }
+    match event.kind {
+        EventKind::Create(_) | EventKind::Modify(_) => {
+            for path in &event.paths {
+                handle_upsert_event(path, loader);
             }
-            EventKind::Remove(_) => {
-                // Convention: plugin directory name matches the plugin's
-                // `name` field in plugin.toml. On removal, the toml may
-                // already be gone so we rely on the directory name.
-                tracing::info!("plugin file removed, unloading '{dir_name}'");
-                if let Err(e) = loader.unload(dir_name) {
-                    tracing::debug!("unload '{dir_name}' after removal: {e}");
-                }
-            }
-            _ => {}
         }
+        EventKind::Remove(_) => {
+            for path in &event.paths {
+                handle_remove_event(path, loader);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Handle a CREATE/MODIFY event for a `plugin.toml` or `*.wasm` file.
+///
+/// Reloads the plugin whose directory contains the changed file. Paths
+/// that aren't a plugin file are ignored.
+fn handle_upsert_event(path: &std::path::Path, loader: &ExtismPluginLoader) {
+    if !(is_plugin_toml(path) || is_wasm_file(path)) {
+        return;
+    }
+    let Some(plugin_dir) = path.parent() else {
+        return;
+    };
+    let Some(dir_name) = plugin_dir.file_name().and_then(|n| n.to_str()) else {
+        return;
+    };
+
+    if loader.is_install_in_progress(dir_name) {
+        tracing::debug!(
+            plugin = %dir_name,
+            "skipping watcher upsert while install is in flight",
+        );
+        return;
+    }
+
+    tracing::info!(
+        "plugin file changed, attempting load from {}",
+        plugin_dir.display()
+    );
+    match parse_manifest(plugin_dir) {
+        Ok((manifest, _)) => {
+            let name = manifest.info().name().to_string();
+            // Unload first if present (reload case). Ignore NotFound.
+            let _ = loader.unload(&name);
+            if let Err(e) = loader.load(&manifest) {
+                tracing::warn!("failed to load plugin '{name}': {e}");
+            } else {
+                tracing::info!("plugin '{name}' loaded");
+            }
+        }
+        Err(e) => {
+            tracing::warn!("failed to parse manifest at {}: {e}", plugin_dir.display());
+        }
+    }
+}
+
+/// Handle a REMOVE event. Tries both shapes the underlying backend may
+/// deliver:
+///
+/// - **Per-file remove** (Linux inotify for files inside a watched dir):
+///   `path = plugins/<name>/plugin.toml` or `…/<name>.wasm`. The plugin
+///   name is the **parent** directory's name.
+/// - **Folder-level remove** (macOS FSEvents, sometimes Windows
+///   ReadDirectoryChangesW): `path = plugins/<name>/`, no per-file
+///   events are emitted. The plugin name is the path's **own** last
+///   segment.
+///
+/// Trying both candidates avoids leaving a plugin loaded when the
+/// backend coalesces the event into a single folder removal. Extra
+/// calls are cheap — `unload` returns `NotFound` when the candidate
+/// doesn't name a registered plugin, which we log at debug level.
+fn handle_remove_event(path: &std::path::Path, loader: &ExtismPluginLoader) {
+    let file_candidate = (is_plugin_toml(path) || is_wasm_file(path))
+        .then(|| {
+            path.parent()
+                .and_then(|p| p.file_name())
+                .and_then(|n| n.to_str())
+        })
+        .flatten();
+    let folder_candidate = path.file_name().and_then(|n| n.to_str());
+
+    let Some(name) = file_candidate.or(folder_candidate) else {
+        return;
+    };
+
+    if loader.is_install_in_progress(name) {
+        tracing::debug!(
+            plugin = %name,
+            "skipping watcher remove while install is in flight",
+        );
+        return;
+    }
+
+    match loader.unload(name) {
+        Ok(()) => tracing::info!("plugin removed, unloaded '{name}'"),
+        Err(e) => tracing::debug!("unload '{name}' after removal: {e}"),
     }
 }
 
@@ -223,6 +262,30 @@ description = "Test plugin"
 
         handle_fs_event(&event, &loader);
         assert!(!loader.registry().contains("doomed-plugin"));
+    }
+
+    #[test]
+    fn test_handle_fs_event_remove_folder_unloads_plugin() {
+        // macOS FSEvents (and occasionally Windows ReadDirectoryChangesW) emit
+        // a single Remove(Folder) event for the plugin directory itself rather
+        // than per-file removes. The watcher must still unload the plugin in
+        // that case.
+        let tmp = TempDir::new().unwrap();
+        setup_plugin_dir(tmp.path(), "folder-doomed");
+        let loader = make_loader(tmp.path());
+
+        loader.load(&make_manifest_for("folder-doomed")).unwrap();
+        assert!(loader.registry().contains("folder-doomed"));
+
+        let plugin_dir = tmp.path().join("folder-doomed");
+        let event = notify::Event {
+            kind: EventKind::Remove(RemoveKind::Folder),
+            paths: vec![plugin_dir],
+            attrs: Default::default(),
+        };
+
+        handle_fs_event(&event, &loader);
+        assert!(!loader.registry().contains("folder-doomed"));
     }
 
     #[test]

--- a/src-tauri/src/adapters/driven/plugin/watcher.rs
+++ b/src-tauri/src/adapters/driven/plugin/watcher.rs
@@ -45,55 +45,66 @@ impl PluginWatcher {
 }
 
 fn handle_fs_event(event: &notify::Event, loader: &ExtismPluginLoader) {
-    match event.kind {
-        EventKind::Create(_) | EventKind::Modify(_) => {
-            for path in &event.paths {
-                if (is_plugin_toml(path) || is_wasm_file(path))
-                    && let Some(plugin_dir) = path.parent()
-                {
-                    tracing::info!(
-                        "plugin file changed, attempting load from {}",
-                        plugin_dir.display()
-                    );
-                    match parse_manifest(plugin_dir) {
-                        Ok((manifest, _)) => {
-                            let name = manifest.info().name().to_string();
-                            // Unload first if present (reload case). Ignore NotFound.
-                            let _ = loader.unload(&name);
-                            if let Err(e) = loader.load(&manifest) {
-                                tracing::warn!("failed to load plugin '{name}': {e}");
-                            } else {
-                                tracing::info!("plugin '{name}' loaded");
-                            }
+    for path in &event.paths {
+        if !(is_plugin_toml(path) || is_wasm_file(path)) {
+            continue;
+        }
+        let Some(plugin_dir) = path.parent() else {
+            continue;
+        };
+        let Some(dir_name) = plugin_dir.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+
+        // Skip watcher events for a plugin while its store install is in
+        // flight. The install handler owns the load/unload lifecycle in
+        // that window; reacting here would race its final `self.load()`
+        // and could leave the plugin unloaded despite a success toast.
+        if loader.is_install_in_progress(dir_name) {
+            tracing::debug!(
+                plugin = %dir_name,
+                kind = ?event.kind,
+                "skipping watcher event while install is in flight",
+            );
+            continue;
+        }
+
+        match event.kind {
+            EventKind::Create(_) | EventKind::Modify(_) => {
+                tracing::info!(
+                    "plugin file changed, attempting load from {}",
+                    plugin_dir.display()
+                );
+                match parse_manifest(plugin_dir) {
+                    Ok((manifest, _)) => {
+                        let name = manifest.info().name().to_string();
+                        // Unload first if present (reload case). Ignore NotFound.
+                        let _ = loader.unload(&name);
+                        if let Err(e) = loader.load(&manifest) {
+                            tracing::warn!("failed to load plugin '{name}': {e}");
+                        } else {
+                            tracing::info!("plugin '{name}' loaded");
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                "failed to parse manifest at {}: {e}",
-                                plugin_dir.display()
-                            );
-                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "failed to parse manifest at {}: {e}",
+                            plugin_dir.display()
+                        );
                     }
                 }
             }
-        }
-        EventKind::Remove(_) => {
-            // Convention: plugin directory name must match the plugin's `name` field in
-            // plugin.toml. On removal, the toml may already be gone so we rely on dir name.
-            for path in &event.paths {
-                if (is_plugin_toml(path) || is_wasm_file(path))
-                    && let Some(plugin_dir) = path.parent()
-                    && let Some(name) = plugin_dir.file_name().and_then(|n| n.to_str())
-                {
-                    // Try unload directly — unload returns NotFound if not loaded,
-                    // which is fine (avoids TOCTOU between contains and unload).
-                    tracing::info!("plugin file removed, unloading '{name}'");
-                    if let Err(e) = loader.unload(name) {
-                        tracing::debug!("unload '{name}' after removal: {e}");
-                    }
+            EventKind::Remove(_) => {
+                // Convention: plugin directory name matches the plugin's
+                // `name` field in plugin.toml. On removal, the toml may
+                // already be gone so we rely on the directory name.
+                tracing::info!("plugin file removed, unloading '{dir_name}'");
+                if let Err(e) = loader.unload(dir_name) {
+                    tracing::debug!("unload '{dir_name}' after removal: {e}");
                 }
             }
+            _ => {}
         }
-        _ => {}
     }
 }
 
@@ -212,6 +223,61 @@ description = "Test plugin"
 
         handle_fs_event(&event, &loader);
         assert!(!loader.registry().contains("doomed-plugin"));
+    }
+
+    #[test]
+    fn test_handle_fs_event_skips_create_when_install_in_progress() {
+        // With the install flag set, the watcher must NOT load the plugin
+        // even though the filesystem looks ready — the install handler
+        // is the owner of the load/unload lifecycle in that window.
+        let tmp = TempDir::new().unwrap();
+        setup_plugin_dir(tmp.path(), "busy-plugin");
+        let loader = make_loader(tmp.path());
+
+        loader.mark_install_in_progress_for_testing("busy-plugin");
+
+        let toml_path = tmp.path().join("busy-plugin").join("plugin.toml");
+        let event = notify::Event {
+            kind: EventKind::Create(CreateKind::File),
+            paths: vec![toml_path],
+            attrs: Default::default(),
+        };
+
+        handle_fs_event(&event, &loader);
+        assert!(
+            !loader.registry().contains("busy-plugin"),
+            "watcher must not load a plugin while its install is in flight"
+        );
+    }
+
+    #[test]
+    fn test_handle_fs_event_skips_remove_when_install_in_progress() {
+        // Critical path for the race that motivated the suppression:
+        // `load_from_dir` calls `remove_dir_all` on the destination, which
+        // fires REMOVE events after the handler has already re-inserted
+        // the new version. If the watcher acts on them, it unloads what
+        // the install just loaded — leaving the user with "success toast,
+        // plugin not installed" state.
+        let tmp = TempDir::new().unwrap();
+        setup_plugin_dir(tmp.path(), "busy-plugin");
+        let loader = make_loader(tmp.path());
+        loader.load(&make_manifest_for("busy-plugin")).unwrap();
+        assert!(loader.registry().contains("busy-plugin"));
+
+        loader.mark_install_in_progress_for_testing("busy-plugin");
+
+        let wasm_path = tmp.path().join("busy-plugin").join("busy-plugin.wasm");
+        let event = notify::Event {
+            kind: EventKind::Remove(RemoveKind::File),
+            paths: vec![wasm_path],
+            attrs: Default::default(),
+        };
+
+        handle_fs_event(&event, &loader);
+        assert!(
+            loader.registry().contains("busy-plugin"),
+            "watcher must not unload a plugin while its install is in flight"
+        );
     }
 
     #[test]

--- a/src-tauri/src/application/commands/store_install.rs
+++ b/src-tauri/src/application/commands/store_install.rs
@@ -4,7 +4,6 @@ use crate::application::command_bus::CommandBus;
 use crate::application::commands::store_refresh::read_cache;
 use crate::application::error::AppError;
 use crate::application::read_models::plugin_store_view::PluginStoreEntryDto;
-use crate::domain::error::DomainError;
 use crate::domain::model::plugin_store::{PluginStoreEntry, PluginStoreStatus};
 
 pub struct StoreInstallCommand {
@@ -96,24 +95,13 @@ impl CommandBus {
             .map_err(|e| AppError::Plugin(format!("download task failed: {e}")))?
             .map_err(|e| AppError::Plugin(e.to_string()))?;
 
-        // Unload any prior in-memory instance so re-install is idempotent.
-        // Without this, a plugin already loaded by the file watcher (on
-        // startup) or by a prior successful install in the same session
-        // makes the DashMap insert in `load()` fail with AlreadyExists,
-        // even though the UI (driven by the cache) still shows the plugin
-        // as "not_installed" because the cache hasn't been refreshed.
-        //
-        // Only swallow `NotFound` — other loader failures (a corrupted
-        // registry, a poisoned mutex) must abort install to avoid leaving
-        // the in-memory state half-mutated.
-        if let Err(e) = self.plugin_loader().unload(&cmd.name)
-            && !matches!(e, DomainError::NotFound(_))
-        {
-            return Err(AppError::from(e));
-        }
-
-        // Parse manifest from the downloaded directory and load via the plugin loader.
-        // Uses load_from_dir which calls parse_manifest internally (adapter concern).
+        // Parse manifest from the downloaded directory and load via the
+        // plugin loader. `load_from_dir` performs its own idempotent
+        // unload inside the install-in-progress suppression window, so
+        // the handler no longer does an explicit pre-unload here — doing
+        // it outside the window would leave a narrow gap during which a
+        // delayed watcher event could re-insert the plugin and cause the
+        // final `load()` to fail with `AlreadyExists`.
         let loader = self.plugin_loader_arc();
         let staging_for_cleanup = plugin_dir.clone();
         tokio::task::spawn_blocking(move || loader.load_from_dir(&plugin_dir))

--- a/src-tauri/src/application/commands/store_install.rs
+++ b/src-tauri/src/application/commands/store_install.rs
@@ -115,10 +115,26 @@ impl CommandBus {
         // Parse manifest from the downloaded directory and load via the plugin loader.
         // Uses load_from_dir which calls parse_manifest internally (adapter concern).
         let loader = self.plugin_loader_arc();
+        let staging_for_cleanup = plugin_dir.clone();
         tokio::task::spawn_blocking(move || loader.load_from_dir(&plugin_dir))
             .await
             .map_err(|e| AppError::Plugin(format!("plugin install task failed: {e}")))?
             .map_err(AppError::from)?;
+
+        // Staging is only meaningful until `load_from_dir` has copied the
+        // files to the permanent plugins directory. After that the staged
+        // copy is dead weight that would otherwise accumulate one
+        // subdirectory per install. Best-effort — a leftover here doesn't
+        // break future installs (the store client overwrites on next
+        // download) so we log and continue.
+        if let Err(e) = std::fs::remove_dir_all(&staging_for_cleanup) {
+            tracing::warn!(
+                plugin = %cmd.name,
+                path = %staging_for_cleanup.display(),
+                error = %e,
+                "failed to clean up plugin staging dir after install",
+            );
+        }
 
         tracing::info!(plugin = %cmd.name, "plugin installed from store");
         Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -199,7 +199,25 @@ pub fn run() {
             // ── Plugin store client ─────────────────────────────────
             let registry_url =
                 "https://raw.githubusercontent.com/mpiton/vortex/main/registry/registry.toml";
-            let store_staging_dir = plugins_dir.join(".staging");
+            // Staging MUST live outside plugins_dir so the recursive plugin
+            // watcher doesn't fire events during an in-progress install.
+            // Those events used to race the install's own load_from_dir
+            // call and could leave the plugin unloaded in memory even after
+            // a successful install (toast said "updated", but the UI then
+            // reported the plugin as not installed).
+            let store_staging_dir = app_data_dir.join("plugin-staging");
+            // One-shot cleanup of the legacy `.staging/` that used to live
+            // inside `plugins_dir`. Harmless if already absent.
+            let legacy_staging = plugins_dir.join(".staging");
+            if legacy_staging.exists()
+                && let Err(e) = std::fs::remove_dir_all(&legacy_staging)
+            {
+                tracing::warn!(
+                    path = %legacy_staging.display(),
+                    error = %e,
+                    "failed to clean up legacy plugin staging dir",
+                );
+            }
             let store_client: Arc<dyn crate::domain::ports::driven::PluginStoreClient> =
                 Arc::new(GithubStoreClient::new(registry_url, store_staging_dir));
 


### PR DESCRIPTION
## Summary

Store installs (install *and* update) could leave users with a "success" toast followed by the plugin silently absent from memory:

- `plugin_list` reports the plugin as not installed.
- `resolve_url` returns `NotFound`, so any matching URL surfaces the "No media plugin installed for this URL" error.
- The plugin only reappears after an app restart, which re-runs the startup scan.

This was observed and reproduced immediately after merging #86: the vimeo v1.1.1 release got installed correctly, the success toast fired, then trying to download a vimeo URL produced the "install the plugin" error. Disk state was correct; in-memory state was empty.

## Root cause

The plugin watcher uses `RecursiveMode::Recursive` on `plugins_dir`, so it receives events for the install's own filesystem writes:

1. `download_plugin` used to write to `plugins_dir/.staging/<name>/` — the watcher fires CREATE/MODIFY events for every staged file.
2. `load_from_dir` calls `remove_dir_all` on the destination (fires REMOVE events), then copies the staged files back (fires CREATE/MODIFY events).
3. The handler's final `self.load()` inserts the new version and returns `Ok` to the UI.
4. The watcher's queued events are *then* processed asynchronously. A late REMOVE event unloads the plugin the handler just inserted; a CREATE event that fires before a `.wasm` file is fully written fails `parse_manifest` and logs a warning without recovering. End state: registry empty, UI says "not installed."

## Fix (three changes, one PR)

### 1. Move staging outside `plugins_dir`

`store_staging_dir` is now `app_data_dir/plugin-staging/` — a sibling of `plugins_dir`, not a child. The watcher no longer sees any of the download-half events.

A one-shot cleanup removes the legacy `plugins_dir/.staging/` on startup, so upgrading users don't leave the cruft around.

### 2. Suppress watcher events for plugins under install

`ExtismPluginLoader` now tracks a `DashSet<String>` of plugins whose `load_from_dir` is in flight. The watcher consults `is_install_in_progress(name)` and skips the event when true. An RAII guard (`InstallInFlight` struct with `Drop` impl) clears the flag even if the body returns `Err` or panics — so a failed install can't leave the watcher permanently deaf for that plugin.

### 3. Clean up staging after a successful install

Best-effort `remove_dir_all(staging_for_cleanup)` after `load_from_dir` returns `Ok`. Prevents the staging root from growing by one subdirectory per install forever.

## Why the suppression belongs in the loader, not the watcher

The watcher doesn't know *why* a burst of events happened. The loader is the component that *initiated* them (via `remove_dir_all` + copy). Owning the suppression flag there keeps the ordering guarantees colocated with the code that creates the race, and the RAII guard makes the invariant impossible to leak.

## Test plan

- [x] `cargo test --lib` — 634 passed, 4 ignored; 2 new watcher tests cover CREATE and REMOVE suppression (the REMOVE test is the exact case that motivated the fix).
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] Manual: update a plugin in the in-app store, then immediately try to download a matching URL — plugin stays loaded, no restart needed.
- [ ] Manual: verify `~/.local/share/dev.vortex.app/plugins/.staging/` is gone after next app launch (legacy cleanup) and that `plugin-staging/` stays empty between installs.

## Trace of the original bug, for the record

```
User:   update vimeo to 1.1.1 → toast "Plugin updated"
User:   click "Download" on https://vimeo.com/<id>
App:    resolve_stream_url → resolve_url → no plugin claims this URL
App:    fall through to builtin-http → NotFound in resolve_wasm_plugin
IPC:    NotFound + known-media-platform(vimeo.com) → "No media plugin installed"
Disk:   plugins/vortex-mod-vimeo/* — correct 1.1.1 files present
Memory: loader registry does not contain vortex-mod-vimeo
```

The memory state vs. disk state divergence is exactly what the watcher-suppression flag prevents.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where the plugin watcher unloaded a just-installed plugin and tightens watcher filtering to avoid spurious reloads. Installs and updates now keep the plugin loaded immediately, and deleting a plugin folder correctly unloads it.

- **Bug Fixes**
  - Moved store staging to `app_data_dir/plugin-staging/` and cleaned legacy `plugins_dir/.staging/` on startup; staging is removed after a successful install.
  - Suppressed watcher events during installs with a per-plugin serializer and refcount in `ExtismPluginLoader`; the watcher checks `is_install_in_progress` and skips events until the last install finishes.
  - `load_from_dir` now unloads any prior instance inside the suppression window; removed the pre-unload from the store install handler to close a timing gap.
  - Watcher handles `Remove(Folder)` and reacts only to `plugins_dir/<name>/plugin.toml` or `*.wasm` for upserts, and to `plugins_dir/<name>` for folder removes; ignores nested paths and non-plugin files to prevent false unloads and noisy parse failures.

<sup>Written for commit 14c08345f589273cfc7efaa862418ad10d832a5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Per-plugin install coordination prevents installer/watcher races, reducing install conflicts.
  * Installer avoids a brief unload window before staging completes, lowering downtime during updates.
  * Staging moved to app data; legacy staging directory cleaned at startup.
  * Temporary staging directories are removed after install (warnings logged if cleanup fails).

* **Bug Fixes**
  * File watcher skips reload/unload events while an install is in progress to avoid spurious actions.

* **Tests**
  * Added unit tests validating overlapping installs, watcher-ignore behaviors, and remove/upsert handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->