### PR TITLE
fix(plugins): set User-Agent on the blocking HTTP client

### DIFF
--- a/src-tauri/src/adapters/driven/plugin/capabilities.rs
+++ b/src-tauri/src/adapters/driven/plugin/capabilities.rs
@@ -20,7 +20,15 @@ pub struct SharedHostResources {
 
 impl SharedHostResources {
     fn http_client_builder(timeout: Duration) -> reqwest::blocking::ClientBuilder {
+        // Match the async download client's User-Agent. reqwest's default
+        // (`reqwest/<version>`) triggers bot-detection on some CDNs that
+        // serve an HTML stub without the player/config payload back —
+        // observed on Vimeo, which returned 1.6 KB stubs instead of the
+        // 26 KB embed page when the default UA was used. A named UA also
+        // gives the remote side a way to identify traffic from Vortex
+        // rather than generic scripted clients.
         reqwest::blocking::Client::builder()
+            .user_agent("Vortex/0.1")
             .redirect(reqwest::redirect::Policy::none())
             .timeout(timeout)
     }


### PR DESCRIPTION
## Summary

The blocking \`reqwest::Client\` that \`SharedHostResources\` hands to plugin host functions was built without calling \`.user_agent(...)\`, so it went out with reqwest's default UA (\`reqwest/<version>\`). Some CDNs bot-detect that string and serve a stripped HTML stub.

Hit this end to end against Vimeo: \`player.vimeo.com/video/<id>\` returned a ~1.6 KB stub (no \`playerConfig\` block) to the plugin, so the \`vortex-mod-vimeo\` v1.2.1 embed-HTML fallback kept surfacing \`Vimeo player config not found on page\` even though v1.2.1 already pins \`Accept-Encoding: identity\`. The response was coming back intact, it just wasn't the page a browser sees.

## Reproducer

Isolated \`reqwest::blocking::Client\` with the exact same \`redirect(none)\` + \`timeout(30s)\` config as \`http_client_builder\`, hitting \`https://player.vimeo.com/video/1105856452\` with \`Accept-Encoding: identity\`:

| UA                      | size    | \`playerConfig\` present |
|-------------------------|---------|-----------------------|
| default (\`reqwest/...\`) | 1672    | no                    |
| \`Vortex/0.1\`            | 26 211  | yes                   |
| \`Mozilla/5.0…\`          | 26 209  | yes                   |

## Fix

One-line change on \`SharedHostResources::http_client_builder\`:

\`\`\`rust
reqwest::blocking::Client::builder()
    .user_agent("Vortex/0.1")       // new
    .redirect(reqwest::redirect::Policy::none())
    .timeout(timeout)
\`\`\`

\`Vortex/0.1\` matches the async download client already configured in \`lib.rs\`, so traffic is consistent across the app and servers stop stub-responding.

## No plugin release needed

\`vortex-mod-vimeo\` v1.2.1 is already installed on users' disks with \`Accept-Encoding: identity\` in its request builders. Only the host was adding the bot-like fingerprint; once the UA is set, v1.2.1 resolves both the \`/config\` path (when the video is public) and the embed HTML fallback (when the video is domain-restricted) correctly.

## Test plan

- [x] \`cargo test --lib\` — 638 passing, 4 ignored
- [x] \`cargo clippy --lib -- -D warnings\` — clean
- [x] reqwest reproducer above confirms the UA swap is what changes the response body
- [ ] After merge + rebuild + relaunch of Vortex, retry \`https://vimeo.com/1105856452?fl=pl&fe=vl\` end to end in the UI with \`vortex-mod-vimeo\` v1.2.1 installed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a named User-Agent on the blocking `reqwest::blocking::Client` used by plugin host calls to avoid CDN bot detection and return full page content (e.g., Vimeo embed pages).

- **Bug Fixes**
  - Add `.user_agent("Vortex/0.1")` in `SharedHostResources::http_client_builder` to match the async client.
  - Restores expected responses for `vortex-mod-vimeo` v1.2.1; no plugin release needed.

<sup>Written for commit 610369a967af93bcd651ced40e4b80a2d40f70a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated HTTP request configuration to include standardized User-Agent identification for outbound requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->