### PR TITLE
chore(registry): bump vortex-mod-vimeo to 1.3.1

### DIFF
--- a/registry/registry.toml
+++ b/registry/registry.toml
@@ -42,9 +42,10 @@ repository           = "https://github.com/mpiton/vortex-mod-vimeo"
 checksum_sha256      = "06df67d2f6788227591eef2f7248935d4f053259b02695a5f6f56cece6461929"
 checksum_sha256_toml = "7386a114dd52ba2817e35febc9197b1e7bf9213d751d1da135cba98d6d95435c"
 official             = true
-# v1.3.0 uses `AdaptiveStreamOnly`, `download_to_file`, and the
-# `run_subprocess` host function — all introduced in Vortex 0.2.0
-# (same reason vortex-mod-youtube above requires 0.2.0).
+# Every 1.x release since 1.3.0 uses `AdaptiveStreamOnly`,
+# `download_to_file`, and the `run_subprocess` host function — all
+# introduced in Vortex 0.2.0 (same reason vortex-mod-youtube above
+# requires 0.2.0).
 min_vortex_version   = "0.2.0"
 
 [[plugin]]

--- a/registry/registry.toml
+++ b/registry/registry.toml
@@ -36,11 +36,11 @@ min_vortex_version   = "0.1.0"
 name                 = "vortex-mod-vimeo"
 description          = "Vimeo public/private videos with quality selection"
 author               = "vortex-community"
-version              = "1.3.0"
+version              = "1.3.1"
 category             = "crawler"
 repository           = "https://github.com/mpiton/vortex-mod-vimeo"
-checksum_sha256      = "9fc8917e6e9366e1ef8522fe53a7b45d3a1e7833f7b2f8f8b2b9cf0d2fb7fe61"
-checksum_sha256_toml = "795dddd1d58f5d7c9828c0469e2b1671917027391271dc2ffe01ec53e96a5496"
+checksum_sha256      = "06df67d2f6788227591eef2f7248935d4f053259b02695a5f6f56cece6461929"
+checksum_sha256_toml = "7386a114dd52ba2817e35febc9197b1e7bf9213d751d1da135cba98d6d95435c"
 official             = true
 # v1.3.0 uses `AdaptiveStreamOnly`, `download_to_file`, and the
 # `run_subprocess` host function — all introduced in Vortex 0.2.0


### PR DESCRIPTION
## Summary

Picks up the `--merge-output-format` fix released in vortex-mod-vimeo v1.3.1 (mpiton/vortex-mod-vimeo#6).

v1.3.0 forwarded the plugin's `format` parameter to yt-dlp's `--merge-output-format`. For HLS-only videos Vortex shipped the variant label `\"m3u8\"` as that format string, and yt-dlp exit-2'd with `invalid merge output format \"m3u8\" given` before any segment fetch happened — users on 1.3.0 saw the adaptive fallback trigger then the download die at the yt-dlp argument layer.

1.3.1 hardcodes `--merge-output-format mp4`. yt-dlp only accepts `avi / flv / mkv / mov / mp4 / webm` anyway, and for audio-only downloads the flag is ignored (no merge needed) — the real output extension still comes from `%(ext)s` in `--output`.

## What changed

- `registry/registry.toml`: vimeo bumped 1.3.0 → **1.3.1** with updated WASM + TOML checksums.
- `min_vortex_version` stays at `\"0.2.0\"` (no new host capability).

## Checksums verified against the release

- `vortex_mod_vimeo.wasm`: `06df67d2f6788227591eef2f7248935d4f053259b02695a5f6f56cece6461929`
- `plugin.toml`:            `7386a114dd52ba2817e35febc9197b1e7bf9213d751d1da135cba98d6d95435c`

Both match the assets attached to https://github.com/mpiton/vortex-mod-vimeo/releases/tag/v1.3.1.

## Test plan

- [ ] After merge + Refresh in the in-app plugin store: update vimeo, retry `https://vimeo.com/1105856452?fl=pl&fe=vl`, confirm a single `.mp4` lands in Downloads (not a `.m3u8`, not an argument error).
- [x] Checksums reproducible from a fresh `cargo build --target wasm32-wasip1 --release` on vimeo main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `vortex-mod-vimeo` to 1.3.1 to pick up the `--merge-output-format` fix. This prevents `yt-dlp` exit-2 on HLS-only videos by hardcoding `mp4`, producing a single .mp4; `min_vortex_version` stays `0.2.0`.

- **Refactors**
  - Reworded the `min_vortex_version` rationale comment to "every 1.x since 1.3.0" to avoid future staleness.

<sup>Written for commit 51086b7ee7ac83b5b1a419d32c35771fe8894a06. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated vortex-mod-vimeo plugin entry to version 1.3.1 and refreshed integrity data to match the new release artifacts.
  * Clarified the compatibility note to state that all 1.x releases since 1.3.0 use the same required Vortex 0.2.0 host functions/domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->